### PR TITLE
FIP 0010: describe proof spam attack

### DIFF
--- a/FIPS/fip-0010.md
+++ b/FIPS/fip-0010.md
@@ -386,9 +386,9 @@ proofs, and disputing their own proofs. However:
 
 1. This attack is rate-limited. It can only be used to extract one reward per active partition every
    two days.
-3. Another miner may dispute the proof first and steal the reward. This is especially true because
+2. Another miner may dispute the proof first and steal the reward. This is especially true because
    the attack is slow so other miners will have a chance to notice it happening.
-4. The attack is expensive. The minimum fine is 20FIL, and the reward is 4FIL. This means an
+3. The attack is expensive. The minimum fine is 20FIL, and the reward is 4FIL. This means an
    attacker would lose at least 5/6th of their vesting FIL.
 
 ### Proof Spam Attack

--- a/FIPS/fip-0010.md
+++ b/FIPS/fip-0010.md
@@ -407,7 +407,7 @@ Most rational miners will simply ignore these proofs as the target miner cannot 
 reward. However, for the good of the network, some parties may wish to dispute any/all invalid
 proofs.
 
-Luckily, even though the miner in question will no _pay out_ rewards to the party that submitted the
+Luckily, even though the miner in question will offer no _pay out_ rewards to the party that submitted the
 dispute, they still need to pay the penalty and rewards eventually or abandon the miner. That is, unpaid penalties and rewards are
 added to the miner's debt and the miner will be unable to declare their sectors "recovered" until
 they pay their debts.

--- a/FIPS/fip-0010.md
+++ b/FIPS/fip-0010.md
@@ -325,6 +325,7 @@ This section addresses:
 * Proof disputability attacks.
 * Power & sector extension attacks.
 * Vesting funds extraction.
+* Proof spam attacks.
 
 ### Chain State Size
 
@@ -385,9 +386,35 @@ proofs, and disputing their own proofs. However:
 
 1. This attack is rate-limited. It can only be used to extract one reward per active partition every
    two days.
-2. Another miner may dispute the proof first and steal the reward. This is especially true because
+3. Another miner may dispute the proof first and steal the reward. This is especially true because
    the attack is slow so other miners will have a chance to notice it happening.
-3. The attacker will still need to pay the fine.
+4. The attack is expensive. The minimum fine is 20FIL, and the reward is 4FIL. This means an
+   attacker would lose at least 5/6th of their vesting FIL.
+
+### Proof Spam Attack
+
+An attacker may attempt to spam the network with invalid proofs. The most likely avenue for this
+attack is to:
+
+1. Register a new miner.
+2. Seal one sector.
+3. Start proving the sector with bad proofs.
+
+Given that this miner will have less power than necessary to mine blocks, the "vesting rewards" will
+be empty. Therefore, disputes will pay out no rewards.
+
+Most rational miners will simply ignore these proofs as the target miner cannot pay out a
+reward. However, for the good of the network, some parties may wish to dispute any/all invalid
+proofs.
+
+Luckily, even though the miner in question will no _pay out_ rewards to the party that submitted the
+dispute, they still need to pay them eventually or abandon the miner. That is, unpaid rewards are
+added to the miner's debt and the miner will be unable to declare their sectors "recovered" until
+they pay their debts.
+
+Given that the minimum fine, even for one sector, is 20FIL, and the reward is 4FIL, the attacker
+will need to pay over 24FIL to "revive" their sector. So the cost of this attack is either ~24FIL or
+the cost of creating a new miner and sealing a new sector.
 
 ## Incentive Considerations
 

--- a/FIPS/fip-0010.md
+++ b/FIPS/fip-0010.md
@@ -472,10 +472,5 @@ amount of storage that can be supported by the network.
 
 The changes to the miner actor are in: https://github.com/filecoin-project/specs-actors/pull/1327
 
-## Open Questions
-
-1. Should there be a reporter reward and how much should it be? Ideally, it would cover the gas fees
-   (although this could, in theory, be handled in the manner of FIP 0009).
-
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/FIPS/fip-0010.md
+++ b/FIPS/fip-0010.md
@@ -408,7 +408,7 @@ reward. However, for the good of the network, some parties may wish to dispute a
 proofs.
 
 Luckily, even though the miner in question will no _pay out_ rewards to the party that submitted the
-dispute, they still need to pay them eventually or abandon the miner. That is, unpaid rewards are
+dispute, they still need to pay the penalty and rewards eventually or abandon the miner. That is, unpaid penalties and rewards are
 added to the miner's debt and the miner will be unable to declare their sectors "recovered" until
 they pay their debts.
 


### PR DESCRIPTION
This patch describes a "spam" attack with faulty proofs and explains why it's unlikely to be rational.