### PR TITLE
FIP-0050: Multisig: Do not export any functionality

### DIFF
--- a/FIPS/fip-0050.md
+++ b/FIPS/fip-0050.md
@@ -138,15 +138,7 @@ No methods are exported for the Cron actor.
 
 #### Multisig Actor
 
-- Propose
-- Approve
-- Cancel
-- AddSigner
-- RemoveSigner
-- SwapSigner
-- ChangeNumApprovalsThreshold
-- LockBalance
-- Receive
+No methods are exported for the Multisig actor, besides the UniversalReceiverHook (which isalready exported).
 
 #### Payment Channel Actor
 

--- a/FIPS/fip-0050.md
+++ b/FIPS/fip-0050.md
@@ -138,7 +138,7 @@ No methods are exported for the Cron actor.
 
 #### Multisig Actor
 
-No methods are exported for the Multisig actor, besides the UniversalReceiverHook (which isalready exported).
+No methods are exported for the Multisig actor, besides the UniversalReceiverHook (which was already exported).
 
 #### Payment Channel Actor
 


### PR DESCRIPTION
Exporting these methods has unintended negative consequences (see https://github.com/filecoin-project/builtin-actors/issues/964), so maintaining the status quo is preferred.