### PR TITLE
Revisions to FRC-0053

### DIFF
--- a/FRCs/frc-0053.md
+++ b/FRCs/frc-0053.md
@@ -56,148 +56,169 @@ An actor implementing a FRC-00XX token must provide the following methods.
 type TokenID = u64;
 
 /// Multiple token IDs are represented as a BitField encoded with RLE+, the index of each set bit
-/// corresponds to a TokenID
-type TokenList = BitField;
+/// corresponds to a TokenID.
+type TokenSet = BitField;
 
-/// Multiple Actor IDs are represented as a BitField encoded with RLE+, the index of each set bit
-/// corresponds to an f0 address expressed as an ActorID
-type ActorList = BitField;
-
-/// A descriptive name for the collection of NFTs in this actor
+/// A descriptive name for the collection of NFTs in this actor.
 fn Name() -> String
 
-/// An abbreviated (ticker) name for the NFT collection
+/// An abbreviated (ticker) name for the NFT collection.
 fn Symbol() -> String
 
-/// Returns the total number of tokens in this collection
-/// Must be non-negative
-/// Must equal the balance of all adresses
-/// Should equal the sum of all minted tokens less tokens burnt
+/// Returns the total number of tokens in this collection.
+/// Must be non-negative.
+/// Must equal the balance of all adresses.
+/// Should equal the sum of all minted tokens less tokens burnt.
 fn TotalSupply() -> u64
 
-/// Returns a URI that resolves to the metadata for a particular token
+/// Returns a URI that resolves to the metadata for a particular token.
 fn MetadataID(tokenID: TokenID) -> String
 
-/// Returns the balance of an address which is the number of unique NFTs held
-/// Must be non-negative
-fn BalanceOf(owner: Address) -> u64
+/// Returns the balance of an address which is the number of unique NFTs held.
+/// Must be non-negative.
+fn Balance(owner: Address) -> u64
 
-/// Returns a parallel list of f0 ID-addresses that own the specified tokens
-fn OwnerOf(tokenIDs: TokenList) -> Vec<ActorID>
+/// Returns a parallel list of actor IDs that own a list of tokens.
+fn Owner(tokenIDs: TokenSet) -> Vec<ActorID>
 
-/// Transfers tokens from caller to the specified address
-/// Each token specified must exist and be owned by the caller
-/// The entire batch of transfers aborts if any of the specified tokens does not meet the criteria
-/// Transferring to the caller must be treated as a normal transfer
-/// Returns the resulting balances for the from and to addresses
-/// The operatorData is passed through to the receiver hook directly
-///
-/// Tokens that were successfully transferred are returned along with the new balances of the sending and receiving addresses
-fn Transfer({to: Address, tokenIDs: TokenList, operatorData: Bytes})
+/// Transfers tokens from caller to the specified address.
+/// Each token specified must exist and be owned by the caller.
+/// The entire batch of transfers aborts if any of the specified tokens does not meet the criteria.
+/// Transferring to the caller must be treated as a normal transfer.
+/// Transferring a token also revokes any operators from the token.
+/// The operatorData is passed through to the receiver hook directly.
+/// Returns the resulting balances for the from and to addresses.
+fn Transfer({to: Address, tokenIDs: TokenSet, operatorData: Bytes})
   -> {fromBalance: u64, toBalance: u64}
 
-/// Transfers tokens to the specified address with the caller acting as an operator
-/// Each token specified must exist and the caller must be authorised to transfer it. The caller is considered authorised by being an approved operator on the token-id or by being an approved operator on the account that owns the token.
-/// The entire batch of transfers aborts if any of the specified tokens does not meet the above criteria
-/// Transferring to the owner must be treated as a normal transfer
-/// Returns the resulting balance for the to address
+/// Transfers tokens to the specified address with the caller acting as an operator.
+/// Each token specified must exist and the caller must be approved to transfer it. 
+/// The caller is considered approved by being an operator for the token-id or 
+/// by being an account-level operator for the address that owns the token.
+/// The entire batch of transfers aborts if any of the specified tokens does not meet the criteria.
+/// Transferring to the owner must be treated as a normal transfer.
+/// Transferring a token also revokes any operators from the token.
+/// Returns the resulting balances for the from and to addresses.
 /// The operatorData is passed through to the receiver hook directly
-///
-/// Returns tokens that were successfully transferred are returned along with the new balance of the receiving address
-fn TransferFrom({to: Address, from: Address, tokenIDs: TokenList, operatorData: Bytes})
-  -> {toBalance: u64}
+fn TransferFrom({from: Address, to: Address, tokenIDs: TokenSet, operatorData: Bytes})
+  -> {fromBalance: u64, toBalance: u64}
 
-/// Authorizes an address as the specified operator for a set of tokens
-/// The caller must own all the specified tokens, or be an account-level operator for every token specified. If not, the entire batch will fail to be approved.
-fn Approve({operator: Address, tokenIDs: TokenList}) -> ()
+/// Approves an address as an operator for a set of tokens.
+/// For all tokens specified, the caller must either own the token or be an account-level operator
+/// for some other (unspecified) owner.
+/// If not, the entire batch will fail to be approved.
+fn Approve({operator: Address, tokenIDs: TokenSet}) -> ()
 
-/// Revokes an address as an authorized operator for a set of tokens
-/// The caller must own all the specified tokens, or be an account-level operator for every token specified. If not, the entire batch will fail to be revoked. If the specified operator is not currently an approved operator for some tokens in the list, the method can still succeed but will be a no-op on those tokens.
-fn RevokeApproval({operator: Address, tokenIDs: TokenList}) -> ()
+/// Revokes an address as an operator for a set of tokens.
+/// For all tokens specified, the caller must either own the token or be an account-level operator
+/// for some other (unspecified) owner.
+/// If not, the entire batch will fail to be revoked. 
+/// If the specified operator is not currently an operator for any tokens in the list,
+/// the method must still succeed but have no effect on those tokens.
+fn RevokeApproval({operator: Address, tokenIDs: TokenSet}) -> ()
 
-/// Returns whether an address is an approved operator for a particular set of tokens
-/// The owner of a token is not implicitly considered as a valid operator of that token
-/// The return value is encoded as a bitfield with the marked bits corresponding to the indices of approved tokens if tokenIDs were interpreted as a vector of TokenIDs
-fn IsApprovedFor({operator: Address, tokenIDs: TokenList}) -> BitField
+/// Returns whether an address is an operator for a particular set of tokens.
+/// The owner of a token is not implicitly considered as a valid operator of that token.
+/// The return value is a subset of the provided token set containing only those token IDs
+/// for which the address is an operator. 
+fn IsApproved({operator: Address, tokenIDs: TokenSet}) -> TokenSet
 
-/// Authorizes the specified address as an operator for any token (including future tokens) that are owned by the caller's address
+/// Sets an address as an account-level operator for any token (including future tokens)
+/// that are owned by the caller.
+/// This does not replace any token-level approvals prior or subsequent.
 fn ApproveForAll({operator: Address}) -> ()
 
-/// Returns whether an address is an authorized operator for another address
-/// Addresses are not reflexive operators on themselves
-fn IsApprovedForAll({operator: Address, owner: Address}) -> bool
+/// Returns whether an address is an account-level operator for another address.
+/// Addresses are not reflexive operators for themselves.
+fn IsApprovedForAll({owner: Address, operator: Address}) -> bool
 
-/// Revokes an address as an authorized operator for the calling address
+/// Revokes an address as an account-level operator for the caller.
+/// Note that the operator may still be an operator for specific tokens owned by the caller.
 fn RevokeApprovalForAll({operator: Address}) -> ()
 
-/// Burns the specified tokens where the caller is the owner
-/// The entire burn operation aborts if any of the tokens is not owned by the caller
+/// Burns tokens owned by the caller.
+/// Aborts if any of the tokens is not owned by the caller.
 ///
-/// Returns the resulting balance of the caller's address
-fn Burn({tokenIDs: TokenList}) -> u64;
+/// Returns the caller's resulting balance.
+fn Burn({tokenIDs: TokenSet}) -> u64;
 
-/// Burns the specified tokens where the caller is an approved operator
-/// The entire burn operation aborts if the caller is not an approved operator on any of the tokens
-fn BurnFrom({from: Address, tokenIDs: TokenList}) -> ();
+/// Burns tokens where the caller is an operator for the owner.
+/// Aborts if the caller is not an operator for any of the tokens.
+fn BurnFrom({from: Address, tokenIDs: TokenSet}) -> ();
 ```
 
 **Optional Extension - Enumerable TokenIDs**
-
-An actor may choose to implement a method to retrieve the list of all
-circulating NFTs.
+An actor may choose to implement a method to retrieve the list of all circulating tokens.
 
 ```rust
-/// Enumerates some number of circulating Token IDs
-/// The method must return all the IDs for tokens in circulation in the range [rangeStart, next)
-/// The method must return next = 0 if the entire range of TokenIDs has been exhausted
-fn ListTokens(rangeStart: TokenID) -> {tokens: TokenList, next: TokenID}
+/// Enumerates some number of circulating (i.e. non-burnt) Token IDs.
+/// Returns the IDs of up to `max` tokens in circulation with ID >= `rangeStart`.
+/// Must return all token IDs in the range from `rangeStart` up to the highest ID returned 
+/// (i.e. mustn't skip tokens). 
+/// May return fewer than `max`, including zero, tokens even if more remain.
+/// Must return `next > rangeStart`, or else `next` = 0 if there are no token IDs
+/// less than or equal to the largest ID returned (or `rangeStart` if none were returned).
+fn ListTokens(rangeStart: TokenID, max: u64) -> {tokens: TokenSet, next: TokenID}
 ```
 
-When listing NFTs the actor must return the next `count` number of TokenIDs in
-ascending order if exist. The returned IDs should start from and include
-`tokenRangeStart` if it exists or the next lowest Token ID if it does not. When
-a TokenList is returned with less than `count` IDs specified, the caller can
-assume there are no more IDs to enumerate.
+When listing NFTs the actor must return the next TokenIDs in ascending order if they exist
+(i.e. have been minted and not burned).
+The returned IDs should start from and include `rangeStart` if it exists,
+or the next lowest Token ID if it does not. 
+
+**Optional Extension - Enumerable Balances**
+An actor may choose to implement a method to retrieve the list of all tokens owned by an address.
+
+```rust
+/// Enumerates some number of tokens owned by an address.
+/// Returns the IDs of up to `max` tokens with ID >= `rangeStart`, owned by `owner`.
+/// See ListTokens for detailed semantics.
+fn ListOwnedTokens(owner: Address, rangeStart: TokenID, max: u64) 
+  -> {tokens: TokenSet, next: TokenID}
+```
 
 **Optional Extension - Enumerable Operators**
 
-An actor may choose to implement any number of the following methods to support
-enumeration of operators.
+An actor may choose to implement the following methods to support enumeration of operators.
 
 ```rust
-/// Returns all the token-level operators that are currently approved
-fn TokenOperatorsFor(tokenID: TokenID) -> ActorList
+/// Returns all the operators approved by an owner for a token.
+fn OperatorsForToken(owner: Address, tokenID: TokenID) -> [ActorID]
 
-/// Returns all the account-level operators that are currently approved
-fn AccountOperatorsFor(actorID: ActorID) -> ActorList
+/// Enumerates tokens for which an account is an operator for an owner.
+fn TokensForOperator(owner: Address, operator: Address, rangeStart: TokenID, max: u64)
+  -> {tokens: TokenSet, next: TokenID}
+
+/// Returns all the account-level operators approved by an owner.
+fn AccountOperators(owner: Address) -> [ActorID]
 ```
 
 ### Receiver Interface
 
 An actor must implement a receiver hook to receive NFTs. The receiver hook is
 defined in FRC-0046 and must not abort when handling an incoming token. When
-transferring batch of tokens, the receiver hook is invoked once meaning the
+transferring batch of tokens, the receiver hook is invoked just once, meaning the
 entire set of NFTs is either accepted or rejected (by aborting).
 
 ```rust
-/// Type of the payload accompanying the receiver hook for a FRCXX NFT.
-struct FRCXXTokensReceived {
-    // The tokens being transferred
-    tokenIDs: TokenList,
-    // The address to which tokens were credited (which will match the hook receiver)
-    to: Address,
+/// Type of the payload accompanying the receiver hook for a FRC-0053 NFT.
+struct FRC53TokensReceived {
     // The address from which tokens were debited
     from: Address,
+    // The address to which tokens were credited (which will match the hook receiver)
+    to: Address,
     // The actor which initiated the mint or transfer
     operator: Address,
+    // The tokens being transferred
+    tokenIDs: TokenSet,
     // Arbitrary data provided by the operator when initiating the transfer
     operatorData: Bytes,
     // Arbitrary data provided by the token actor
     tokenData: Bytes,
 }
 
-/// Receiver hook type value for an FRC-00XX token
-const FRCXXTokenType = frc42_hash("FRCXX")
+/// Receiver hook type value for an FRC-0053 token
+const FRC53TokenType = frc42_hash("FRC53")
 
 // Invoked by a NFT actor after transfer of tokens to the receiver’s address.
 // The NFT collection state must be persisted such that the receiver will observe the new balances.
@@ -210,8 +231,8 @@ fn Receive({type: uint32, payload: byte[]})
 **Universal receiver hook**
 
 The NFT collection must invoke the receiver hook method on the receiving address
-whenever it credits tokens. The `type` parameter must be `FRCXXTokenType` and
-the payload must be the IPLD-CBOR serialized `FRCXXTokensReceived` structure.
+whenever it credits tokens. The `type` parameter must be `FRC53TokenType` and
+the payload must be the IPLD-CBOR serialized `FRC53TokensReceived` structure.
 
 The attempted credit is only persisted if the receiver hook is implemented and
 does not abort. A mint or transfer operation should abort if the receiver hook
@@ -237,7 +258,7 @@ Operators can be approved at two separate levels.
 _Token level operators_ are approved by the owner of the token via the `Approve`
 method. If an account is an operator on a token, it is permitted to debit (burn
 or transfer) that token. An NFT can have many operators at a time, but
-transferring the token will revoke approval on all its existing operators.
+transferring the token will revoke approval of all its existing operators.
 
 _Account level operators_ are approved via the `ApproveForAll` method. If an
 owner approves an operator at the account level, that operator has permission to
@@ -259,9 +280,9 @@ case they should automatically become functional for this standard.
 
 **Extensions**
 
-An NFT collection may implement other methods for transferring tokens and
-managing operators. These must maintain the invariants about supply and
-balances, and invoke the receiver hook when crediting tokens.
+An NFT collection may implement other methods for transferring tokens and managing operators.
+These must maintain the invariants about supply and balances,
+and invoke the receiver hook when crediting tokens.
 
 An NFT collection may implement restrictions on allowances and transfer of
 tokens.
@@ -270,7 +291,7 @@ tokens.
 
 ### Batching
 
-Methods on this interface accept a list of `TokenID`s. When a list of IDs is
+Some methods on this interface accept a set of `TokenID`s. When a list of IDs is
 specified, the method must succeed or fail atomically. This simplifies retry
 logic for actors when methods fail and encourages further inspection of the
 intended parameters when human errors may have been made.
@@ -283,7 +304,7 @@ supply and operators. For the same safety reasons described in FRC-0046, this
 token standard requires a universal receiver on actors that wish to hold tokens.
 
 This allows easier interactions between fungible tokens and NFTs and opens
-possibilities for composition of the the two standards to represent different
+possibilities for composition of the two standards to represent different
 structures of ownership such as fractionalized NFTs or semi-fungible tokens.
 Instead of encoding such semantics directly into the standard, a minimal
 interface is proposed instead to make the primary simple use cases more
@@ -311,12 +332,12 @@ resolved to the metadata.
 
 ## Backwards Compatability
 
-There are no implementatons of NFT collections yet on Filecoin.
+There are no implementations of NFT collections yet on Filecoin.
 
 ## Test Cases
 
 Extensive test cases are present in the implementation of this proposal at
-https://github.com/helix-onchain/filecoin/tree/main/frcxx_nft.
+https://github.com/helix-onchain/filecoin/tree/main/frc53_nft.
 
 ## Security Considerations
 
@@ -340,7 +361,7 @@ N/A
 ## Implementation
 
 An implementation of this standard is in development at
-https://github.com/helix-onchain/filecoin/tree/main/frcxx_nft.
+https://github.com/helix-onchain/filecoin/tree/main/frc53_nft.
 
 ## Copyright
 

--- a/FRCs/frc-0053.md
+++ b/FRCs/frc-0053.md
@@ -151,20 +151,26 @@ fn BurnFrom({from: Address, tokenIDs: TokenSet}) -> ();
 An actor may choose to implement a method to retrieve the list of all circulating tokens.
 
 ```rust
-/// Enumerates some number of circulating (i.e. non-burnt) Token IDs.
-/// Returns the IDs of up to `max` tokens in circulation with ID >= `rangeStart`.
-/// Must return all token IDs in the range from `rangeStart` up to the highest ID returned 
-/// (i.e. mustn't skip tokens). 
+/// Enumerates some number, up to `max`, of circulating (i.e. non-burnt) Token IDs.
 /// May return fewer than `max`, including zero, tokens even if more remain.
-/// Must return `next > rangeStart`, or else `next` = 0 if there are no token IDs
-/// less than or equal to the largest ID returned (or `rangeStart` if none were returned).
-fn ListTokens(rangeStart: TokenID, max: u64) -> {tokens: TokenSet, next: TokenID}
+/// The cursor is an opaque pagination token.
+/// An empty byte array requests enumeration of all tokens (up to `max`).
+/// If more tokens remain, a next cursor must be returned, and must differ from the provided one.
+/// This cursor may be passed to a subsequent call to
+/// continue enumeration from where the previous call left off.
+/// A sequence of calls, each passing the cursor provided by the previous one,
+/// must enumerate all tokens.
+/// Tokens need not be enumerated in ID order.
+///
+/// A cursor is valid only while the token state remains unchanged.
+/// Implementations should abort if provided a stale cursor.
+fn ListTokens(cursor: byte[], max: u64) -> {tokens: TokenSet, next_cursor: Option<byte[]>}
 ```
 
 When listing NFTs the actor must return the next TokenIDs in ascending order if they exist
 (i.e. have been minted and not burned).
 The returned IDs should start from and include `rangeStart` if it exists,
-or the next lowest Token ID if it does not. 
+or the next lowest Token ID if it does not.
 
 **Optional Extension - Enumerable Balances**
 An actor may choose to implement a method to retrieve the list of all tokens owned by an address.
@@ -183,14 +189,14 @@ An actor may choose to implement the following methods to support enumeration of
 
 ```rust
 /// Returns all the operators approved by an owner for a token.
-fn OperatorsForToken(owner: Address, tokenID: TokenID) -> [ActorID]
+fn ListTokenOperators(owner: Address, tokenID: TokenID) -> [ActorID]
 
 /// Enumerates tokens for which an account is an operator for an owner.
-fn TokensForOperator(owner: Address, operator: Address, rangeStart: TokenID, max: u64)
-  -> {tokens: TokenSet, next: TokenID}
+fn ListOperatorTokens(owner: Address, operator: Address, cursor: byte[], max: u64)
+  -> {tokens: TokenSet, next_cursor: Option<byte[]>}
 
 /// Returns all the account-level operators approved by an owner.
-fn AccountOperators(owner: Address) -> [ActorID]
+fn ListAccountOperators(owner: Address) -> [ActorID]
 ```
 
 ### Receiver Interface

--- a/FRCs/frc-0053.md
+++ b/FRCs/frc-0053.md
@@ -55,9 +55,10 @@ An actor implementing a FRC-00XX token must provide the following methods.
 ```rust
 type TokenID = u64;
 
-/// Multiple token IDs are represented as a BitField encoded with RLE+, the index of each set bit
-/// corresponds to a TokenID.
+/// Multiple token or actor IDs are represented as a BitField encoded with RLE+, 
+/// the index of each set bit corresponds to a token or actor ID.
 type TokenSet = BitField;
+type ActorIDSet = BitField;
 
 /// A descriptive name for the collection of NFTs in this actor.
 fn Name() -> String
@@ -151,10 +152,10 @@ fn BurnFrom({from: Address, tokenIDs: TokenSet}) -> ();
 An actor may choose to implement a method to retrieve the list of all circulating tokens.
 
 ```rust
-/// Enumerates some number, up to `max`, of circulating (i.e. non-burnt) Token IDs.
-/// May return fewer than `max`, including zero, tokens even if more remain.
+/// Enumerates some number, up to `limit`, of circulating (i.e. non-burnt) Token IDs.
+/// May return fewer than `limit`, including zero, tokens even if more remain.
 /// The cursor is an opaque pagination token.
-/// An empty byte array requests enumeration of all tokens (up to `max`).
+/// An empty byte array requests enumeration of all tokens (up to `limit`).
 /// If more tokens remain, a next cursor must be returned, and must differ from the provided one.
 /// This cursor may be passed to a subsequent call to
 /// continue enumeration from where the previous call left off.
@@ -164,23 +165,17 @@ An actor may choose to implement a method to retrieve the list of all circulatin
 ///
 /// A cursor is valid only while the token state remains unchanged.
 /// Implementations should abort if provided a stale cursor.
-fn ListTokens(cursor: byte[], max: u64) -> {tokens: TokenSet, next_cursor: Option<byte[]>}
+fn ListTokens({cursor: byte[], limit: u64}) -> {tokens: TokenSet, next_cursor: Option<byte[]>}
 ```
-
-When listing NFTs the actor must return the next TokenIDs in ascending order if they exist
-(i.e. have been minted and not burned).
-The returned IDs should start from and include `rangeStart` if it exists,
-or the next lowest Token ID if it does not.
 
 **Optional Extension - Enumerable Balances**
 An actor may choose to implement a method to retrieve the list of all tokens owned by an address.
 
 ```rust
-/// Enumerates some number of tokens owned by an address.
-/// Returns the IDs of up to `max` tokens with ID >= `rangeStart`, owned by `owner`.
+/// Enumerates some number, up to `limit`, of tokens owned by an address.
 /// See ListTokens for detailed semantics.
-fn ListOwnedTokens(owner: Address, rangeStart: TokenID, max: u64) 
-  -> {tokens: TokenSet, next: TokenID}
+fn ListOwnedTokens({owner: Address, cursor: byte[], limit: u64}) 
+  -> {tokens: TokenSet, next_cursor: Option<byte[]>}
 ```
 
 **Optional Extension - Enumerable Operators**
@@ -188,15 +183,23 @@ fn ListOwnedTokens(owner: Address, rangeStart: TokenID, max: u64)
 An actor may choose to implement the following methods to support enumeration of operators.
 
 ```rust
-/// Returns all the operators approved by an owner for a token.
-fn ListTokenOperators(owner: Address, tokenID: TokenID) -> [ActorID]
+/// Returns all the operators approved by an owner for a specific token.
+/// The result does not include account-level operators unless such operators are also
+/// explicitly approved for the token.
+fn ListTokenOperators({owner: Address, tokenID: TokenID, cursor: byte[], limit: u64}) 
+    -> {operators: ActorIDSet, next_cursor: Option<byte[]>}
 
-/// Enumerates tokens for which an account is an operator for an owner.
-fn ListOperatorTokens(owner: Address, operator: Address, cursor: byte[], max: u64)
+/// Enumerates tokens for which an account is an explicit operator for an owner.
+/// For account-level operators, the result only includes tokens for which the address would
+/// be an operator even if account-level approval were revoked.
+/// (Use ListTokens to enumerate the tokens an account-level operator can control,
+/// which is all of them).
+fn ListOperatorTokens({owner: Address, operator: Address, cursor: byte[], limit: u64})
   -> {tokens: TokenSet, next_cursor: Option<byte[]>}
 
 /// Returns all the account-level operators approved by an owner.
-fn ListAccountOperators(owner: Address) -> [ActorID]
+fn ListAccountOperators({owner: Address, cursor: byte[], limit: u64})
+    -> {operators: ActorIDSet, next_cursor: Option<byte[]>}
 ```
 
 ### Receiver Interface


### PR DESCRIPTION
Apart from cosmetic changes, substantive changes are:
- Rename some methods for alignment with FRC-0046 (e.g. "BalanceOf" -> "Balance")
- Re-ordered some parameters and result structures for consistency with FRC-0046 (always: from, to, operator, tokens, data)
- Add `fromBalance` to `TransferFromReturn`, which we can provide now that transfers are limited to a single source owner
- Add `max` parameter to paginated enumeration methods
- Added optional enumeration of owned tokens
- Added option enumeration tokens for which an account is an operator

Please wait for review from @alexytsu 