### PR TITLE
WithdrawBalance fails when beneficiary is expired or out of quota

### DIFF
--- a/FIPS/fip-0029.md
+++ b/FIPS/fip-0029.md
@@ -49,6 +49,7 @@ The following channges apply to specs-actors module:
 
 ### Withdrawals to beneficiary
 - The **WithdrawBalance** method of a miner can be called by the miner's **Beneficiary** or **Owner**, but the balance always being sent to the beneficiary. The total balance withdrawed to a beneficiary address could not exceed the quota.
+- If the **Beneficiary** is expired, or has used all of its **Quota**, then no withdrawls are possible until the beneficiary is updated or changed. Calls to **WithdrawBalance** will fail in this case.
 
 ### Setting the beneficiary address
 - Add **ChangeBeneficiary** method to miner actor to propose or confirm a change of beneficiary address and/or beneficiaryTerm. When changing beneficiaryTerm, the quota must be larger than the usedQuota. The beneficiaryChange is following a proposal/confirmation manner. A **ChangeBeneficiary** proposal can only be submitted by the **Owner**, and it takes effect only after approval(s) related parties if effective. The related parties include the **Owner**, the current Beneficiary, and the proposed Beneficiary. However, there are scenarios of auto-approval (no message required) as below: 

--- a/FIPS/fip-0029.md
+++ b/FIPS/fip-0029.md
@@ -49,7 +49,7 @@ The following channges apply to specs-actors module:
 
 ### Withdrawals to beneficiary
 - The **WithdrawBalance** method of a miner can be called by the miner's **Beneficiary** or **Owner**, but the balance always being sent to the beneficiary. The total balance withdrawed to a beneficiary address could not exceed the quota.
-- If the ** BeneficiaryTerm** is expired, or has used all of its **Quota**, then no withdrawals are possible until the beneficiary is updated or changed. Calls to **WithdrawBalance** will fail in this case with `illegal_state`.
+- If the ** BeneficiaryTerm** is expired, or has used all of its **Quota**, then no withdrawals are possible until the beneficiary is updated or changed. Calls to **WithdrawBalance** will fail in this case with USR_FORBIDDEN(18). This behaviour is different to when the owner withdraws to themselves, where a withdrawal when 0 available will "succeed" to withdraw nothing (best effort).
 
 ### Setting the beneficiary address
 - Add **ChangeBeneficiary** method to miner actor to propose or confirm a change of beneficiary address and/or beneficiaryTerm. When changing beneficiaryTerm, the quota must be larger than the usedQuota. The beneficiaryChange is following a proposal/confirmation manner. A **ChangeBeneficiary** proposal can only be submitted by the **Owner**, and it takes effect only after approval(s) related parties if effective. The related parties include the **Owner**, the current Beneficiary, and the proposed Beneficiary. However, there are scenarios of auto-approval (no message required) as below: 

--- a/FIPS/fip-0029.md
+++ b/FIPS/fip-0029.md
@@ -49,7 +49,7 @@ The following channges apply to specs-actors module:
 
 ### Withdrawals to beneficiary
 - The **WithdrawBalance** method of a miner can be called by the miner's **Beneficiary** or **Owner**, but the balance always being sent to the beneficiary. The total balance withdrawed to a beneficiary address could not exceed the quota.
-- If the **Beneficiary** is expired, or has used all of its **Quota**, then no withdrawls are possible until the beneficiary is updated or changed. Calls to **WithdrawBalance** will fail in this case.
+- If the ** BeneficiaryTerm** is expired, or has used all of its **Quota**, then no withdrawals are possible until the beneficiary is updated or changed. Calls to **WithdrawBalance** will fail in this case with `illegal_state`.
 
 ### Setting the beneficiary address
 - Add **ChangeBeneficiary** method to miner actor to propose or confirm a change of beneficiary address and/or beneficiaryTerm. When changing beneficiaryTerm, the quota must be larger than the usedQuota. The beneficiaryChange is following a proposal/confirmation manner. A **ChangeBeneficiary** proposal can only be submitted by the **Owner**, and it takes effect only after approval(s) related parties if effective. The related parties include the **Owner**, the current Beneficiary, and the proposed Beneficiary. However, there are scenarios of auto-approval (no message required) as below: 


### PR DESCRIPTION
Related code changes in `builtin-actors` PR [here](https://github.com/filecoin-project/builtin-actors/pull/602) 