### PR TITLE
Move FIP 0019 to accepted

### DIFF
--- a/FIPS/fip-0019.md
+++ b/FIPS/fip-0019.md
@@ -3,7 +3,7 @@ fip: 0019
 title: Snap Deals
 author: @Kubuxu, @lucaniz, @nicola, @rosariogennaro, @irenegia
 discussions-to: https://github.com/filecoin-project/FIPs/issues/145
-status: Draft
+status: Accepted
 type: Core
 created: 2021-08-24
 spec-sections: 


### PR DESCRIPTION
According to @kaitlin-beegle  - the FIP was accepted on Jan 25th.

([source](https://filecoinproject.slack.com/archives/C01EU76LPCJ/p1643145641020100)