### PR TITLE
Move FIP-0006 to Last Call

### DIFF
--- a/FIPS/fip-0006.md
+++ b/FIPS/fip-0006.md
@@ -3,7 +3,8 @@ fip: 0006
 title: No repay debt requirement for DeclareFaultsRecovered
 author:  Nicola (@nicola), Irene (@irenegia)
 discussions-to: https://github.com/filecoin-project/FIPs/issues/21
-status: Draft
+status: Last Call
+review-period-end: 2020-11-11
 type: Technical
 created: 2020-10-23
 ---


### PR DESCRIPTION
There seems to be general approval and no dissenting opinions about not requiring debt repayment for delating faults recovered - so I propose moving it to last call.