### PR TITLE
Record f4 addresses in-state

### DIFF
--- a/FIPS/fip-0048.md
+++ b/FIPS/fip-0048.md
@@ -39,6 +39,8 @@ Specifically, this FIP:
 1. Creates a new extensible address class (`f4`) to support new addressing schemes.
 2. Allows funds to be sent to an `f4` address before an actor has been deployed to the address.
 3. Extends the `Init` actor with a new `Exec4` method for creating actors with specific `f4` addresses.
+4. Extends `ActorState` objects to include the `f4` address, if assigned.
+5. Adds a new `lookup_delegated_address` syscall to the FVM for looking up an actor's `f4` address, if assigned.
 
 ## Change Motivation
 <!--The motivation is critical for FIPs that want to change the Filecoin protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the FIP solves. FIP submissions without sufficient motivation may be rejected outright.-->
@@ -65,11 +67,12 @@ This FIP adds a new extensible address class (`f4`) where user-defined address m
 
 For now, this FIP proposes that address management actors be limited to built-in "singleton" actors, but expect users to be able to deploy their own address management actors in the future.
 
-There are three key parts to the design:
+There are four key changes proposed in this design:
 
-1. The introduction of the new `f4` address class. Tooling will need to be adapted to parse and handle said addresses.
-2. The introduction of embryo actors.
-3. A new `Exec4` method on the init actor to support the `f4` address class.
+1. A new address class (`f4`). Tooling will need to be adapted to parse and handle said addresses.
+2. A new `lookup_delegated_address` syscall to retrieve an actor's `f4` address and a new `delegated_address` field in the `ActorState` object to record an actor's `f4` address.
+3. A new "embryo" actor.
+4. A new `Exec4` method on the init actor to support the `f4` address class.
 
 **Parameters**
 
@@ -86,6 +89,69 @@ In text, this address will be formatted as `f4{decimal(actor-id)}f{base32(sub-ad
 For example, an address management actor at `f010` will be able to assign addresses starting with `f410-` in text or `[4, 10, ...]` in binary. [^1]
 
 **NOTE**: The textual format defined here is the *universal* textual format for `f4` addresses. We expect that chain explorers and client implementations will understand specific well-known address types and will format these addresses according to their "native" representation. For example, tooling should transparently convert Ethereum addresses in the `0x...` to and from the equivalent `f4` address. [^2]
+
+### New `lookup_delegated_address` Syscall And State Changes
+
+To support foreign address systems, the FVM must provide a way to lookup an actor's `f4` address. This FIP proposes two changes to support this functionality:
+
+1. A new field in the actor state-root object to store an actor's `f4` address, if assigned.
+2. A new syscall to retrieve this information.
+
+The `ActorState` object currently has the following fields (encoded as a CBOR list):
+
+ ```rust
+pub struct ActorState {
+    pub code: Cid,
+    pub state: Cid,
+    pub nonce: u64,
+    pub balance: TokenAmount,
+}
+```
+
+This FIP adds a fifth field, `delegated_address`:
+
+ ```rust
+pub struct ActorState {
+    pub code: Cid,
+    pub state: Cid,
+    pub nonce: u64,
+    pub balance: TokenAmount,
+    pub delegated_address: Option<Address>, // NEW!
+}
+```
+
+If an actor doesn't have an `f4` address, this field will be a CBOR `null`. Otherwise, it will contain the actor's `f4` address.
+
+This FIP also proposes a new `lookup_delegated_address` syscall to retrieve this information:
+
+```rust
+mod actor {
+    /// Looks up the "delegated" (f4) address of the target actor (if any).
+    ///
+    /// # Arguments
+    ///
+    /// `addr_buf_off` and `addr_buf_len` specify the location and length of the output buffer in
+    /// which to store the address.
+    ///
+    /// # Returns
+    ///
+    /// The length of the address written to the output buffer, or 0 if the target actor has no
+    /// delegated (f4) address.
+    ///
+    /// # Errors
+    ///
+    /// | Error           | Reason                                                           |
+    /// |-----------------|------------------------------------------------------------------|
+    /// | NotFound        | if the target actor does not exist                               |
+    /// | BufferTooSmall  | if the output buffer isn't large enough to fit the address       |
+    /// | IllegalArgument | if the output buffer isn't valid, in memory, etc.                |
+    pub fn lookup_delegated_address(
+        actor_id: u64,
+        addr_buf_off: *mut u8,
+        addr_buf_len: u32,
+    ) -> Result<u32>;
+}
+```
 
 ### Embryo Actors
 
@@ -106,15 +172,27 @@ pub extern "C" fn invoke(_: u32) -> u32 {
 On `send` to an unassigned `f4` address `f4{actor-id}f{subaddress}`, the FVM will:
 
 1. Validate that an actor with ID `actor-id` exists.
-2.  Create a new "embryo actor" to hold the received funds, assigning the `f4` address to that new actor.
+2.  Create a new "embryo actor" to hold the received funds, assigning the `f4` address to that new actor and recording the new actor's `f4` address in the actor's `ActorState` object.
 
 Sending to an unassigned `f2` address will not be supported as `f2` addresses are designed to protect against reorgs and aren't designed to for this use-case (see [`f2` versus `f4`](#f2-versus-f4)).
 
 Specifically, the FVM will:
 
-1. Create a new "embryo" actor.
+1. Create a new "embryo" actor with the appropriate code CID, an empty state, zero nonce, and the target `f4` address.
 2. Invoke the requested method on the embryo, depositing any value transferred. For any method number other than 0, the embryo will abort with `USR_UNHANDLED_MESSAGE` (see above) and the embryo will be deleted.
 3. Assign the target `f4` address to that actor (but don't yet assign an `f2` address) by updating the `Init` actor's address map.
+
+The embryo actor will have the following state object serialized as a DagCBOR tuple:
+
+ ```rust
+ ActorState {
+     code: EMBYRO_CODE_CID,
+     state: EMPTY_ARRAY_CID,
+     nonce: 0,
+     balance: TokenAmount::zero(),
+     delegated_address: f4_address
+}
+```
 
 ### Exec4
 
@@ -242,17 +320,40 @@ The embryo actor rejects all messages except simple value transfers (method 0) t
 
 Because embryos _reject_ all messages except simple value transfers, the message from U2 will _fail_ and no funds will be lost. If the embryo _allowed_ messages other than simple value transfers, the funds would have been deposited but not credited to `some_address` and therefore would have been lost.
 
+### Recording F4 addresses in the ActorState root
+
+Instead of recording `f4` addresses in each actor's state-root, one _could_ record this address in the actor's state itself (i.e., implement this in "userland"). However, this approach has some significant downsides:
+
+First, the actor needs to somehow _learn_ about its address, which means the address would likely need to be passed into the actor in the constructor parameters. If the address is derived _from_ the constructor parameters, the actor may need to be constructed in multiple steps.
+
+Second, learning an actor's `f4` address would involve:
+
+1. Calling some well-known method to lookup the `f4` address.
+2. Resolving that address back into an actor ID to make sure it actually belongs to the actor in question.
+
+### Recording _other_ addresses in the ActorState root
+
+A previous proposal suggested storing the `f1` and `f3` addresses in the actor state root object as well. Effectively, the `delegated_address` field would simply be an `address` field. However:
+
+1. In many ways, the `f4` address class supersedes the `f1` and `f3` address classes. By only recording `f4` addresses in this field, we leave room to eventually deprecate `f1` and `f3` addresses (assigning `f4` addresses to all actors, even [existing accounts][f4-4-all]). This also aligns well with the push towards [account abstraction][account-abstraction], because user-programmed accounts would likely have `f4` addresses (and couldn't have `f1` or `f3` addresses).
+2. There's no easy-to-explain reason group `f1`, `f3`, and `f4` addresses into a common "class" while leaving out `f2`. The real answer is that these (`f1`, `f3`, and `f4`) are are _useful_ to know on-chain, while `f2` addresses generally are not, but that doesn't make the situation any less confusing.
+
+[account-abstraction]: https://github.com/filecoin-project/FIPs/discussions/388
+[f4-4-all]: https://github.com/filecoin-project/FIPs/discussions/473#discussioncomment-4404809
+
 ## Backwards Compatibility
 <!--All FIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The FIP must explain how the author proposes to deal with these incompatibilities. FIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
 
-This FIP aims to minimize backwards incompatible changes to the chain state and will not require a state migration. However, it will still introduce new features and behavior changes:
+While this FIP aims to minimize backwards incompatible changes, it will require a state migration and will introduce new features and behavior changes:
 
+- A new `delegated_address` field will be added to all actor state-root objects. For all existing actors, this will be a single byte per actor to represent a CBOR null. To support this, the state-tree version will be bumped to version 5.
 - The address map in the init actor may now map multiple addresses to the same actor. Clients (especially dashboards) that aggregate/parse chain state will need to handle this case.
 - The code CID of a deployed actor may now change from the "embryo" code CID to an actual code CID. Implementations that cache code CIDs will need to handle this case.
 - This FIP introduces a new address class (`f4`). Implementations of the Filecoin addressing standard will need to handle parsing of this new address class.
 
 ## Test Cases
 <!--Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.-->
+
 ### Address Format
 
 TODO: ...


### PR DESCRIPTION
This is the resolution from the discussion in https://github.com/filecoin-project/FIPs/discussions/477.

Instead of a separate FIP, it's being folded into this FIP and simplified because:

1. As noted in https://github.com/filecoin-project/FIPs/discussions/477#discussioncomment-4278980,
it's intimately tied to this FIP. Half the motivation in this FIP (supporting foreign address systems) is difficult (or, at least, ugly) to implement without this extension.
2. We were unable to come up with an accurate name for the f1/f3/f4 address super-class, which likely indicates that it's not a particularly good category (https://github.com/filecoin-project/FIPs/discussions/477#discussioncomment-3919226).
3. We may want to eventually assign f4 addresses to all actors (https://github.com/filecoin-project/FIPs/discussions/473#discussioncomment-4404809).