### PR TITLE
FIP-0032: Clarify block operation costs and overflow handling

### DIFF
--- a/FIPS/fip-0032.md
+++ b/FIPS/fip-0032.md
@@ -157,7 +157,10 @@ Currently, IPLD block read incur a fixed fee, and IPLD block writes incur a
 variable fee, dependent on the number of bytes written.
 
 With the FVM, IPLD state I/O is managed through five syscalls, with the
-specified overhead and pricing:
+specified overhead and pricing. We introduce a `block_memcpy_per_byte` cost for those
+operations that involve a memcpy. The overhead and pricing are as follows:
+
+**Overhead**
 
 - `block_open`: looks up the supplied CID, loads the block from the state
   blockstore into the FVM kernel’s block cache, reports its size and codec. It
@@ -196,11 +199,11 @@ specified overhead and pricing:
 
 **Pricing formulae**
 
-- `block_open` (extern-traversing): `<<TODO>>`
-- `block_read`: `<<TODO>>`
-- `block_write`: `<<TODO>>`
-- `block_link` (extern-traversing): `<<TODO>>`
-- `block_stat`: `<<TODO>>`
+- `block_open` (extern-traversing): `block_open_base + block_open_per_byte * len`
+- `block_read`: `block_read_base + block_memcpy_per_byte * len`
+- `block_write`: `block_create_base + block_memcpy_per_byte * len`
+- `block_link` (extern-traversing): `block_link_base + block_link_per_byte * storage_gas_multiplire * len`
+- `block_stat`: `block_stat` (fixed cost)
 
 ### Extern-traversing syscall fee revision
 
@@ -241,6 +244,17 @@ The pricing formulae for extern-traversing syscalls are:
   blockstore operations performed.
 - Blockstore operations: already absorbed in the fees specified above ("IPLD
   state management fees").
+
+### Under/overflow handling
+
+Operations that have the potential of either underflowing or overflowing should be performed
+using [saturation arithmetic](https://en.wikipedia.org/wiki/Saturation_arithmetic). The valid
+range for any fuel operation, including total fuel consumed, is [0, 2<sup>64</sup>-1]. 
+
+The valid range for any gas operation, including gas available and total gas used, is 
+[0, 2<sup>63</sup>-1]. Gas operations only go up to 2^63-1 because they are performed using
+signed arithmetic. This is because the Filecoin protocol has some gas costs that are negative as 
+of nv15.
 
 ## Design Rationale
 


### PR DESCRIPTION
- Elaborates on block operation costs, introducing the new `block_memcpy_per_byte`
- Specifies that all gas operations should be performed using [saturation arithmetic](https://en.wikipedia.org/wiki/Saturation_arithmetic) to be under/overflow safe