### PR TITLE
FIP0054: clarify the behavior of the read-only flag

### DIFF
--- a/FIPS/fip-0054.md
+++ b/FIPS/fip-0054.md
@@ -1067,13 +1067,17 @@ pub fn message_context() -> Result<MessageContext>;
 #### `send::send` syscall
 
 This syscall now takes two extra fields:
-- `gas_limit` (u64), the gas limit applicable to the send (where `u64::MAX` can be safely used to mean none).
+- `gas_limit` (u64), the gas limit applicable to the send (where `u64::MAX` can be safely used to mean "no limit"). This value is always clamped to the maximum gas available.
 - `send_flags` (u64), encoding a bitmap of send flags.
 
 The possible send flags are:
 
-- `0x01`: Read-only. Nor the callee nor any of its transitive callees can cause any side effects.
-  That is, no IPLD writes are allowed, no events can be emitted, no value can be sent, and no actor deletions are possible.
+- `0x01`: Read-only. Nor the callee nor any of its transitive callees can cause any side effects: state updates, value transfers, or events. Specifically, the following calls all fail with the `ReadOnly` error number:
+  - `self::self_destruct`
+  - `self::set_root`
+  - `event::emit_event`
+  - `send::send` when transferring a non-zero balance or auto-creating the recipient.
+  - `actor::create_actor`. This causes `Init::Exec` and `Init::Exec4` to exit with `USR_READ_ONLY` (see [New general exit codes](#new-general-exit-codes)).
 
 This syscall now returns a new error number:
 


### PR DESCRIPTION
This clarifies exactly which syscalls fail when read-only and how/when.