### PR TITLE
FIP-0032: Make the verify_consensus_fault cost constant

### DIFF
--- a/FIPS/fip-0032.md
+++ b/FIPS/fip-0032.md
@@ -229,9 +229,9 @@ The pricing formulae for extern-traversing syscalls are:
 - `get_chain_randomness`: `<<TODO>>`
 - `get_beacon_randomness`: `<<TODO>>`
 - `verify_consensus_fault`: `<<TODO>>`. This is a fixed cost that covers all blockstore operations,
-signature verifications, and other logic needed to resolve whether a consensus fault has occured.
-Note that this is different from the current (network v15 and earlier)
-in which each blockstore operation is charged.
+  signature verifications, and other logic needed to resolve whether a consensus fault has occured.
+  Note that differs from network v15 and earlier, where the cost is variable depending on the exact
+  blockstore operations performed.
 - Blockstore operations: already absorbed in the fees specified above ("IPLD
   state management fees").
 

--- a/FIPS/fip-0032.md
+++ b/FIPS/fip-0032.md
@@ -198,7 +198,7 @@ specified overhead and pricing:
 ### Extern-traversing syscall fee revision
 
 Some syscalls cannot be resolved entirely within FVM space. Such syscalls
-need to traverse the "extern" (FVM<>client) boundary to access client
+need to traverse the "extern" (FVM<>node) boundary to access client
 functionality.
 
 Depending on the languages of the client and the FVM implementation, traversing
@@ -228,7 +228,10 @@ The pricing formulae for extern-traversing syscalls are:
 
 - `get_chain_randomness`: `<<TODO>>`
 - `get_beacon_randomness`: `<<TODO>>`
-- `verify_consensus_fault`: `<<TODO>>`
+- `verify_consensus_fault`: `<<TODO>>`. This is a fixed cost that covers all blockstore operations,
+signature verifications, and other logic needed to resolve whether a consensus fault has occured.
+Note that this is different from the current (network v15 and earlier)
+in which each blockstore operation is charged.
 - Blockstore operations: already absorbed in the fees specified above ("IPLD
   state management fees").
 


### PR DESCRIPTION
The motivation for this proposed change is simplicity: It is much easier to charge for the worst case, than to try and accurately assess the cost of this syscall in the client and then report that back to the FVM.

We are not especially concerned with the accuracy of the measurement here since this syscall is rarely invoked.