### PR TITLE
update fip number

### DIFF
--- a/FIPS/fip-0030.md
+++ b/FIPS/fip-0030.md
@@ -1,5 +1,5 @@
 ---
-fip: 0030
+fip: "0030"
 title: Introducing the Filecoin Virtual Machine (FVM)
 authors: Raúl Kripalani (@raulk), Steven Allen (@stebalien)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/287


### PR DESCRIPTION
without the "" FIP id is taken as octal value , which suggests the fip number is 24 instead of 30