### PR TITLE
fip-0031: prepare for move to Last Call.

### DIFF
--- a/FIPS/fip-0031.md
+++ b/FIPS/fip-0031.md
@@ -24,150 +24,228 @@ replaces: N/A
 - [Abstract](#abstract)
 - [Change Motivation](#change-motivation)
 - [Specification](#specification)
-  - [WASM bytecode management](#wasm-bytecode-management)
-  - [Warming up the module cache](#warming-up-the-module-cache)
-  - [Atomic switch of execution layer](#atomic-switch-of-execution-layer)
-  - [Migration procedure](#migration-procedure)
-  - [Optional removal of intrinsic VM from Filecoin client codebases](#optional-removal-of-intrinsic-vm-from-filecoin-client-codebases)
-  - [Actor changes](#actor-changes)
-    - [Init actor](#init-actor)
-    - [Power actor](#power-actor)
+  - [Canonicalization of built-in actors](#canonicalization-of-built-in-actors)
+  - [Adoption of content-addressed Code CIDs](#adoption-of-content-addressed-code-cids)
+  - [Sourcing built-in actors Wasm bytecode](#sourcing-built-in-actors-wasm-bytecode)
+  - [Upgrade procedure](#upgrade-procedure)
+    - [State migration](#state-migration)
+    - [VM atomic switch](#vm-atomic-switch)
+    - [Message replacements](#message-replacements)
+  - [Optional: Legacy VM removal](#optional-legacy-vm-removal)
 - [Design Rationale](#design-rationale)
 - [Backwards Compatibility](#backwards-compatibility)
-  - [CodeCIDs](#codecids)
-  - [Non-versioned changes and state tree migrations](#non-versioned-changes-and-state-tree-migrations)
+  - [Structure of Code CIDs](#structure-of-code-cids)
+  - [Actor evolution](#actor-evolution)
 - [Test Plan](#test-plan)
 - [Coordinated testnets](#coordinated-testnets)
-  - [Per-implementation testnets](#per-implementation-testnets)
-  - [Cross-implementation testnets](#cross-implementation-testnets)
+  - [Per-implementation private testnets](#per-implementation-private-testnets)
+  - [Cross-implementation shared testnets](#cross-implementation-shared-testnets)
 - [Security Considerations](#security-considerations)
 - [Incentive Considerations](#incentive-considerations)
 - [Product Considerations](#product-considerations)
 - [Implementation](#implementation)
+- [Credits](#credits)
+- [Footnotes](#footnotes)
 - [Copyright](#copyright)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Simple Summary
 
-This FIP proposes an **atomic switch** from the current intrinsic VM to a
-**non-programmable version of the Filecoin Virtual Machine**, at a chain epoch
-TBD.
-
-A baseline specification of the Filecoin Virtual Machine is provided in
-[filecoin-project/FIPs#288](https://github.com/filecoin-project/FIPs/pull/288).
-Only the canonical built-in actors will be supported after the atomic switch.
-
-This switch won't introduce new user-facing features or capabilities, but it's
-an important step in the trajectory towards full on-chain user-programmability.
-It also improves network security by sandboxing execution and making it
-deterministic.
+This FIP proposes the atomic activation of a non-programmable version of the FVM
+in Filecoin mainnet (and consequent deprecation of the legacy VM), along with a
+state migration and the introduction of a state object for the system actor
+(`f00`). It also establishes
+[filecoin-project/builtin-actors](https://github.com/filecoin-project/builtin-actors)
+as the canonical actor implemenetation for all clients to use.
 
 ## Abstract
 
-At chain height TBD, the network's execution layer will transition from the
-intrinsic VM to a non-programmable version of the FVM. By _non-programmable_ we
-mean that users won't be able to deploy custom code, yet.
+This FIP proposes an **atomic switch** from the legacy VM to a
+**non-programmable version of the Filecoin Virtual Machine**. A baseline
+specification of the Filecoin Virtual Machine is provided in
+[FIP-0030](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0030.md).
 
-The network will continue running the logic of the prevailing built-in actor
-version, estimated to be v7 (assuming this FIP is scheduled to go live right
-after nv15: OhSnap).
+The switch involves a state tree migration to replace synthetic actor Code CIDs
+with genuine content-addressed CID, computed over the respective Wasm bytecode.
 
-However, the code and deployment form of built-in actors will now be Wasm
-bytecode. Actor code will begin to be identified through real
-content-addressing. The current _synthetic_ actor CodeCIDs will migrate to CIDs
-that hash over their actual Wasm bytecode.
+We also introduce a state object for the system actor (up until now, stateless)
+to hold static network configuration, starting with the registry of built-in
+actor CodeCIDs.
+
+Furthermore, we propose to canonicalize
+[filecoin-project/builtin-actors](https://github.com/filecoin-project/builtin-actors)
+as the standard built-in actor implementation.
+
+This FIP introduces no functional actor behaviour changes; however, some exit
+codes have been adjusted.
 
 ## Change Motivation
 
-Swapping out core components in the execution layer of a blockchain is a complex
-operation. It's analogous to replacing the engine of an airplane while airborne.
-
-For this reason, its advisable to manage risk carefully. Monolithic, big-bang
-deployments are risky. It's appropriate to break up changes in smaller units
-that can be deployed in an orderly, incremental fashion, eventually leading up
-to the final goal: on-chain user-programmability.
-
-Even though this FIP doesn't introduce user-facing features, it represents a
-fundamental technological transition in the network, where a new technology
-comes alive and the previous technology is decomissioned, all in a single atomic
-step.
-
-Subsequent FVM-related FIPs will introduce changes atop the foundations
-installed in the network by this FIP.
+This step represents an important preparatory step in the trajectory towards
+full on-chain user-programmability. As a side effect, it improves overall
+network security by sandboxing execution and making it deterministic.
 
 ## Specification
 
-### WASM bytecode management
+### Canonicalization of built-in actors
 
-The WASM bytecode for built-in actors will be available within CAR files
-generated by the build scripts at repo:
-https://github.com/filecoin-project/canonical-actors (TBD).
+We establish
+[`filecoin-project/builtin-actors`](https://github.com/filecoin-project/builtin-actors)
+[^1] as the canonical implementation of Filecoin built-in actors (aka as System
+Actors in the [Filecoin
+Spec](https://spec.filecoin.io/#section-systems.filecoin_vm.sysactors)), for all
+client implementations to use.
 
-These CAR files will contain one IPLD block per built-in actor. The IPLD block
-will contain the bytecode in raw and full (no chunking into IPLD DAGs).
+This FIP introduces actors v8, a version fundamentally equivalent to actors v7
+(nv15), but reliant on the FVM as its execution environment.
 
-The node must load the content of these CAR files into the node's state
-blockstore. These blocks will remain orphan until the migration is run at the
-upgrade epoch. Thus, any form of stage garbage collection must explicitly
-protect these blocks from deletion (e.g. splitstore). At migration, all actors
-will be linked to their respective bytecode in the state tree.
+### Adoption of content-addressed Code CIDs
 
-The node must verify that exactly N blocks were loaded, with CIDs ...
+Every actor in the state tree specifies the CID of the executable code that
+backs it (`CodeCID`), doubling as an actor type designator.
 
-### Warming up the module cache
+Prior to the Wasm-based FVM, there was no universal, portable execution bytecode
+for the network to agree on. Therefore, the network used synthetic CIDs of the
+following form:
 
-Prior to the upgrade epoch, it is advisable for the Filecoin client to warm up
-the Wasm module cache by pre-compiling the built-in actors into machine code.
+```
+CodeCid = Cid(IPLD_RAW_CODEC, Mh(IDENTITY, bytes('fil/$actor_version/$actor_type')))
+```
 
-### Atomic switch of execution layer
+Where:
 
-Filecoin clients must simultaneously support both execution layers:
+- `IPLD_RAW_CODEC=0x55`
+- `IDENTITY=0x00`
 
-1. The current, intrinsic VM (the source).
-2. The non-programmable FVM (the target).
+This FIP transitions to true content-addressed CIDs for every actor, computed
+over their Wasm bytecode, in the following way:
 
-At upgrade epoch TBD, blocks assembled by block producers in epoch TBD-1 with
-the source VM will be compiled into a tipset and be executed by all validators
-**with the target VM**.
+```
+CodeCid = Cid(IPLD_RAW_CODEC, Mh(BLAKE2B-256, $wasm_bytecode))
+```
 
-From that moment onwards, block producers will construct blocks using the target
-VM. Validators will validate tipsets with target VM also. In other words, both
-block production and validation will operate with the target VM.
+### Sourcing built-in actors Wasm bytecode
 
-Following one finality (900 epochs), the deprecation of the source VM will be
-considered final.
+The build process of
+[`filecoin-project/builtin-actors`](https://github.com/filecoin-project/builtin-actors)
+produces a CARv1 archive that bundles all Wasm bytecode for all actors. It has
+the following characteristics:
 
-> Notes:
-> Should we run sanity check procedures in the epochs preceding TBD? Validating
-> tipsets in parallel with both VMs; and aborting the upgrade on mismatch.
+- The CARv1 header is single-rooted.
+- The root CID resolves to a data structure that acts like a _Manifest_.
+- The _Manifest_ type is an IPLD `Map<String, Cid>`. Every entry represents a
+  built-in actor.
+  - Keys (`String`) range over an enum that identifies the actor type. These
+    strings match the current synthetic Code CIDs, and therefore can eventually
+    facilitate translations if necessary.
+    - `system`
+    - `init`
+    - `cron`
+    - `account`
+    - `storagepower`
+    - `storageminer`
+    - `storagemarket`
+    - `paymentchannel`
+    - `multisig`
+    - `reward`
+    - `verifiedregistry`
+  - Values (`Cid`) point to the Wasm bytecode of an actor as a single block.
 
-### Migration procedure
+Clients are free to ship the bundle as they see fit. The simplest approach is to
+embed the CARv1 into the client binary, but downloading it on-demand is also an
+option.
 
-At epoch TBD, prior to executing the tipset assembled at epoch TBD-1, Filecoin
-clients will run a migration over the state tree to replace the CodeCID in the
-ActorState struct of every actor.
+On node startup, the client is expected to:
 
-The replacement will be performed according to this replacement table:
+1. Import the CARv1 contents into its state blockstore, and retain the
+   _Manifest_ CID in memory.
+2. Instruct the FVM to preload all built-in actors and precompile Wasm modules.
 
-| Old value (synthetic CID)         | New value (content-addressed CID)                     |
-| --------------------------------- | ----------------------------------------------------- |
-| `fil/7/system`                    | TBD                                                   |
-| `fil/7/init`                      | TBD                                                   | 
-| `fil/7/cron`                      | TBD                                                   |
-| `fil/7/account`                   | TBD                                                   |
-| `fil/7/storagepower`              | TBD                                                   |
-| `fil/7/storageminer`              | TBD                                                   |
-| `fil/7/storagemarket`             | TBD                                                   |
-| `fil/7/paymentchannel`            | TBD                                                   |
-| `fil/7/multisig`                  | TBD                                                   |
-| `fil/7/reward`                    | TBD                                                   |
-| `fil/7/verifiedregistry`          | TBD                                                   |
+Point (2) is critical to avoid Wasm compilation costs at the upgrade epoch. If
+using [`filecoin-project/ref-fvm`], simply instantiating the `Machine` suppying
+the CID of the _Manifest_ will trigger precompilation.
 
-> Notes:
-> What would a premigration look like here?
+At this point, it is worthy to note that these block will be orphan, so
+garbage-collecting mechanisms may prune them, and walking the tree will not
+discover them (e.g. during snapshotting).
 
-### Optional removal of intrinsic VM from Filecoin client codebases
+### Upgrade procedure
+
+At the upgrade epoch `N`, clients should do the following:
+
+1. Re-import the CARv1 bundle, to restore any bytecode blocks that may have been
+   pruned.
+2. Perform a state migration.
+3. Atomically switch execution to the non-programmable FVM.
+4. Perform any message replacements needed to adjust gas limits on pending
+   messages.
+
+Points 2-4 are developed further in the next sections.
+
+#### State migration
+
+At epoch `N`, prior to executing the tipset assembled at epoch `N-1`, clients
+will run a migration over the state tree. The migration will perform two tasks:
+
+1. Patch the CodeCID of every actor will be by their corresponding
+   content-addressed CIDs, according to this lookup table:
+
+  | Old value (synthetic CID)         | New value (content-addressed CID)                     |
+  | --------------------------------- | ----------------------------------------------------- |
+  | `fil/7/system`                    | TBD                                                   |
+  | `fil/7/init`                      | TBD                                                   | 
+  | `fil/7/cron`                      | TBD                                                   |
+  | `fil/7/account`                   | TBD                                                   |
+  | `fil/7/storagepower`              | TBD                                                   |
+  | `fil/7/storageminer`              | TBD                                                   |
+  | `fil/7/storagemarket`             | TBD                                                   |
+  | `fil/7/paymentchannel`            | TBD                                                   |
+  | `fil/7/multisig`                  | TBD                                                   |
+  | `fil/7/reward`                    | TBD                                                   |
+  | `fil/7/verifiedregistry`          | TBD                                                   |
+
+
+2. Create and initialize a new state object for the System Actor (`f00`), and
+   link it from the actor's entry in the state tree:
+
+  ```rust
+  struct State {
+    builtin_actor_registry: Cid, // Map<String, Cid>
+  }
+  ```
+
+  The value of `builtin_actor_registry` is the CID of the _Manifest_ imported
+  from the bundle.
+
+#### VM atomic switch
+
+Exactly at the upgrade epoch `N`, message execution will switch from the legacy
+VM to the non-programmable FVM, for all system processes. That includes block
+validation, block production, gas estimation, and message publishing. JSON-RPC
+calls (like `StateComputeTipset` in the case of Lotus) will also begin using the
+new VM runtime.
+
+In practice, this implies that blocks assembled by producers in epoch `N-1` with
+the ***outgoing VM*** will be executed with the ***incoming VM*** at epoch `N`.
+
+Following one finality (900 epochs), the decommissioning of the legacy VM will
+be considered final.
+
+#### Message replacements
+
+This FIP is likely to be bundled with FIP-0032 within the same network upgrade.
+FIP-0032 introduces gas changes by revising the gas model to accurately account
+for the execution costs under the FVM environment.
+
+Pending messages awaiting in the mempool (whose gas limit was estimated with the
+legacy VM) are unlikely to be included with the FVM, since gas usage rules will
+have been altered.
+
+To avoid disruption, clients must re-estimate gas for pending messages they are
+tracking, and re-submit them through the message replacement mechanism.
+
+### Optional: Legacy VM removal
 
 After the upgrade epoch is over and one finality is attained, Filecoin clients
 may choose to complete erase the current VM from their respective codebases.
@@ -178,67 +256,43 @@ undesirable loss of functionality depending on the desired UX of every client,
 hence why this is entirely optional.
 
 Alternatively, Filecoin clients may provide historical chain support by
-preserving the intrinsic VM in their codebases but activating it only through
+preserving the legacy VM in their codebases but activating it only through
 optional compilation (e.g. using Go build flags, or Rust Cargo features).
-
-### Actor changes
-
-#### Init actor
-
-The init actor acts like the constructor for actor types that can be
-instantiated by user messages, namely:
-
-1. Miner actor, via the power actor.
-2. Multisig actor.
-3. Payment channel actor.
-
-While this FIP introduces no changes in this behaviour, nor to the allow list
-itself, the filtering logic will need to use the new content-addressed CodeCIDs
-for these actors.
-
-#### Power actor
-
-The `CreateMiner` method (method number 2) calls the Init actor to construct a
-new Miner actor. It will need to pass the new content-addressed CodeCID for the
-latter.
 
 ## Design Rationale
 
-WIP.
+Design rationale was integrated in the specification section.
 
 ## Backwards Compatibility
 
-### CodeCIDs
+### Structure of Code CIDs
 
-Changing the CodeCID of built-in actors can have visible consequences for users:
+Altering the structure of the Code CID of built-in actors may have visible
+consequences for users:
 
-1. When constructing multisig or payment channel actors, they will need to use a
-   content-addressed CodeCID (unpredicable) instead of a synthetic CID
-   (predictable).
+1. When constructing user-instantiable actors directly though the Init Actor
+   (i.e. multisig or payment channel actors), users will have to specify
+   unpredictable content-addressed Code CIDs instead of predictable synthetic
+   CIDs.
 2. When querying an actor in the state tree (e.g. via the `StateGetActor`
    JSON-RPC API in Lotus), the `Code` field will no longer follow a structured
-   name. This may break applications that depend on CodeCID parsing (e.g.
-   statediff).
+   pattern. This may break applications that parse Code CIDs.
 
-A possible solution is to implement a lookup table that maps synthetic CodeCIDs
-to content-addressed CodeCIDs, and vice versa, for JSON-RPC handlers to use.
+A possible solution is to implement a JSON-RPC operation to query the CodeCID of
+a built-in actor. However, the Filecoin community [was
+polled](https://github.com/filecoin-project/FIPs/discussions/310) on this topic,
+and no concerns were raised. Thus, no action is proposed at this time.
 
-When CodeCIDs are to be returned, JSON-RPC operations can be extended with a
-"legacy CodeCIDs" option for the user to demand a conversion prior to returning.
+### Actor evolution
 
-### Non-versioned changes and state tree migrations
+Pre-FVM, actor logic could change without its version being affected and,
+therefore, without the associated Code CIDs changing in the state tree. This is
+because the actor version (e.g. actors v6) represented the version of the ABI,
+not of the actor's logic.
 
-Today, actor logic can change without its version being affected and, therefore,
-without the associated CodeCIDs changing in the state tree. This is because the
-actor version (e.g. actors v6) represents a version of the ABI, not of the
-actor's logic.
-
-However, with the adoption of a canonical Wasm actors codebase across the
-network, _any_ and _every_ change in actor logic will result in different
-bytecode. Because actor code is now truly content-addressed over the bytecode,
-the CodeCIDs will change, therefore requiring a migration of all relevant actors
-in the state tree where, in the past, such migration would've not been
-necessary.
+However, with truly content-addressed CIDs, _any_ and _every_ change in actor
+logic will result in different bytecode. In practice this implies that state
+tree migrations will be more frequent.
 
 There is no action to take in this FIP, but it is worth noting the difference in
 change management dynamics that this FIP will bring on.
@@ -311,7 +365,6 @@ Machine](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0030.md)
   - Client implementations wishing to join the network upgrade deploying this
     FIP should join the coordinated testnets plan outlined below.
 
-
 ## Coordinated testnets
 
 Testnets are a critical instrument to test and verify the behavior of
@@ -377,7 +430,10 @@ remodel):**
 
 ## Security Considerations
 
-WIP.
+With the adoption of common codebases across all clients (ref-fvm and canonical
+actors), any bugs in them will threaten the stability of the entire network.
+These codebases also carry a novelty factor that should be mitigated via a
+collection of hardening and auditing actions.
 
 ## Incentive Considerations
 
@@ -385,12 +441,23 @@ N/A.
 
 ## Product Considerations
 
-WIP.
+Besides the change in Code CIDs explained in previous sections, there are no
+other product considerations emerging from this FIP alone.
 
 ## Implementation
 
-WIP.
+This FIP will be implemented in the reference Filecoin client implementation:
+Lotus.
+
+## Credits
+
+Thanks to @jennijuju for graphic work.
 
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+<!-- Footnotes -->
+
+[^1]: Originally forked from the [Forest](https://github.com/ChainSafe/forest/)
+client implementation.

--- a/FIPS/fip-0031.md
+++ b/FIPS/fip-0031.md
@@ -134,23 +134,35 @@ the following characteristics:
 
 - The CARv1 header is single-rooted.
 - The root CID resolves to a data structure that acts like a _Manifest_.
-- The _Manifest_ type is an IPLD `Map<String, Cid>`. Every entry represents a
-  built-in actor.
-  - Keys (`String`) range over an enum that identifies the actor type. These
-    strings match the current synthetic Code CIDs, and therefore can eventually
-    facilitate translations if necessary.
-    - `system`
-    - `init`
-    - `cron`
-    - `account`
-    - `storagepower`
-    - `storageminer`
-    - `storagemarket`
-    - `paymentchannel`
-    - `multisig`
-    - `reward`
-    - `verifiedregistry`
-  - Values (`Cid`) point to the Wasm bytecode of an actor as a single block.
+- The _Manifest_ type is a versioned struct, encoded as a CBOR tuple, defined as following:
+
+  ```rust
+  struct Manifest {
+    version: u32
+    data: CID
+  }
+  ```
+
+  The _Manifest_ `data` for version 1 (the only version currently defined) is a CID linking
+  to an IPLD `Vector<(String, CID)>`, ordered by explicit position, specified below.
+
+  Each entry represents a built-in actor.
+
+- Keys (`String`) range over an enum that identifies the actor type. These strings match parts
+  of the current synthetic Code CIDs, and therefore can eventually facilitate translations if
+  necessary.
+    - `system` (index 0)
+    - `init` (index 1)
+    - `cron` (index 2)
+    - `account` (index 3)
+    - `storagepower` (index 4)
+    - `storageminer` (index 5)
+    - `storagemarket` (index 6)
+    - `paymentchannel` (index 7)
+    - `multisig` (index 8)
+    - `reward` (index 9)
+    - `verifiedregistry` (index 10)
+- Values (`CID`) point to the Wasm bytecode of an actor as a single block.
 
 Clients are free to ship the bundle as they see fit. The simplest approach is to
 embed the CARv1 into the client binary, but downloading it on-demand is also an
@@ -159,8 +171,9 @@ option.
 On node startup, the client is expected to:
 
 1. Import the CARv1 contents into its state blockstore, and retain the
-   _Manifest_ CID in memory.
-2. Instruct the FVM to preload all built-in actors and precompile Wasm modules.
+   _Manifest_ data link CID in memory.
+2. Instruct the FVM to preload all built-in actors and precompile Wasm modules, by
+   supplying the manifest data Cid.
 
 Point (2) is critical to avoid Wasm compilation costs at the upgrade epoch. If
 using [`filecoin-project/ref-fvm`], simply instantiating the `Machine` suppying
@@ -194,7 +207,7 @@ will run a migration over the state tree. The migration will perform two tasks:
   | Old value (synthetic CID)         | New value (content-addressed CID)                     |
   | --------------------------------- | ----------------------------------------------------- |
   | `fil/7/system`                    | TBD                                                   |
-  | `fil/7/init`                      | TBD                                                   | 
+  | `fil/7/init`                      | TBD                                                   |
   | `fil/7/cron`                      | TBD                                                   |
   | `fil/7/account`                   | TBD                                                   |
   | `fil/7/storagepower`              | TBD                                                   |


### PR DESCRIPTION
This is a heavy editing pass that should get this FIP closer to Last Call. We're missing the final content-addressed Code CIDs, but these won't be available until later. And they are simple parameters that don't affect the body of the changes proposed in this FIP.