### PR TITLE
FIP-0034: Note changes to ProveReplicaUpdates

### DIFF
--- a/FIPS/fip-0034.md
+++ b/FIPS/fip-0034.md
@@ -88,6 +88,9 @@ Change the parameters and return type of `market.ActivateDeals` to match the pri
 `market.VerifyDealsForActivation`, so that the market actor returns the deal weights to the miner while
 activating deals (and also [supports batching](https://github.com/filecoin-project/specs-actors/issues/474)).
 
+Change `miner.ProveReplicaUpdate` to similarly call `market.VerifyDealsForActivation` and 
+`market.ActivateDeals`, obtaining the unsealed sector CID and deal weights from the new return values.
+
 ## Design Rationale
 This value for the pre-commit deposit is simple to calculate, 
 and is always less than the value due for the sector's initial pledge.


### PR DESCRIPTION
The first draft omitted consideration of `ProveReplicaUpdates`, which needs an update to handle the new return values from market methods.

Note that `ProveReplicaUpdates` could be further optimised with a dedicated both-at-once call in the built-in market actor. But this would become irrelevant after future planned changes to the miner-market interactions.

FYI @Kubuxu 