### PR TITLE
Create frc for Filecoin storage deals 

### DIFF
--- a/FRCs/frc-0056.md
+++ b/FRCs/frc-0056.md
@@ -1,0 +1,93 @@
+---
+fip: "0056"
+title: Filecoin Storage Deals Proposal Protocol Updates
+author: torfinn(github handle), brendalee
+status: Draft
+type: FRC
+created: 2023-01-12
+dependency: none
+---
+
+## Simple Summary
+
+### Storage Deal Protocol v1.2.1 Release FRC
+We're happy to announce Storage Deal Protocol v1.2.1, a minor release which adds improved configurability to Indexer announcements, and unsealed copy storage. We would like to request community comment.
+
+
+This release includes improved functionality, but does not disrupt present default Storage Deal Protocol behaviors. No bug fixes are addressed in this release, so while upgrading is encouraged, it is not immediately required. Please update at your earliest convenience.
+
+
+## Abstract
+
+-Adding a flag to enable storage clients to elect to not announce deal data to IPNI(InterPlanetary Network Indexer)
+
+
+-Adding a flag to enable storage clients to elect to not have an unsealed copy of their data stored.
+
+
+
+## Change Motivation
+
+As the Filecoin network continues to grow, there are different clients and storage providers handling a variety of data storage use cases which require more flexibility. Storage clients may have specific requirements around discoverability of content, and storage providers may want to only store sealed data. 
+
+Currently by default, storage providers announce their content to the IPNI (Interplanetary Network Indexer), and also store unsealed copies of data. This change would give them the option to do otherwise. 
+
+## Specification
+
+### :file_folder: **Storing unsealed copies:** default is to store the unsealed copy ###
+
+
+The Propose Storage Deal libp2p protocol is updated: two optional boolean fields are introduced to enable more options at the deal proposal stage
+
+### :satellite: **Announce to Indexer behavior:** ###
+
+
+#### When a deal is made: ####
+
+
+**If**
+
+
+   'SkipIPNIAnnounce = False'
+
+
+**OR** No setting is made at all: An announcement is sent to **IPNI**
+
+
+**DEFAULT** behavior is to announce to the indexer just as it is today.
+
+
+**If**
+
+
+   'SkipIPNIAnnounce = True'
+
+
+Deal will **NOT** be announced to the indexer.
+
+
+## **Backwards Compatibility**
+
+This release includes improved functionality, but does not change the existing default Storage Deal Protocol behavior. By default, deals will be announced to IPNI, and a copy of unsealed data will be kept.
+
+## **Security Considerations**
+
+No changes to underlying proofs or security.
+
+## **Incentive Considerations**
+
+No change to incentives.
+
+## **Product Considerations**
+
+We are updating the storage deal proposal libp2p protocol; two optional boolean fields are introduced to enable more options at the deal proposal stage. 
+
+## **Implementation**
+
+<link to the new propose storage deal protocol>
+
+## **Copyright**
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+

--- a/FRCs/frc-0056.md
+++ b/FRCs/frc-0056.md
@@ -39,6 +39,30 @@ Currently by default, storage providers announce their content to the IPNI (Inte
 
 The Propose Storage Deal libp2p protocol is updated: two optional boolean fields are introduced to enable more options at the deal proposal stage
 
+### :file_folder: **Storing unsealed copies:** default is to store the unsealed copy ###
+#### When a deal is made: ####
+
+
+**If**
+
+
+   'RemoveUnsealedCopy = False'
+
+
+**OR** No setting is made at all: An unsealed copy of the data is stored.
+
+
+**DEFAULT** behavior is to keep an unsealed copy of the data just as it is today.
+
+
+**If**
+
+
+   'RemoveUnsealedCopy = True'
+
+
+An unsealed copy of the data will **NOT** be stored.
+
 ### :satellite: **Announce to Indexer behavior:** ###
 
 

--- a/FRCs/frc-0056.md
+++ b/FRCs/frc-0056.md
@@ -11,10 +11,10 @@ dependency: none
 ## Simple Summary
 
 ### Storage Deal Protocol v1.2.1 Release FRC
-We're happy to announce Storage Deal Protocol v1.2.1, a minor release which adds improved configurability to Indexer announcements, and unsealed copy storage. We would like to request community comment.
+We're releasing Storage Deal Protocol v1.2.1, a minor release which adds improved configurability to Indexer announcements, and unsealed copy storage. We would like to request community comment.
 
 
-This release includes improved functionality, but does not disrupt present default Storage Deal Protocol behaviors. No bug fixes are addressed in this release, so while upgrading is encouraged, it is not immediately required. Please update at your earliest convenience.
+This release includes improved functionality, but does not disrupt present default Storage Deal Protocol behaviors. No bug fixes are addressed in this release, so while upgrading is encouraged, it is not immediately required.
 
 
 ## Abstract

--- a/FRCs/frc-0056.md
+++ b/FRCs/frc-0056.md
@@ -100,6 +100,7 @@ Deal will **NOT** be announced to the indexer.
 	   SkipIPNIAnnounce   bool
    }
 
+[Link to Datastructure](https://github.com/filecoin-project/boost/blob/5f6d9e45fec69735dbdbf5c8f3d3510c26bb0a39/storagemarket/types/types.go#L80-L88)
 
 ## **Backwards Compatibility**
 

--- a/FRCs/frc-0056.md
+++ b/FRCs/frc-0056.md
@@ -84,7 +84,7 @@ We are updating the storage deal proposal libp2p protocol; two optional boolean 
 
 ## **Implementation**
 
-<link to the new propose storage deal protocol>
+[Link to Client flags to not announce deals Boost PR #1051](https://github.com/filecoin-project/boost/pull/1051#top)
 
 ## **Copyright**
 

--- a/FRCs/frc-0056.md
+++ b/FRCs/frc-0056.md
@@ -1,7 +1,7 @@
 ---
 fip: "0056"
 title: Filecoin Storage Deals Proposal Protocol Updates
-author: torfinn(github handle), brendalee
+author: torfinnolsen, brendalee
 status: Draft
 type: FRC
 created: 2023-01-12

--- a/FRCs/frc-0056.md
+++ b/FRCs/frc-0056.md
@@ -1,5 +1,5 @@
 ---
-fip: "0056"
+fip: ""
 title: Filecoin Storage Deals Proposal Protocol Updates
 author: torfinnolsen, brendalee
 status: Draft

--- a/FRCs/frc-0056.md
+++ b/FRCs/frc-0056.md
@@ -88,6 +88,18 @@ An unsealed copy of the data will **NOT** be stored.
 
 Deal will **NOT** be announced to the indexer.
 
+## **Protocol Message**
+
+   type DealParams struct {
+	   DealUUID           uuid.UUID
+	   IsOffline          bool
+	   ClientDealProposal market.ClientDealProposal
+	   DealDataRoot       cid.Cid
+	   Transfer           Transfer // Transfer params will be the zero value if this is an offline deal
+	   RemoveUnsealedCopy bool
+	   SkipIPNIAnnounce   bool
+   }
+
 
 ## **Backwards Compatibility**
 

--- a/FRCs/frc-0056.md
+++ b/FRCs/frc-0056.md
@@ -34,7 +34,6 @@ Currently by default, storage providers announce their content to the IPNI (Inte
 
 ## Specification
 
-### :file_folder: **Storing unsealed copies:** default is to store the unsealed copy ###
 
 
 The Propose Storage Deal libp2p protocol is updated: two optional boolean fields are introduced to enable more options at the deal proposal stage


### PR DESCRIPTION
Configurability switches for Index announcement and storage of unsealed copies being added to boost available for comment.

Default behaviors not being changed!