### PR TITLE
FIP-0050: Clarify restriction of the internal API

### DIFF
--- a/FIPS/fip-0050.md
+++ b/FIPS/fip-0050.md
@@ -59,7 +59,9 @@ This FRC provides a convention for converting method names to method numbers. Th
 
 ### Restricted internal API
 
-The currently implemented API of all built-in actors is restricted to reject calls from any caller that isn't a built-in actor. These interfaces can then be relatively easily changed in the future as needed. The restriction is uniformly applied to all existing actors today. When a method is invoked, we check whether the method number is:
+The currently implemented API of all built-in actors is restricted to reject calls from any caller that isn't a built-in actor.
+We perform this check by looking up the code ID of the calling actor, and only proceeding if the caller is a non-EVM built-in actor.
+  These interfaces can then be relatively easily changed in the future as needed. The restriction is uniformly applied to all existing actors today. When a method is invoked, we check whether the method number is:
 
 - Greater than or equal to 2^24: If so, the method is presumed "exported", and are callable, regardless of the type of caller
 - Less than 2^24: If so, we lookup the code CID of the caller, which is exposed through the runtime. If the caller has one of the CIDs of the built-in actors, the invocation continues; if not, the call is rejected.


### PR DESCRIPTION
This clarification is a little premature, since it references the EVM built-in actor which hasn't yet been described in a FIP. We could wait on landing until after that FIP is open if we like.