### PR TITLE
Change master branch to auto-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: 🚀 Publish
 on:
   push:
     branches:
-      - bmann-jekyll
+      - master
 jobs:
   jekyll:
     runs-on: ubuntu-latest # can change this to ubuntu-latest if you prefer


### PR DESCRIPTION
Missed this in the big PR. Secrets _should_ have copied across I think.

@kaitlin-beegle if Github secrets currently copied the key across, this SHOULD auto-build whenever things are merged to master.

Whoever has permission should be able to go into Settings > Secrets and see this FISSION_KEY entry:

<img width="963" alt="Screen Shot 2021-08-24 at 11 27 17 AM" src="https://user-images.githubusercontent.com/280420/130670209-cc33eceb-eac6-41a9-a527-e40012128bd9.png">

