### PR TITLE
Proposal to update the list of current FIP editors

### DIFF
--- a/FIPS/fip-0001.md
+++ b/FIPS/fip-0001.md
@@ -213,14 +213,11 @@ If you are interested in assuming ownership of a FIP, send a message asking to t
 
 The current FIP editors are
 
-* Whyrusleeping (@whyrusleeping)
-* Friedel Ziegelmayer (@dignifiedquire)
 * Molly Mackinlay (@momack2)
 * Aayush Rajasekaran (@arajasek)
 * Jennifer Wang (@jennijuju)
-* Clara Tsao (@filecoincorgi)
-
-` * Kaitlin Beegle (@kaitlin-beegle)`
+* Kaitlin Beegle (@kaitlin-beegle)
+* Alex North (@anorth)
 
 ## FIP Editor Responsibilities
 


### PR DESCRIPTION
We have some listed FIP Editors (whyrusleeping, dignifiedquire, filcoincorgi) who have been inactive as editors for the past ~year. Proposal to remove them as FIP editors (they are still very welcome to participate in the FIP process!) and replace them with new, more active FIP triagers / reviewers (namely @anorth).

As a reminder: "The editors don't pass judgment on FIPs. They merely do the administrative & editorial part."