### PR TITLE
Fix inconsistency in FIP-0042 reserved range

### DIFF
--- a/FRCs/frc-0042.md
+++ b/FRCs/frc-0042.md
@@ -89,7 +89,7 @@ though build tools are expected to compute most method numbers statically at com
 This proposal requires the 512-bit digest variant of the Blake2b hash function.
 
 Calculated method numbers are disjoint from all existing built-in actor method numbers.
-New and existing actors can use values < 256 for internal conventions.
+New and existing actors can use values < `2^24` for internal conventions.
 The numbers `0` and `1`, which carry special semantics for the VM, are excluded from the range.
 
 Both the blockchain `Message` structure and FVM support up to 64-bits for a method number.


### PR DESCRIPTION
The value 2^24 is specified correctly in the pseudocode above.