### PR TITLE
FIP0055: Update Create/Create2/CreateExternal logic

### DIFF
--- a/FIPS/fip-0055.md
+++ b/FIPS/fip-0055.md
@@ -177,36 +177,51 @@ It returns the `USR_FORBIDDEN` (18) exit code when the above assumptions are unm
 
 #### Contract factory methods
 
-To act like an EVM smart contract factory, the EAM offers two Filecoin methods `Create` (method number 2) and `Create2` (method number 3), equivalent to their Ethereum counterparts.
+To act like an EVM smart contract factory, the EAM offers three Filecoin methods:
 
-The `Create` method is to be used in two cases:
+1. `Create` (method number 2).
+2. `Create2` (method number 3).
+3. `CreateExternal` (method number 4).
 
-1. When an Ethereum Account deploys an EVM smart contract by submitting a native Ethereum message to Filecoin.
-2. When a smart contract (running within the EVM runtime actor) calls the `CREATE` opcode.
+All these methods create new EVM actors but have slightly different semantics, parameters, and permissions.
 
-The `Create2` method is only used when a smart contract running within the EVM runtime actor calls the `CREATE2` opcode.
+In general:
 
-In Ethereum, `CREATE` and `CREATE2` differ in their Ethereum address generation rules:
-
-- `CREATE` computes the address in this manner: `Keccak-256(rlp_list(sender, nonce))`. It is thus non-deterministic.
-- `CREATE2` computes the address in this manner: `Keccak-256(rlp_list(0xff, sender, salt, bytecode))`. It is suitable for counterfactual deployments.
-
-The Filecoin EAM `Create` and `Create2` methods match these heuristics to calculate Ethereum addresses (castable to `f410` Filecoin addresses).
-The sender's Ethereum address is obtained by calling the `actor::lookup_delegated_address` syscall introduced in [FIP-0054], and extracting the Ethereum address from the `f410` address.
-If the caller has no `f410` address, the EAM falls back to the masked ID address form defined in [FIP-0054].
-
-_General mechanics_
-
-EVM smart contracts are deployed to the Filecoin chain as follows:
-
-1. The contract deployment message is directed to the `Create` or `Create2` methods of the EAM, containing the EVM init bytecode and further arguments (see below).
-2. The EAM computes the would-be Ethereum address, respecting the original Ethereum semantics, thus retaining tool compatibility.
-2. The EAM invokes the Init actor's `Exec4` method (see [FIP-0048]), supplying:
+1. The contract deployment message is directed to one of the `Create`, `Create2`, or `CreateExternal` methods of the EAM, containing the EVM init bytecode and further arguments (see below).
+2. The EAM determines the caller's Ethereum address by:
+    1. First attempting to extract it from the caller's `f4` address.
+    2. Otherwise, the EAM creates an "embedded ID address" from the caller's ID.
+3. The EAM computes the would-be Ethereum address, respecting the original Ethereum semantics where applicable, thus retaining tool compatibility.
+4. The EAM exits with `USR_FORBIDDEN` if said address is a reserved precompile address or an embedded ID address:
+    1. Is in the range `0x00-0xff`.
+    2. Is in the range `0xfe000...000-0xfe000...0ff`.
+    2. Is in the range `0xff000...00000000000000000-0xff000-0ffffffffffffffff`.
+5. If an EVM contract has already been deployed to the target address, the EAM attempts to resurrect the contract.
+    1. It calls the `Resurrect` method (see [FIP-0055]) with the given initcode and the caller's address.
+    2. If successful, the EAM returns the actor's ID and Ethereum address (see `Return` below).
+    3. Otherwise, the EAM propagates the exit code from `Resurrect`.
+6. Otherwise, the EAM invokes the Init actor's `Exec4` method (see [FIP-0048]), supplying:
       - The CodeCID of the EVM runtime actor (introduced in [FIP-0054]).
       - The EVM runtime actor's constructor parameters, concretely the EVM init code and the address of the original creator.
       - The computed Ethereum address, which the Init actor uses as the subaddress to form the `f410` address for binding it in its address registry.
+5. The EAM returns the new actor's ID, f2 address, and the Ethereum address (see `Return` below).
 
-_`Create` Input parameters_
+
+```rust
+// DAG-CBOR tuple encoded.
+pub struct Return {
+    /// The ID of the EVM runtime actor that was constructed.
+    pub actor_id: ActorID,
+    /// Its f2 address.
+    pub robust_address: Option<Address>,
+    /// Its Ethereum address, translatable to an `f410` address.
+    pub eth_address: [u8; 20],
+}
+```
+
+##### Create
+
+The `Create` method may only be called by the EVM's `CREATE` opcode. It's called with:
 
 ```rust
 // DAG-CBOR tuple encoded.
@@ -218,38 +233,39 @@ pub struct CreateParams {
 }
 ```
 
-Note that this method differs from Ethereum in that we take a user-provided nonce as a parameter.
-This is necessary for the EAM to learn the nonce of a contract, when the `CREATE` opcode is used.
-Technically, this allows an Ethereum account to deploy a contract with an arbitrary nonce, potentially using nonces in a non-contiguous manner, but this is not deemed risky because the system guarantees no overwrites can happen.
+After verifying that the caller is an EVM contract, the `Create` method computes the address as the last 20 bytes of
+`Keccak-256(rlp_list(caller_eth_address, nonce))` then follows the general contract deployment logic specified above.
 
-_`Create2` Input parameters_
+Note that this method differs from Ethereum in that we take a user-provided nonce as a parameter. This is necessary for the EAM to learn the nonce of a contract, when the `CREATE` opcode is used and is secure because:
+
+1. This method may only be invoked by the EVM runtime (the caller must be an EVM contract, and the `call_actor` precompile (see [FIP-0055]) cannot invoke methods < 1024.
+2. The system itself prevents deploying over existing actors.
+
+##### Create2
+
+The `Create2` method may only be called by the EVM's `CREATE2` opcode. It's called with:
 
 ```rust
-pub struct Create2Params {
+// DAG-CBOR tuple encoded.
+pub struct CreateParams {
     /// EVM init code.
     pub initcode: Vec<u8>,
-    /// User provided salt.
+    /// Salt from which to derive the new contract's address.
     pub salt: [u8; 32],
 }
 ```
 
-_Return value from both `Create` and `Create2`_
+After verifying that the caller is an EVM contract, the `Create2` method computes the address as the last 20 bytes of
+`Keccak-256(concat([0xff], caller_eth_addr, salt, Keccak-256(initcode)))` then follows the general contract deployment logic specified above.
 
-```rust
-// DAG-CBOR tuple encoded.
-pub struct Return {
-    /// The ID of the EVM runtime actor that was constructed.
-    pub actor_id: ActorID,
-    /// Its f2 address.
-    pub robust_address: Address,
-    /// Its Ethereum address, translatable to an `f410` address.
-    pub eth_address: [u8; 20],
-}
-```
+##### CreateExternal
 
-_Errors_
+The `CreateExternal` method may only be called by externally owned accounts (currently EthAccount and native Accounts).
 
-- `USR_FORBIDDEN` (18) when the caller has an f4 address but it's not under namespace `10`.
+`CreateExternal` computes the address according to the same logic as `Create` with two key differences:
+
+1. The `nonce` comes from the top-level message, not the method parameters.
+2. If the caller is a native account, the new contract's address is not derived from the caller's Ethereum address as the caller's Ethereum address will be an embedded ID address, which isn't reorg stable. Instead, the `caller_eth_addr` input to the `Create` address computation logic is set to the last 20 bytes of `Keccak-256(caller_key_addr)`.
 
 ### Delegated signature type
 

--- a/FIPS/fip-0055.md
+++ b/FIPS/fip-0055.md
@@ -39,7 +39,7 @@ replaces: N/A
     - [Actor interface](#actor-interface)
     - [State](#state-1)
 - [Design Rationale](#design-rationale)
-  - [Upgrade path towards [Account Abstraction] (AA)](#upgrade-path-towards-account-abstraction-aa)
+  - [Upgrade path towards Account Abstraction (AA)](#upgrade-path-towards-account-abstraction-aa)
 - [Backwards Compatibility](#backwards-compatibility)
 - [Test Cases](#test-cases)
 - [Security Considerations](#security-considerations)
@@ -195,7 +195,7 @@ In general:
 4. The EAM exits with `USR_FORBIDDEN` if said address is a reserved precompile address or an embedded ID address:
     1. Is in the range `0x00-0xff`.
     2. Is in the range `0xfe000...000-0xfe000...0ff`.
-    2. Is in the range `0xff000...00000000000000000-0xff000-0ffffffffffffffff`.
+    3. Is in the range `0xff000...00000000000000000-0xff000-0ffffffffffffffff`.
 5. If an EVM contract has already been deployed to the target address, the EAM attempts to resurrect the contract.
     1. It calls the `Resurrect` method (see [FIP-0055]) with the given initcode and the caller's address.
     2. If successful, the EAM returns the actor's ID and Ethereum address (see `Return` below).
@@ -204,7 +204,7 @@ In general:
       - The CodeCID of the EVM runtime actor (introduced in [FIP-0054]).
       - The EVM runtime actor's constructor parameters, concretely the EVM init code and the address of the original creator.
       - The computed Ethereum address, which the Init actor uses as the subaddress to form the `f410` address for binding it in its address registry.
-5. The EAM returns the new actor's ID, f2 address, and the Ethereum address (see `Return` below).
+7. The EAM returns the new actor's ID, f2 address, and the Ethereum address (see `Return` below).
 
 
 ```rust
@@ -348,7 +348,7 @@ This actor has no state. The actor's `Head` field in the state tree is the `EMPT
 
 ## Design Rationale
 
-### Upgrade path towards [Account Abstraction] (AA)
+### Upgrade path towards Account Abstraction (AA)
 
 We prototyped [Account Abstraction] solutions extensively before submitting this FIP.
 This FIP preserves the key extension points that will facilitate a (projected) elegant transition to fully-fledged [Account Abstraction] (AA).


### PR DESCRIPTION
We've:

1. Added a `CreateExternal` method.
2. Tweaked the logic for `Create` and `Create2` (mostly just adding restrictions).
3. Introduced the ability to "resurrect" EVM contracts.

I also re-organized this to make it easier to describe these as separate methods, but it should contain all the same information.