### PR TITLE
Fix bug

### DIFF
--- a/FIPS/fip-0021.md
+++ b/FIPS/fip-0021.md
@@ -39,7 +39,7 @@ This is problematic because it goes against the design intention of rewarding ve
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Filecoin implementations. -->
 
-During sector extension a storage provider specifies the sector to be extended and the new expiration. The sector info on chain contains the activation and current expiration epoch.  It is trivial to compute the spent fraction of the sector's lifetime with arithmetic: `spentFraction = (currentEpoch - activation) / 
+During sector extension a storage provider specifies the sector to be extended and the new expiration. The sector info on chain contains the activation and current expiration epoch.  It is trivial to compute the remaining fraction of the sector's lifetime with arithmetic: `remainingFrac = (currentExpiration - currentEpoch) / 
 (currentExpiration - activation)`. Multiply this number by the `DealWeight` and `VerifiedDealWeight` fields of the sector info before rewriting to the Sectors array. In practice this should be done as a big Int multiplication of the deal weights with the numerator and then a division by the denominator as the last step. All miner actor sector quality calculations first read the sector info so this is a sufficient change to propagate correct sector power information.
 
 ## Design Rationale


### PR DESCRIPTION
There is a conceptual bug in the existing fip.  The deal weights should be scaled down by the fraction of remaining sector lifetime, not by the spent sector lifetime.

A small ascii diagram:

```
[                                         spent                         |     remaining ]
```

Left bracket is activation, right bracket is current expiration dividing line is extension (current) epoch.  The fip as written multiplies by `spent / total` but should multiply by `remaining / total`