### PR TITLE
fip-0032: add fees for extern-traversing syscalls.

### DIFF
--- a/FIPS/fip-0032.md
+++ b/FIPS/fip-0032.md
@@ -162,12 +162,10 @@ specified overhead and pricing:
       thus there is an alloc and memcpy cost. The bytes are retained in memory
       until the actor call finishes and the invocation container is dropped, and
       thus the actor is charged for this memory usage.
-    - Cost: `<<TODO: benchmarking>>`.
 - `block_read`: takes a block handle and an output buffer, and copies the
   block’s data from the FVM kernel’s block cache into the actor’s memory.
     - Overhead: This syscall resolves inside the FVM and doesn’t traverse the
       FVM<>node boundary. The overhead is that of a memcpy operation.
-    - Cost: `<<TODO: benchmarking>>`.
 - `block_write`: takes some block data and a codec, and merely copies it to the
   FVM kernel’s block cache. It returns a numeric block handle.
     - Overhead: This syscall resolves inside the FVM and doesn’t traverse the
@@ -175,7 +173,6 @@ specified overhead and pricing:
       until the actor call finishes. The bytes are retained in memory until the
       actor call finishes and the invocation container is dropped, and thus the
       actor is charged for this memory usage.
-    - Cost: `<<TODO: benchmarking>>`.
 - `block_link`: computes the CID of a block, and commits the block to the state
   blockstore.
     - Overhead: This syscall traverses the FVM<>client boundary via an extern in
@@ -186,11 +183,17 @@ specified overhead and pricing:
       operation (akin to the hash syscall, but without the syscall overhead).
       Because the CID is returned to the actor via an output buffer, there is
       another memcpy involved.
-    - Cost: `<<TODO: benchmarking>>`.
 - `block_stat`: returns the length and the codec of a block.
     - Overhead: This syscall resolves inside the FVM and doesn’t traverse the
       FVM<>node boundary. It performs a map lookup and returns an integer tuple.
-    - Cost: `<<TODO: benchmarking>>`.
+
+**Pricing formulae**
+
+- `block_open` (extern-traversing): `<<TODO>>`
+- `block_read`: `<<TODO>>`
+- `block_write`: `<<TODO>>`
+- `block_link` (extern-traversing): `<<TODO>>`
+- `block_stat`: `<<TODO>>`
 
 ### Extern-traversing syscall fee revision
 

--- a/FIPS/fip-0032.md
+++ b/FIPS/fip-0032.md
@@ -197,7 +197,7 @@ specified overhead and pricing:
 
 ### Extern-traversing syscall fee revision
 
-Some syscalls that cannot be resolved entirely within FVM space. Such syscalls
+Some syscalls cannot be resolved entirely within FVM space. Such syscalls
 need to traverse the "extern" (FVM<>client) boundary to access client
 functionality.
 

--- a/FIPS/fip-0032.md
+++ b/FIPS/fip-0032.md
@@ -38,8 +38,9 @@ actor logic.
 
 This FIP expands the current gas model by introducing a new gas category to
 account for the real compute cost of the logic performed by every actor in the
-system. It also rearchitects IPLD state management gas, and adjusts the actor
-call fee to account for Wasm invocation container mechanics.
+system. It also rearchitects IPLD state management gas, adjusts the actor call
+fee to account for Wasm invocation container mechanics, and revises the fees for
+syscalls that traverse the extern boundary (FVM <> Node).
 
 This is the first FIP out of a two-FIP series to revise the gas model as a
 result of the introduction of the Filecoin Virtual Machine in FIP-0030 and
@@ -98,6 +99,7 @@ each one in detail in the following sections.
 - Introduce Wasm bytecode-metered execution gas.
 - Adjust the *actor call* fee, to account for new call dispatch overhead.
 - Rearchitect the IPLD state IO fees.
+- Revise fees for extern-traversing syscalls.
 
 ### Wasm bytecode-metered execution gas
 
@@ -189,6 +191,43 @@ specified overhead and pricing:
     - Overhead: This syscall resolves inside the FVM and doesn’t traverse the
       FVM<>node boundary. It performs a map lookup and returns an integer tuple.
     - Cost: `<<TODO: benchmarking>>`.
+
+### Extern-traversing syscall fee revision
+
+Some syscalls that cannot be resolved entirely within FVM space. Such syscalls
+need traverse the "extern" (FVM<>client) boundary to access client
+functionality.
+
+Depending on the languages of the client and the FVM implementation, traversing
+this boundary may involve foreign-function interface (FFI) mechanics.
+
+That is indeed the case with the reference client (Lotus) and the reference FVM
+(ref-fvm). Not only is this the worst case scenario, but it's the most common
+scenario today given the client distribution of the network.
+
+In accordance to the design principle of high-execution fidelity, we propose
+that the gas fees account for the cost of the FFI boundary.
+
+The associated costs are:
+
+- data structure translation between representations, including serialization
+  costs.
+- context switch.
+- the memory overhead on both sides of the interface.
+- the amortized (opportunity) cost of dedicating OS threads.
+- the amortized garbage collection or deallocation costs once the extern
+  concludes.
+- function lookup and dispatch.
+
+**Pricing formulae**
+
+The pricing formulae for extern-traversing syscalls are:
+
+- `get_chain_randomness`: `<<TODO>>`
+- `get_beacon_randomness`: `<<TODO>>`
+- `verify_consensus_fault`: `<<TODO>>`
+- Blockstore operations: already absorbed in the fees specified above ("IPLD
+  state management fees").
 
 ## Design Rationale
 

--- a/FIPS/fip-0032.md
+++ b/FIPS/fip-0032.md
@@ -198,7 +198,7 @@ specified overhead and pricing:
 ### Extern-traversing syscall fee revision
 
 Some syscalls that cannot be resolved entirely within FVM space. Such syscalls
-need traverse the "extern" (FVM<>client) boundary to access client
+need to traverse the "extern" (FVM<>client) boundary to access client
 functionality.
 
 Depending on the languages of the client and the FVM implementation, traversing


### PR DESCRIPTION
This is an iteration on the draft of FIP-0032.

FIP-0032 introduces gas model revisions to accurately model the cost of operations under the new technical environment of the FVM.

As such, the cost of traversing the extern boundary needs to be taken into account in the relevant syscalls. 