### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Reference
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
+
+# Global owners
+# Ensure maintainers team is a requested reviewer for non-draft PRs
+*                       @filecoin-project/fips-editors


### PR DESCRIPTION
Id like to propose to  enable "2 approval from fip editors", the goal is to encourage deeper and more thorough reviews before DRAFTs move to LAST CALLs 