### PR TITLE
FRC-0042: expand rejection sampling to numbers < 256

### DIFF
--- a/FRCs/frc-0042.md
+++ b/FRCs/frc-0042.md
@@ -52,16 +52,16 @@ let domain_separation_tag = "1|" // Note `|` is illegal in method names
 let mut digest Vec<u8>= blake2b(domain_separation_tag + method_name)
 while !digest.is_empty() {
   let method_id = u32::from_be(digest[0..4])
-  if method_id != 0 && method_id != 1 {
+  if method_id >= 256 {
     return method_id
   }
   digest = digest[4..] // pop-front
 }
-// probability of 2^{-248}, aka it won't happen
+// probability of 2^{-192}, aka it won't happen
 panic!("Method ID could not be determined, please change it")
 ```
 
-The values `0` and `1` are avoided via rejection sampling, 
+Values less than 256 are avoided via rejection sampling, 
 i.e. they are rejected and a subsequent slice of the blake2b hash is inspected.
 Note that the code above is not the most efficient implementation.
 
@@ -72,7 +72,9 @@ Note that these conventions only apply to methods exported to the VM for inter-a
 Actor developers can continue to use relevant programming language conventions for simple internal function calls.
 
 Exported method names *should*:
-- Use only the ASCII characters in `[a-zA-Z0-9_]` (the same set as the C programming language). Other characters, including unicode beyond this set, are excluded in order to reduce the opportunity for misleading spelling of names in user interfaces.
+- Use only the ASCII characters in `[a-zA-Z0-9_]` (the same set as the C programming language). 
+  Other characters, including unicode beyond this set, are excluded in order to 
+  reduce the opportunity for misleading spelling of names in user interfaces.
 - Start with a character in `[A-Z_]`, i.e. a capital letter or underscore, not a numeral.
 - Use CamelCase to identify word boundaries.
 - Capitalize all letters in acronyms.
@@ -85,12 +87,9 @@ The blake2b hash function is already implemented in the VM and available as a sy
 This permits easy dynamic method number calculation, 
 though build tools are expected to compute most method numbers statically at compile time.
 
-Method number `1` is expected as the constructor function by the built-in `Init` actor, 
-and user-deployed actors must implement it. This proposal assigns a conventional name.
-
-Method number `0` is treated by the FVM as a special-case bare send of the native Filecoin token, 
-and will not invoke an actor's code. 
-Rather than have some subset of method names be inaccessible, this proposal maps them to a different method number.
+Calculated method numbers are disjoint from all existing built-in actor method numbers.
+New and existing actors can use values < 256 for internal conventions.
+The numbers `0` and `1`, which carry special semantics for the VM, are excluded from the range.
 
 Both the blockchain `Message` structure and FVM support up to 64-bits for a method number.
 This proposal restricts values to 32-bits in order to compress the representation for top-level message method numbers


### PR DESCRIPTION
Expands the range of method numbers excluded by the rejection sampling mechanism to 256. This removes the possibility of collision with any existing built-in actor method number, and leaves a decent range for new actors to use for internal dispatch or other conventions.

This idea is due to @Kubuxu.