### PR TITLE
Update and rename fip-0019.md to fip-0020.md

### DIFF
--- a/_fips/fip-0020.md
+++ b/_fips/fip-0020.md
@@ -1,5 +1,5 @@
 ---
-fip: 0019
+fip: 0020
 title: Add Return Value to WithdrawBalance
 author: Steven Li (@steven004), Zenground0 (@Zenground0)
 discussions-to: https://github.com/filecoin-project/FIPs/issues/26


### PR DESCRIPTION
Updating FIP numbering from 0019 to 0020. 

We have already been circulating the Snap Deals draft as "FIP 19", but the technical draft hasn't been reviewed yet so the draft cannot yet be merged (and numbered). Making this FIP0020 will also allow us to group all of the FIP enhancements slated for Fall 2021 implementation together (e.g., FIPS 20, 21, and 22).