### PR TITLE
FIP-0057: Update gas charging schedule and system limits for FEVM

### DIFF
--- a/FIPS/fip-0057.md
+++ b/FIPS/fip-0057.md
@@ -1,7 +1,7 @@
 ---
 fip: "0057"
 title: Update gas charging schedule and system limits for FEVM
-author: Steven Allen (@stebalien), Raúl Kripalani (@raulk), Akosh Farkash (@aakoshh)
+author: Steven Allen (@stebalien), Raúl Kripalani (@raulk), Akosh Farkash (@aakoshh), Jakub Sztandera  (@kubuxu)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/588
 status: Draft
 type: Technical Core

--- a/FIPS/fip-0057.md
+++ b/FIPS/fip-0057.md
@@ -234,6 +234,10 @@ When an actor is implicitly created due to a send, we charge an additional `p_ad
 = 3,375,000
 ```
 
+#### Actor Deletion
+
+There is currently a gas _refund_ on actor deletion of `1300*(36+40) = 98,800`. This FIP _removes_ this refund entirely.
+
 #### Hashing
 
 Before this FIP, hashing cost a flat 31355 gas. This FIP proposes the following gas fee schedule, incurred when calling the `crypto::hash` syscall.
@@ -398,6 +402,19 @@ Previously, Filecoin charged for `32+40 = 72` bytes when creating new actors. Ho
 ```
 
 We then round this up to 192 to account for structure and state-tree overhead, which yields `192 * 1300 = 249600 ~= 250,000` gas.
+
+### Actor Deletion Refund
+
+This FIP removes the actor deletion refund because:
+
+1. It only applies to payment channels (at the moment).
+2. It's _tiny_ compared to the computation cost of updating the state-tree. In this new gas model, the computational cost of updating the state-tree vastly exceeds the gas refund.
+3. Negative gas charges are, in general, a security hazard.
+
+In the future, we will likely want some incentive to delete unused actor state. But that incentive will:
+
+1. Have to be proportional to the amount of state freed.
+2. Have to be something _other_ than gas.
 
 ### Address Resolution & Assignment
 

--- a/FIPS/fip-0057.md
+++ b/FIPS/fip-0057.md
@@ -1,5 +1,5 @@
 ---
-fip: "<to be assigned>"
+fip: "0057"
 title: Update gas charging schedule and system limits for FEVM
 author: Steven Allen (@stebalien), Raúl Kripalani (@raulk), Akosh Farkash (@aakoshh)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/588

--- a/FIPS/fip-nnnn-fevm-gas.md
+++ b/FIPS/fip-nnnn-fevm-gas.md
@@ -1,0 +1,212 @@
+---
+fip: "<to be assigned>"
+title: Update gas charging schedule and system limits for FEVM
+author: Steven Allen (@stebalien), Raúl Kripalani (@raulk), Akosh Farkash (@aakoshh)
+discussions-to: <URL>
+status: Draft
+type: Technical Core
+category (*only required for Standard Track): Core
+created: 2022-12-12
+spec-sections:
+  - <section-id>
+  - <section-id>
+requires: 0032, PR-512 (draft)
+---
+
+## Simple Summary
+
+With the introduction of user programmable smart contracts, we need to ensure that the gas model accurately reflects the cost of on-chain computation. In the current network, users can only trigger course-grained behaviors by submitting messages to built-in actors. However, with the introduction of FEVM, users will be able to deploy new smart contracts with fine-grained control over FVM execution. If we don't carefully tune the gas model to accurately charge for computation, an attacker could carefully construct a contract to take advantage that and slow down or even stop chain validation.
+
+## Abstract
+
+This FIP proposes a few adjustments to the gas charging schedule. Specifically:
+
+1. Adds charges to syscalls that were previously free.
+2. Adds charges to externs that were previously free.
+3. Adds variable charges (scaling with the input) to some syscalls that previously charged a fixed fee.
+4. Exempts some Wasm instructions from execution gas. 
+5. Adds bulk memory copy fee to all instructions that initialize and/or copy memory.
+6. Adds a memory expansion fee.
+7. Introduces memory limits and table limits.
+8. Reduces the default instruction cost for execution gas.
+
+## Change Motivation
+
+With the introduction of FEVM, users will be able to trigger these operations:
+
+1. Operations that have runtime cost varying in the size of the inputs (bulk memory copies, hashing, etc.).
+2. Syscalls traversing the extern boundary.
+3. Syscalls not traversing the extern boundary.
+4. Sequences of predefined Wasm instructions backing FEVM opcode handlers.
+5. Memory allocation.
+
+We propose gas charges and system limits to Currently, there is a fixed fee but no per-byte charge for hashing, memory copies, fills, etc. Furthermore, all Wasm instructions are priced through execution gas at a flat rate of 4 gas/op with the exception of some control flow instructions. However, recent observations suggest that some incur in no CPU cost, so we propose new gas exemptions for higher accuracy.
+
+## Specification
+
+Notes:
+
+- Filecoin targets 10 gas/ns. That is, an operation that takes 1 nanosecond should cost 10 gas.
+- The FVM supports gas charges with _milligas_ precision. That is, we can charge for gas in increments of 0.001 gas.
+
+### System Calls
+
+The following unpriced syscalls begin accruing the following costs.
+
+TODO.
+
+| Syscall | Cost |
+| ------- | ---- |
+|         |      |
+
+#### Hashing
+
+Before this FIP, hashing cost a flat 31355 gas. This FIP proposes the following gas fee schedule, incurred when calling the `crypto::hash` syscall.
+
+| Hash Function | Flat | Per-Byte           |
+| ------------- | ---- | ------------------ |
+| SHA2-256      | 0    | 64500 milligas     |
+| Blake2b-256   | 0    | 11500 milligas     |
+| Blake2b-512   | 0    | 11500 milligas     |
+| Keccak256     | 0    | 48500 milligas     |
+| Ripemd160     | 0    | 43900 milligas     |
+
+Whether this is a net reduction or increase depends on the length of the preimage. For example, for the Blake2b family, the crossover is at ~2726 bytes.
+
+#### Signature verification
+
+Before this FIP, signature verification had these costs:
+
+- BLS: 16598605 gas.
+- secp256k1: 1637292 gas.
+
+We revise these costs and introduce a new fee for secp256k1 public key recovery (syscall introduced in FIP-TODO).
+
+| Concept                          | Flat                  | Per-Byte           |
+| -------------------------------  | --------------------- | ------------------ |
+| BLS signature verification       | 18719325000 milligas  | 11400 milligas     |   
+| secp256k1 signature verification | 2639001000 milligas   | 11400 milligas     |
+| secp256k1 signature recovery     | 2643945000 milligas   | 0                  |
+
+This implies a slight base upwards revision of existing fees, which should have minimal impact because these operations aren't frequent.
+
+### Wasm Instructions
+
+This FIP introduces charges for Wasm instructions that operate on variable-sized memory, and exempts execution gas for some no-op instructions.
+
+#### Memory Copy
+
+The memory copy cost was first introduced in FIP-0032 but only applied to memory copying within the FVM itself.
+
+Instructions that operate on variable-sized memory chunks are now charged a per-byte memory copy fee: `{table,memory}.{init,fill,copy,grow}`.
+
+This fee is identical to `p_memcpy_gas_per_byte` as defined in [FIP-0032](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0032.md), currently priced at 500 milligas per byte.
+
+Additionally, these fees are charged for memory and table allocation when the actor is instantiated (started).
+
+#### No-Ops
+
+Costs have been removed from some operations that would have little to no cost on a traditional CPU. These rules are _valid_ under FEVM because the user cannot trigger _specific_ sequences of WebAssembly instructions but must be revisited before introducing full user programmability as some pathologically unoptimized programs may be able to find a way to make these instructions actually take time.
+
+This is in addition to no-op equivalent instructions that were already exempted in FIP-0032 (`nop`, `block`, `loop`, `unreachable`, `return`, `else`, `end`, `drop`).
+
+##### Locals & Globals
+
+Setting/getting locals and globals is now free because these instructions are mostly just telling other instructions which registers to use. Furthermore, in FEVM, the user cannot directly control and/or create new locals/globals.
+
+The newly exempt instructions are:
+
+- `local.{get,set,tee}`
+- `global.{get,set}`
+
+##### Casts
+
+Logic-less casts have been made free as they generally don't turn into actual instructions (or, when they do, these instructions basically free and tied to some other more expensive operation).
+
+The newly exempt instructions are:
+
+1. `i64.extend32_u` - re-interprets the input as a u64 (without sign extension).
+2. `i32.wrap_i64`- casts an i64 to an i32.
+3. `$t.reinterpret_$t` - bitwise casts.
+
+##### Bulk memory drops
+
+The `{data,elem}.drop` bulk memory drop instructions are now exempt from execution gas.
+
+##### Constants
+
+All operations that push constants onto the WebAssembly stack (`$t.const`) have been made free. In most cases, these will compile down to "immediate" arguments, or, in the worst case, _very_ predictable loads from read-only memory.
+
+### Memory expansion gas
+
+We define two fees for memory expansion:
+
+- A flat fee per operation to cover the base cost of the allocation operation.
+- A dynamic per-byte fee, which is effectively applied in increments of 64KiB (Wasm memory page size).
+
+Their prices are:
+
+```
+p_memory_fill_base_cost := TODO
+p_memory_fill_per_byte_cost := TODO
+```
+
+These fees are applied in three scenarios:
+
+1. On initialization of an invocation container, we charge both fees, with the dynamic fee charging for the number of Wasm memory bytes preallocated by the environment before control is handed to the actor.
+2. On initialization of an invocation container, we charge both fees if the module exports a table. The dynamic fee charging for the memory required to hold the minimum table size (8 bytes per element).
+3. During execution, we charge both fees for every `memory.grow` operation carried out.
+
+Note: (1) and (2) may be wasmtime-dependent at this stage.
+
+### Memory limits
+
+A call stack is entitled to allocate a maximum of 2GiB in cumulative Wasm memory across all active invocation containers. If an actor triggers an allocation that breaches this limit, execution will be interrupted and:
+
+- The `SYS_ILLEGAL_INSTRUCTION` (4) exit code will be returned to the caller if the offending actor was called through an internal send, or
+- The `SYS_ILLEGAL_INSTRUCTION` (4) exit code will be stamped on the receipt if the offending actor was the top of the stack.
+
+### Default instruction cost reduction
+
+We reduce the default instruction cost from 4 gas/op to TODO gas/op. This reduction is made possible thanks to the specific memory expansion modelling. Previously, memory allocation overheads were averaged and smoothed into the default instruction cost.
+
+## Design Rationale
+
+Execution fidelity, accuracy, and security are the overarching principles that motivates this FIP. Fees have been revised to deliver a more accurate gas model while preserving the security properties of the network, which revolve around the baseline cost of 10 gas/ns.
+
+The rationale backing each decision has been documented in the specification section.
+
+## Backwards Compatibility
+
+This FIP is consensus breaking, but should have no other impact on backwards compatibility. However, agents making assumptions about gas (e.g. setting hardcoded gas limits) may need to adapt.
+
+## Test Cases
+
+TODO: Will be covered by conformance tests.
+
+## Security Considerations
+
+This FIP charges zero for some operations. These operations should consume no CPU time, but this should be rigorously verified before allowing users to deploy arbitrary WebAssembly contracts.
+
+Furthermore, this FIP does not charge variable amounts for different types of mathematical operations. For example, in the future, we'll likely want to charge more for floating point operations, and significantly more for the "sqrt" operation.
+
+However, the proposed gas schedule should be "good enough" for FEVM because:
+
+1. Users cannot deploy new WebAssembly contracts, so there's no way to write custom WebAssembly that creates sequences of "free" instructions that actually have runtime costs.
+2. Floating point instructions, including the square-root instruction, is not available in the EVM.
+
+## Incentive Considerations
+
+As with all gas schedule changes, this FIP introduces changes to the operation costs of built-in actors which may alter operational cost structures for network stakeholders affective incentive structures.
+
+## Product Considerations
+
+This FIP will likely increase gas fees in some cases and needs to be carefully benchmarked.
+
+## Implementation
+
+TODO in progress in ref-fvm.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/FIPS/fip-nnnn-fevm-gas.md
+++ b/FIPS/fip-nnnn-fevm-gas.md
@@ -31,6 +31,8 @@ This FIP proposes a few adjustments to the gas charging schedule. Specifically:
 
 This FIP also introduces overall memory limits. However, these memory limits currently only include Wasm memories and table elements (not IPLD blocks, wasm _code_, and other metadata).
 
+Additionally, this FIP introduces a maximum block size limit of 1MiB for all newly created IPLD blocks.
+
 Finally, this FIP reduces the maximum recursive call depth limit from 1025 to 1024 to bring it in-line with the initial intentions of this limit and other blockchain VMs.
 
 ## Change Motivation
@@ -232,6 +234,13 @@ A call stack is entitled to allocate a maximum of 2GiB in cumulative Wasm memory
 
 - If an actor attempts to exceed either of these limits at runtime, the Wasm container will return `-1` to the actor (as per the Wasm spec). All current built-in actors will then abort immediately with the `SYS_ILLEGAL_INSTRUCTION` exit code.
 - If instantiating an actor would exceed either of these limits, the instantiating actor will immediately exit with the `SYS_ILLEGAL_INSTRUCTION` exit code.
+
+### Block Size Limits
+
+This FIP introduces a 1MiB limit on all newly created blocks (through the `ipld::block_create` syscall). This affects:
+
+1. Blocks in state.
+2. The size of internal (actor to actor) messages and return values.
 
 ## Design Rationale
 

--- a/FIPS/fip-nnnn-fevm-gas.md
+++ b/FIPS/fip-nnnn-fevm-gas.md
@@ -21,26 +21,28 @@ With the introduction of user programmable smart contracts, we need to ensure th
 
 This FIP proposes a few adjustments to the gas charging schedule. Specifically:
 
-1. Adds charges to syscalls that were previously free.
-2. Adds charges to externs that were previously free.
-3. Adds variable charges (scaling with the input) to some syscalls that previously charged a fixed fee.
-4. Exempts some Wasm instructions from execution gas. 
-5. Adds bulk memory copy fee to all instructions that initialize and/or copy memory.
-6. Adds a memory expansion fee.
-7. Introduces memory limits and table limits.
-8. Reduces the default instruction cost for execution gas.
+- Adjustments to some syscall gas:
+    - State read and write costs.
+    - Internal send costs.
+    - Hashing, signature verification, and randomness.
+- Variable charges for memory initialization, copying, and allocation.
+- New charges for state-tree reads and writes.
+- New charges for actor address resolution.
+
+This FIP also introduces overall memory limits. However, these memory limits currently only include Wasm memories and table elements (not IPLD blocks, wasm _code_, and other metadata).
+
+Finally, this FIP reduces the maximum recursive call depth limit from 1025 to 1024 to bring it in-line with the initial intentions of this limit and other blockchain VMs.
 
 ## Change Motivation
 
-With the introduction of FEVM, users will be able to trigger these operations:
+With the introduction of FEVM, users will be able to trigger operations that were previously priced according to "expected costs". These prices took things caching, overall message execution costs, and size limits imposed by the actors themselves into account. Unfortunately, with the introduction of FEVM, these assumptions no longer hold.
 
-1. Operations that have runtime cost varying in the size of the inputs (bulk memory copies, hashing, etc.).
-2. Syscalls traversing the extern boundary.
-3. Syscalls not traversing the extern boundary.
-4. Sequences of predefined Wasm instructions backing FEVM opcode handlers.
-5. Memory allocation.
+With a FEVM contract, users can:
 
-We propose gas charges and system limits to Currently, there is a fixed fee but no per-byte charge for hashing, memory copies, fills, etc. Furthermore, all Wasm instructions are priced through execution gas at a flat rate of 4 gas/op with the exception of some control flow instructions. However, recent observations suggest that some incur in no CPU cost, so we propose new gas exemptions for higher accuracy.
+1. Perform operations that have runtime cost varying in the size of the inputs (bulk memory copies, hashing, etc.). These operations previously had fixed costs.
+2. Make state read and write operations that have not been re-priced since network launch. These prices were estimated before the FVM existed, and while the state-tree was quite small.
+3. Make syscalls that were previously expected to have their costs amortized over the execution of the transaction as a whole. Unfortunately, with FEVM, prices must assume random pathological access.
+4. Allocate arbitrary amounts of memory. Existing built-in actors have explicit limits to avoid running out of memory, but FEVM requires system-imposed global memory limits.
 
 ## Specification
 
@@ -48,30 +50,136 @@ Notes:
 
 - Filecoin targets 10 gas/ns. That is, an operation that takes 1 nanosecond should cost 10 gas.
 - The FVM supports gas charges with _milligas_ precision. That is, we can charge for gas in increments of 0.001 gas.
+- In terms of chain throughput (gas per unit time), there's about 222 Filecoin gas to every 1 Ethereum gas. This ratio should be kept in mind when comparing Filecoin gas costs to Ethereum gas costs.
+
+### Adjustments to FIP-0032
+
+First and foremost, this FIP makes a few adjustments to FIP-0032.
+
+- Memory copy costs `p_memcpy_per_byte` have been reduced from 0.5gas/byte to 0.4gas/byte to more accurately match benchmarks. We're reasonably confident in this number as it exactly matches the expected speed of 3200 MT/s memory.
+- The explicit "extern" cost (`p_extern_gas`) of 21,000 gas has been rolled into the various syscall costs themselves to make it easier to reason about the costs of the individual syscalls. This change has no affect on the gas _charged_, it simply makes it easier to benchmark and discuss changes to gas charges.
 
 ### System Calls
 
-The following unpriced syscalls begin accruing the following costs.
+#### IPLD Reads & Writes
 
-TODO.
+This FIP updates the cost of all 4 IPLD operations according to the latest benchmarks.
 
-| Syscall | Cost |
-| ------- | ---- |
-|         |      |
+##### `ipld::block_open`
+
+1. The flat fee has been increased from 135,617 to 187,440 account for an increased size in the state-tree since network launch.
+2. The per-byte fee has been reduced from `10.5 gas/byte` to a flat `10 gas/byte` (`p_memret_per_byte`). This reduction comes from the fact that the "memory retention" cost more than covers the actual per-byte compute cost from loading IPLD blocks.
+
+The new read costs were determined through [benchmarking][read-benchmark]. However, the per-byte costs were ignored as they were already covered by the existing memory retention cost.
+
+[read-benchmark]: https://bafybeifx23obtfhzdomhtlrv5h3lkb4zjnj32kye27q24gvjlkpjva7zre.ipfs.dweb.link/blockstore-read-gas.html
+
+##### `ipld::block_create`
+
+The per-byte fee has been reduced from `10.5 gas/byte` to a flat `10 gas/byte` for the same reasons as `ipld::block_open`.
+
+##### `ipld::block_read`
+
+The per-byte fee has been reduced from `0.5 gas/byte` to `0.4 gas/byte` due to the adjustment to `p_memcpy_per_byte`.
+
+##### `ipld::block_link`
+
+The cost of "linking" a block has been adjusted to take deferred compute costs (the cost of "flushing" blocks at the end of an epoch), hashing, allocating, and copying into account.
+
+Specifically, this FIP proposes the following:
+
+1. A `2.4 gas/byte` fee for to allocate and copy the block into temporary storage.
+2. A per-byte hashing fee according to the price list defined in the hashing section below.
+3. A fixed per-block fee of 172,000 gas to account for the cost of "flushing" blocks at the end of an epoch.
+4. A fixed 130,000 per-block storage fee to account for metadata overhead.
+5. A per-byte storage fee of 1,300 gas/byte.
+
+These fees supersede the current prices:
+
+1. A 1,300 gas/byte storage fee.
+2. A fixed 353,640 per-block fee.
+
+Overall, blocks under ~4KiB are actually cheeper under this model as the fixed cost is reduced from 353,640 to 302,000.
+
+As with reads, these costs were determined through [benchmarking](write-benchmark).
+
+[write-benchmark]: https://bafkreifhqfbc2scfq6s4roj625y2a4bm5cmo7bs6to56vjbu5cqswdxswe.ipfs.dweb.link/
+
+#### Send
+
+This FIP changes `send` costs to:
+
+1. Account for the cost of instantiating and invoking a Wasm actor.
+2. Not account for account  actor state loading and storing as those costs will now be accounted for separately.
+
+Previously, there were four send-related gas fees:
+
+1. A base send cost of 29233 gas.
+2. A transfer charge of 27500 gas.
+3. A transfer only premium of 159672 gas. This was charged for actors that didn't invoke any actual code.
+4. A method invocation (actor instantiation) "rebate"' of 5377 gas. This gas was refunded to actors that actually invoked code.
+
+These costs were designed to "make the numbers work out" in aggregate and took things like actor state loading/storing into account.
+
+This model has been simplified to:
+
+1. A fixed "transfer" fee of 6000 gas for all non-zero value transfers.
+2. A fixed "invocation" cost of 75000 for all sends except method 0, to charge for instantiating and calling into an actor.
+
+#### Actor State & Address Lookups
+
+Previously, the FVM relied heavily on caching to reduce the costs of actor state loading and address resolution. Unfortunately, in the presence of user defined actors, it's now possible to trigger random address resolutions and actor state loads.
+
+This FIP introduces:
+
+1. An actor-state lookup cost of 400,000 gas (`p_actor_lookup`. This covers an expected 2 IPLD block loads, decodes, etc.
+2. An address resolution cost of 1,000,000 gas (`p_address_lookup`). This covers the expected 5 IPLD block loads, decodes, etc.
+
+As these costs are significant, this FIP proposes two mechanisms to reduce these costs:
+
+1. First, this FIP takes caching into account and only charges for the _first_ time, during a single transaction, that an address is _successfully_ resolved or an actor's state is loaded.
+2. Second, this FIP will not charge to load builtin singleton actor states (actors 0-7, 10, and 99).
+
+#### Actor State Updates
+
+Currently, the cost for actor-state updates is bundled into the cost of calling an actor. This FIP breaks these costs out to more accurately charge for state changes. As with actor state reads, these fees are only charged the first time an actor is updated during a transaction.
+
+When an actor's state is updated (e.g., when transferring funds or calling `sself::set_root`) for the first time during a transaction:
+
+1. If the actor state has not yet been loaded, `p_actor_lookup` is charged.
+2. If the actor state has not yet been updated, TODO (`p_actor_update`) is charged to cover not only the cost of updating the state-tree, but the cost of the expected state churn resulting from the update.
+
+TODO:
+
+- It's unclear what the update fee here should be.
+
+#### Actor Creation
+
+The explicit "actor creation" compute cost of 1108454 is removed while the actor creation _storage_ cost of `(36+40) * 1300` remains.
+
+Instead:
+
+- Whenever a new actor is created, we charge `p_actor_update + p_actor_lookup` (in addition to the storage fee above).
+- When implicitly creating an actor (e.g., implicitly creating an account and/or a FIP-0048 placeholder), we also charge `p_address_lookup` to cover the cost of assigning an address.
+
+TODO:
+
+- Ideally we'd just execute the init actor when implicitly creating an actor.
+- We should likely charge an explicit fee when assigning an address to an implicitly created actor, in addition to the address lookup fee.
 
 #### Hashing
 
 Before this FIP, hashing cost a flat 31355 gas. This FIP proposes the following gas fee schedule, incurred when calling the `crypto::hash` syscall.
 
-| Hash Function | Flat | Per-Byte           |
-| ------------- | ---- | ------------------ |
-| SHA2-256      | 0    | 64500 milligas     |
-| Blake2b-256   | 0    | 11500 milligas     |
-| Blake2b-512   | 0    | 11500 milligas     |
-| Keccak256     | 0    | 48500 milligas     |
-| Ripemd160     | 0    | 43900 milligas     |
+| Hash Function | Per-Byte |
+| ------------- | -------- |
+| SHA2-256      |  7 gas   |
+| Blake2b-256   | 10 gas   |
+| Blake2b-512   | 10 gas   |
+| Keccak256     | 33 gas   |
+| Ripemd160     | 35 gas   |
 
-Whether this is a net reduction or increase depends on the length of the preimage. For example, for the Blake2b family, the crossover is at ~2726 bytes.
+Whether this is a net reduction or increase depends on the length of the preimage. For example, for the Blake2b family, the crossover is at ~3135 bytes.
 
 #### Signature verification
 
@@ -80,95 +188,50 @@ Before this FIP, signature verification had these costs:
 - BLS: 16598605 gas.
 - secp256k1: 1637292 gas.
 
-We revise these costs and introduce a new fee for secp256k1 public key recovery (syscall introduced in FIP-TODO).
+This FIP adds a per-byte cost as well:
 
-| Concept                          | Flat                  | Per-Byte           |
-| -------------------------------  | --------------------- | ------------------ |
-| BLS signature verification       | 18719325000 milligas  | 11400 milligas     |   
-| secp256k1 signature verification | 2639001000 milligas   | 11400 milligas     |
-| secp256k1 signature recovery     | 2643945000 milligas   | 0                  |
+- 10 gas/byte for secp256k1.
+- 26 gas/byte for BLS.
 
-This implies a slight base upwards revision of existing fees, which should have minimal impact because these operations aren't frequent.
+Note: the new `crypto::recover_secp_public_key` only charges the base 1637292 gas as it doesn't have to hash any messages.
 
-### Wasm Instructions
+This implies a slight base upwards revision of existing fees, which should have minimal impact because:
 
-This FIP introduces charges for Wasm instructions that operate on variable-sized memory, and exempts execution gas for some no-op instructions.
+1. These operations aren't frequent.
+2. The base cost dwarfs the cost of hashing.
 
-#### Memory Copy
+#### Randomness
 
-The memory copy cost was first introduced in FIP-0032 but only applied to memory copying within the FVM itself.
+Previously, retrieving randomness only costed the flat `p_extern_gas` fee (FIP-0032). This FIP proposes an additional charge to cover the hashing involved. Specifically,  `(seed_size + entropy_size) * blake2b_hashing + p_extern_gas` where:
 
-Instructions that operate on variable-sized memory chunks are now charged a per-byte memory copy fee: `{table,memory}.{init,fill,copy,grow}`.
+1. `seed_size` is 48 (the size of the randomness "seed").
+2. `entropy_size` is the size of the entropy passed by the actor (usually 8).
+3. `blake2b_hashing` is 10 (as defined above in the hashing section.
 
-This fee is identical to `p_memcpy_gas_per_byte` as defined in [FIP-0032](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0032.md), currently priced at 500 milligas per byte.
+This should usually come out to about 560 gas which will increase the cost of this operation by about 2% in most cases. However, this additional charge prevents an attacker from potentially tricking the system into hashing a large amount of data for free.
 
-Additionally, these fees are charged for memory and table allocation when the actor is instantiated (started).
+### Memory Gas
 
-#### No-Ops
+This FIP introduces charges for Wasm instructions that operate on variable-sized memory.
 
-Costs have been removed from some operations that would have little to no cost on a traditional CPU. These rules are _valid_ under FEVM because the user cannot trigger _specific_ sequences of WebAssembly instructions but must be revisited before introducing full user programmability as some pathologically unoptimized programs may be able to find a way to make these instructions actually take time.
+The memory copy cost (`p_memcpy_gas_per_byte`) was first introduced in FIP-0032 but only applied to memory copying within the FVM itself.
 
-This is in addition to no-op equivalent instructions that were already exempted in FIP-0032 (`nop`, `block`, `loop`, `unreachable`, `return`, `else`, `end`, `drop`).
+This FIP:
 
-##### Locals & Globals
-
-Setting/getting locals and globals is now free because these instructions are mostly just telling other instructions which registers to use. Furthermore, in FEVM, the user cannot directly control and/or create new locals/globals.
-
-The newly exempt instructions are:
-
-- `local.{get,set,tee}`
-- `global.{get,set}`
-
-##### Casts
-
-Logic-less casts have been made free as they generally don't turn into actual instructions (or, when they do, these instructions basically free and tied to some other more expensive operation).
-
-The newly exempt instructions are:
-
-1. `i64.extend32_u` - re-interprets the input as a u64 (without sign extension).
-2. `i32.wrap_i64`- casts an i64 to an i32.
-3. `$t.reinterpret_$t` - bitwise casts.
-
-##### Bulk memory drops
-
-The `{data,elem}.drop` bulk memory drop instructions are now exempt from execution gas.
-
-##### Constants
-
-All operations that push constants onto the WebAssembly stack (`$t.const`) have been made free. In most cases, these will compile down to "immediate" arguments, or, in the worst case, _very_ predictable loads from read-only memory.
-
-### Memory expansion gas
-
-We define two fees for memory expansion:
-
-- A flat fee per operation to cover the base cost of the allocation operation.
-- A dynamic per-byte fee, which is effectively applied in increments of 64KiB (Wasm memory page size).
-
-Their prices are:
-
-```
-p_memory_fill_base_cost := TODO
-p_memory_fill_per_byte_cost := TODO
-```
-
-These fees are applied in three scenarios:
-
-1. On initialization of an invocation container, we charge both fees, with the dynamic fee charging for the number of Wasm memory bytes preallocated by the environment before control is handed to the actor.
-2. On initialization of an invocation container, we charge both fees if the module exports a table. The dynamic fee charging for the memory required to hold the minimum table size (8 bytes per element).
-3. During execution, we charge both fees for every `memory.grow` operation carried out.
-
-Note: (1) and (2) may be wasmtime-dependent at this stage.
+1. Reduces this fee from 500 milligas to 400 milligas. This reduction applies to the relevant
+   syscalls as well (e.g., block reads and writes).
+2. Charges this fee (per byte) for instructions that operate on variable-sized memory:
+   `{table,memory}.{init,fill,copy,grow}`. Table operations charge for 8 bytes per table entry (3.2
+   gas/entry).
+3. Charges this fee (again, per byte) for memory initialized when instantiating an actor. This includes both the Wasm memory and Wasm any tables initialized.
+4. Removes the "one free page of memory" rule from FIP-0032. The FVM now charges for every page of memory allocated, even on initialization.
 
 ### Memory limits
 
-A call stack is entitled to allocate a maximum of 2GiB in cumulative Wasm memory across all active invocation containers. If an actor triggers an allocation that breaches this limit, execution will be interrupted and:
+A call stack is entitled to allocate a maximum of 2GiB in cumulative Wasm memory across all active invocation containers, and 512MiB for any given actor instance.
 
-- The `SYS_ILLEGAL_INSTRUCTION` (4) exit code will be returned to the caller if the offending actor was called through an internal send, or
-- The `SYS_ILLEGAL_INSTRUCTION` (4) exit code will be stamped on the receipt if the offending actor was the top of the stack.
-
-### Default instruction cost reduction
-
-We reduce the default instruction cost from 4 gas/op to TODO gas/op. This reduction is made possible thanks to the specific memory expansion modelling. Previously, memory allocation overheads were averaged and smoothed into the default instruction cost.
+- If an actor attempts to exceed either of these limits at runtime, the Wasm container will return `-1` to the actor (as per the Wasm spec). All current built-in actors will then abort immediately with the `SYS_ILLEGAL_INSTRUCTION` exit code.
+- If instantiating an actor would exceed either of these limits, the instantiating actor will immediately exit with the `SYS_ILLEGAL_INSTRUCTION` exit code.
 
 ## Design Rationale
 
@@ -186,14 +249,15 @@ TODO: Will be covered by conformance tests.
 
 ## Security Considerations
 
-This FIP charges zero for some operations. These operations should consume no CPU time, but this should be rigorously verified before allowing users to deploy arbitrary WebAssembly contracts.
+This FIP exists to improve the security of the Filecoin network, but has intentionally skipped over a few cases:
 
-Furthermore, this FIP does not charge variable amounts for different types of mathematical operations. For example, in the future, we'll likely want to charge more for floating point operations, and significantly more for the "sqrt" operation.
+- This FIP does not charge variable amounts for different types of mathematical operations. For example, in the future, we'll likely want to charge more for floating point operations, and significantly more for the "sqrt" operation.
+- This FIP does not make any explicit charges to account for memory latency.
 
 However, the proposed gas schedule should be "good enough" for FEVM because:
 
-1. Users cannot deploy new WebAssembly contracts, so there's no way to write custom WebAssembly that creates sequences of "free" instructions that actually have runtime costs.
-2. Floating point instructions, including the square-root instruction, is not available in the EVM.
+1. There's enough overhead in FEVM to "drown out" the effects of memory latency.
+2. Floating point instructions, including the square-root instruction, are not available in the EVM.
 
 ## Incentive Considerations
 

--- a/FIPS/fip-nnnn-fevm-gas.md
+++ b/FIPS/fip-nnnn-fevm-gas.md
@@ -2,7 +2,7 @@
 fip: "<to be assigned>"
 title: Update gas charging schedule and system limits for FEVM
 author: Steven Allen (@stebalien), Raúl Kripalani (@raulk), Akosh Farkash (@aakoshh)
-discussions-to: <URL>
+discussions-to: https://github.com/filecoin-project/FIPs/discussions/588
 status: Draft
 type: Technical Core
 category (*only required for Standard Track): Core


### PR DESCRIPTION
**Discussions:** https://github.com/filecoin-project/FIPs/discussions/588

With the introduction of user programmable smart contracts, we need to ensure that the gas model accurately reflects the cost of on-chain computation. In the current network, users can only trigger course-grained behaviors by submitting messages to built-in actors. However, with the introduction of FEVM, users will be able to deploy new smart contracts with fine-grained control over FVM execution. If we don't carefully tune the gas model to accurately charge for computation, an attacker could carefully construct a contract to take advantage that and slow down or even stop chain validation.

This FIP proposes a few adjustments to the gas charging schedule. Specifically:

- Adjustments to some syscall gas:
    - State read and write costs.
    - Internal send costs.
    - Hashing, signature verification, and randomness.
- Variable charges for memory initialization, copying, and allocation.
- New charges for state-tree reads and writes.
- New charges for actor address resolution.

This FIP also introduces overall memory limits. However, these memory limits currently only include Wasm memories and table elements (not IPLD blocks, wasm _code_, and other metadata).

Additionally, this FIP introduces a maximum block size limit of 1MiB for all newly created IPLD blocks.

Finally, this FIP reduces the maximum recursive call depth limit from 1025 to 1024 to bring it in-line with the initial intentions of this limit and other blockchain VMs.