### PR TITLE
fix: Amend maximum term for migrated verified deals

### DIFF
--- a/FIPS/fip-0045.md
+++ b/FIPS/fip-0045.md
@@ -654,7 +654,7 @@ That migration must:
   taking the value `DealWeight == 0 && VerifiedDealWeight == 0`
 - Add the pending allocation mapping to market state, and claim ID field to deal states (all `0`)
 - For each pending (not yet activated) deal with `Verified = true`, create an Allocation
-  - The maximum term for such allocations is 540 days, in order to support any possible sector duration
+  - The maximum term for such allocations is set to the `TermMinimum` + 90 days.
   - The expiration for such allocations is set to `MaximumVerifiedAllocationExpiration` after the migration epoch,
     which may be before the deal's start date.
 


### PR DESCRIPTION
Changing the FIP document to accurately reflect what has been implemented in `builtin-actors`. 