### PR TITLE
Add gas modelling numbers to FIP-0045

### DIFF
--- a/FIPS/fip-0045.md
+++ b/FIPS/fip-0045.md
@@ -779,7 +779,58 @@ the final decoupling from the miner actor.
   including those far more efficient than the built-in one.
 
 By opening the field of competition for market-like actors, we can expect deal costs to decrease over time,
-while the network enforces just enough state to administer the quality-adjusted power of verified data. 
+while the network enforces just enough state to administer the quality-adjusted power of verified data.
+
+#### Publish Storage Deals
+Publish storage deals will see a large increase in gas usage in this FIP. This will be drastically reduced in the future by:
+
+- Aggregating datacap token transfers to the verifreg actor 
+
+- Removing the need for the market actor to be involved at all.
+
+1 deal - 
+Old Gas: ~110M
+New Gas: ~200M
+Increase: ~80%
+
+8 deals -
+Old Gas: ~370M
+New Gas: ~970M
+Increase: ~260%
+
+20 deals
+Old Gas: ~800M
+New Gas: ~2250M
+Increase: ~280%
+
+#### Prove Commit Aggregate
+Prove Commit Aggregate calls with no verified deals will see no change. Calls with verified deals will see around a 75% increase.
+
+9 sectors, no verified deals
+Old Gas: ~280M
+New Gas: ~284M
+Increase: ~1%
+
+11 sectors with verified deals
+Old Gas: ~750M
+New Gas: ~1400M
+Increase: ~85%
+
+20 sectors with verified deals
+Old Gas: ~1900M
+New Gas: ~3200M
+Increase: ~65%
+
+#### Prove Replica Update
+Each call to Prove replica Update with verified deals will see a ~30% increase in gas usage.
+
+1 verified deal
+Old Gas: ~180M
+New Gas: ~230M
+Increase: 30%
+
+#### Prove Commit
+Deal activation for prove commit it handled in cron, so SPs will not see an increase in gas costs for Prove Commit. This will however add an extra ~50M gas to cron execution, which we may want to compensate for in a future update.
 
 ### Deal packing
 Storage providers choose how to arrange deals into sectors, subject to the constraints on size and start epoch.

--- a/FIPS/fip-0045.md
+++ b/FIPS/fip-0045.md
@@ -782,7 +782,7 @@ By opening the field of competition for market-like actors, we can expect deal c
 while the network enforces just enough state to administer the quality-adjusted power of verified data.
 
 #### Publish Storage Deals
-Publish storage deals will see a large increase in gas usage in this FIP. This will be drastically reduced in the future by:
+`PublishStorageDeals` messages that include verified deals will see a large increase in gas usage in this FIP. This will be drastically reduced in the future by:
 
 - Aggregating datacap token transfers to the verifreg actor 
 


### PR DESCRIPTION
I've added gas modelling numbers for all the calls affected by this FIP.

I want to flag that the increased execution cost for each verified deal is ~50M gas. For Prove Commit, this 50M increase is going to executed in cron. We already have issues with bounding cron execution. Would it make sense to add an addition fixed gas cost to prove commits with verified deals? I don't think the marginal cost increase is too big an issue to counteract to network issues that might arise from cron bloating even more.

It's probably too late to do anything about this for nv17, but something we may want to consider in a future network upgrade.