### PR TITLE
FIP0055: Update based on user feedback

### DIFF
--- a/FIPS/fip-0055.md
+++ b/FIPS/fip-0055.md
@@ -332,7 +332,7 @@ Additionally, this conversion asserts that:
 
 1. The sender address is a valid `f410` address with a 20 byte payload.
 2. The recipient is either a valid `f410` address or a valid `f0` address.
-3. If the receiver is `f010` (EAM), `FilecoinMessage#Method` is `EAM#CreateExternal` (`4`). Otherwise, `FilecoinMessage#Method` is `EVM#InvokeContract` (`3844450837`).
+3. If the recipient is `f010` (EAM), `FilecoinMessage#Method` is `EAM#CreateExternal` (`4`). Otherwise, `FilecoinMessage#Method` is `EVM#InvokeContract` (`3844450837`).
 4. The message version is 0.
 5. The parameters contain no additional values or bytes beyond the CBOR encoded byte string.
 

--- a/FIPS/fip-0055.md
+++ b/FIPS/fip-0055.md
@@ -287,8 +287,7 @@ During this period, all senders of messages with `Delegated` signatures must hav
 Additionally, delegated signatures are restricted to:
 
 1. Messages to the Ethereum Address Manager (`f010`), calling its `CreateExternal` method, and carrying a non-empty, validly CBOR-encoded byte array as its parameters (with no extra bytes)
-1. `Send` messages with empty parameters
-1. Messages with `MethodNum` equal to the EVM built-in actor's `InvokeContract` number, and carrying a validly CBOR-encoded byte array as its parameters (with no extra bytes)
+2. Messages to ID addresses (`f0`) other than `f010`, and messages to `f410` addresses (`f4` addresses assigned by the EAM) with `MethodNum` equal to the EVM built-in actor's `InvokeContract` method number  (`frc42_hash("InvokeEVM")`), and carrying a validly CBOR-encoded byte array as its parameters (with no extra bytes).
 
 A message carrying a `Delegated` signature that does not meet one of these criteria is considered to have an invalid signature.
 
@@ -320,12 +319,19 @@ The top-level object is an [RLP] list, and integers are encoded in the RLP way (
 | 2     | Max priority fee gas  | `FilecoinMessage#GasPremium`, re-encoded as an RLP integer                                                                                                                |
 | 3     | Max fee per gas       | `FilecoinMessage#GasFeeCap`, re-encoded as an RLP integer                                                                                                                 |
 | 4     | Gas limit             | `FilecoinMessage#GasLimit`, re-encoded as an RLP integer                                                                                                                  |
-| 5     | Recipient             | Ethereum address extracted from the `f410` address in `FilecoinMessage#To`, or nil if `f010` (EAM), as this denotes a contract deployment, re-encoded as an RLP byte string |
+| 5     | Recipient             | Ethereum address extracted from the `f410` or `f0` address in `FilecoinMessage#To`, or nil if `f010` (EAM), as this denotes a contract deployment, re-encoded as an RLP byte string |
 | 6     | Value                 | `FilecoinMessage#Value`, re-encoded as an RLP integer                                                                                                                     |
-| 7     | Input data            | CBOR-deserialization of `FilecoinMessage#Params`, and re-encoded as an RLP byte string                                                                                                                                               |
+| 7     | Input data            | CBOR-deserialization of `FilecoinMessage#Params` as a CBOR byte string, and re-encoded as an RLP byte string                                                                                                                                               |
 | 8     | Access list           | Empty.                                                                                                                                                                   |
 
-The Input data must be empty if the `FilecoinMessage#Method` indicates a `Send`, and must be a CBOR-encoded byte array with no extra bytes otherwise. 
+Additionally, this conversion asserts that:
+
+1. The sender address is a valid `f410` address with a 20 byte payload.
+2. The recipient is either a valid `f410` address or a valid `f0` address.
+3. If the receiver is `f010` (EAM), `FilecoinMessage#Method` is `EAM#CreateExternal` (`4`). Otherwise, `FilecoinMessage#Method` is `EVM#InvokeContract` (`3844450837`).
+4. The message version is 0.
+5. The parameters contain no additional values or bytes beyond the CBOR encoded byte string.
+
 If these conditions are not met, the signature is considered invalid.
 
 #### Calculating the inverse (RLP-encoding -> FilecoinMessage)
@@ -339,15 +345,15 @@ We do so as follows:
 | Pos   | Filecoin Message Field | Source                                                                                                                                      |
 | ----- |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | 0     | Version                | 0, the only supported Message version on Filecoin as of this FIP                                                                            |
-| 1     | Recipient              | Filecoin address converted (f410 or ID address) from the `EthereumTransaction#To` field, or `f010` if nil as this denotes a contract deployment                        |
-| 2     | Sender                 | Copied from the original `FilecoinMessage#Sender`, since this field is not present in the `EthereumTransaction`                             |
+| 1     | Recipient              | Filecoin address converted (`f410` or ID address) from the `EthereumTransaction#To` field, or `f010` if nil as this denotes a contract deployment         |
+| 2     | Sender                 | The message's sender (Ethereum address) encoded as an `f410` address, extracted from the transaction's signature through EcRecover          |
 | 3     | Nonce                  | `EthereumTransaction#Nonce`                                                                                                                 |
 | 4     | Value                  | `EthereumTransaction#Value`                                                                                                                 |
 | 5     | Gas Limit              | `EthereumTransaction#GasLimit`                                                                                                              |
 | 6     | Gas Fee Cap            | `EthereumTransaction#GasFeeCap`                                                                                                             |
 | 7     | Gas Premium            | `EthereumTransaction#MaxPriorityFeeGas`                                                                                                     |
-| 8     | Method                 | `EAM::CreateExternal`, if `EthereumTransaction#To` is nil. `Send`, if `EthereumTransaction#Input` is empty. `EVM::InvokeContract` otherwise |
-| 9     | Params                 | CBOR-serialization of the byte array `EthereumTransaction#Input`, which must not be empty if `EthereumTransaction#Recipient` is nil         |
+| 8     | Method                 | `EAM::CreateExternal`, if `EthereumTransaction#To` is nil. `EVM::InvokeContract` otherwise                                                  |
+| 9     | Params                 | CBOR-serialization of the byte array `EthereumTransaction#Input`.                                                                           |
 
 ### Ethereum Account
 

--- a/FIPS/fip-0055.md
+++ b/FIPS/fip-0055.md
@@ -42,7 +42,9 @@ replaces: N/A
     - [Promotion](#promotion)
     - [Actor interface](#actor-interface)
     - [State](#state-1)
+  - [Account Changes](#account-changes)
 - [Design Rationale](#design-rationale)
+  - [Accepting v. Rejecting Calls on Accounts](#accepting-v-rejecting-calls-on-accounts)
   - [Upgrade path towards Account Abstraction (AA)](#upgrade-path-towards-account-abstraction-aa)
 - [Backwards Compatibility](#backwards-compatibility)
 - [Test Cases](#test-cases)
@@ -89,6 +91,8 @@ This FIP introduces three technical elements:
    
 3. The Delegated signature type, carrying a signature eventually verified by actor code through [Account Abstraction] (AA).
    At this time, Delegated signatures are special-cased secp256k1 ECDSA signatures over the RLP encoding of native EIP-1559 Ethereum transactions.
+
+Finally, it extends the existing Account actor (f1/f3) to align it with the Ethereum Account actor and the Placeholder actor by making it accept all methods greater than or equal to the minimum FRC-0042 method number (`2^24`).
 
 ## Change Motivation
 
@@ -384,13 +388,35 @@ Failure to meet chain inclusion gas will prevent the inclusion of the message an
 
 #### Actor interface
 
-None.
+This actor implements two methods:
+
+1. A `Constructor` that:
+    1. Takes no parameters and returns no parameters.
+    2. Asserts that the caller is the _system_ actor (not the init actor). An EthAccount can only be constructed by promoting a Placeholder on first send.
+2. `AuthenticateMessage` as specified in FIP-0044. Internally, this method:
+    1. Uses `crypto::recover_secp_public_key` to recover the public key from the signed data and the signature.
+    2. Computes the correct Ethereum address from this public key.
+    3. Compares this Ethereum address with the account's f4 address.
+
+Additionally, this actor returns success (instead of rejecting the call with an "unhandled message" error) when called with any method numbers greater than or equal to the minimum FRC-0042 method number (`2^24`).
 
 #### State
 
 This actor has no state. The actor's `Head` field in the state tree is the `EMPTY_ARR_CID` static value, defined as the CID of an empty CBOR byte string.
 
+### Account Changes
+
+The account actor is changed to do nothing and return success for all methods greater than or equal to the minimum FRC-0042 method number to match the Ethereum Account actor.
+
+
 ## Design Rationale
+
+### Accepting v. Rejecting Calls on Accounts
+
+As of this FIP, both account types now accept calls to all method numbers greater than or equal to `2^24`:
+
+1. This means all accounts become "universal acceptors" and will automatically accept any funds deposited via FRC-0042 interfaces in the future. Previously, the built-in account _explicitly_ implemented the FRC-0053 universal receiver hook, but this is no longer necessary.
+2. Method numbers less than `2^24` still _reject_ calls by default to be conservative and to mirror the private-use behavior implemented in other built-in actors. This restriction will likely be lifted or altered in the future.
 
 ### Upgrade path towards Account Abstraction (AA)
 


### PR DESCRIPTION
- Always invoke the target actor, never "demote" to a bare-value send.
- Accept all method numbers (>= 2^24) on both account types.

This PR also fleshes out some details and fixes a couple of errors.