### PR TITLE
FIP-0049: Change event structure and add limits

### DIFF
--- a/FIPS/fip-0049.md
+++ b/FIPS/fip-0049.md
@@ -111,28 +111,26 @@ struct StampedEvent {
 }
 
 /// An event as originally emitted by the actor.
-struct ActorEvent {
-    /// The key-value entries that make up the event.
-    entries: [Entry],
-}
+type ActorEvent = [Entry];
 
 struct Entry {
     /// A bitmap conveying metadata or hints about this entry.
     flags: u64,
     /// The key of this entry.
     key: String,
-    /// The value of this entry.
-    /// Any DAG-CBOR encoded type, but currently restricted to only byte strings (CBOR major type 2).
-    value: any,
+    /// The value's IPLD codec (0 is defined to mean "no value/codec".
+    codec: u64,
+    /// The value of this entry as a byte string.
+    value: Bytes,
 }
 ```
 
 Its main constituent is a list of ordered key-value **entries**. This approach
 is inspired by structured logging concepts. **Keys** are UTF-8 strings, while
-**values** can be any DAG-CBOR encodeable type.
+**values** can be any IPLD block.
 
-However, this FIP restricts the effectively accepted types for values to byte
-strings only (CBOR major type 2). A future FIP will loosen this restriction.
+However, this FIP restricts the acceptable codecs to `IPLD_RAW` (raw bytes) with the IPLD codec
+0x55. A future FIP will loosen this restriction.
 
 Every **entry** contains a **flags** bitmap with underlying type u64, conveying
 metadata or hints about the entry. These are the currently supported flags:
@@ -180,11 +178,11 @@ See FIP-0054 for more information.
 Event {
     emitter: 1234,
     entries: [
-        (0x03, "t1", <32-byte array>),  // CBOR major type 2
-        (0x03, "t2", <32-byte array>),  // CBOR major type 2
-        (0x03, "t3", <32-byte array>),  // CBOR major type 2
-        (0x03, "t4", <32-byte array>),  // CBOR major type 2
-        (0x03, "p", <32-byte array>),   // CBOR major type 2
+        (0x03, "t1", 0x55, <32-byte array>), // 0x55 = IPLD_RAW
+        (0x03, "t2", 0x55, <32-byte array>),
+        (0x03, "t3", 0x55, <32-byte array>),
+        (0x03, "t4", 0x55, <32-byte array>),
+        (0x03, "p", 0x55, <32-byte array>),
     ],
 }
 ```
@@ -198,10 +196,11 @@ _Fungible token transfer_
 Event {
     emitter: 1260,
     entries: [
-        (0x03, "type", "transfer"),     // CBOR major type 3
-        (0x03, "sender", <actor id>),   // CBOR major type 0
-        (0x03, "receiver", <actor id>), // CBOR major type 0
-        (0x00, "amount", <token amount in atto precision>),  // CBOR major type 2, BE-encoded BigInt, Not indexed.
+        (0x03, "type", 0x51, cbor_encode("transfer")), // 0x51 = CBOR
+        (0x03, "sender", 0x51, cbor_encode(<actor id>)),
+        (0x03, "receiver", 0x51, cbor_encode(<actor id>)),
+        // BE-encoded BigInt, Not indexed.
+        (0x00, "amount", 0x51, cbor_encode(<token amount in atto precision>)),
     ],
 }
 ```
@@ -215,10 +214,10 @@ _Non-fungible token transfer_
 Event {
     emitter: 101,
     entries: [
-        (0x01, "transfer", null),
-        (0x03, "sender", <actor id>),    // CBOR major type 0
-        (0x03, "receiver", <actor id>),  // CBOR major type 0
-        (0x03, "token_id", <internal identifier>), // CBOR major type 2
+        (0x01, "transfer", 0x0, []), // no codec, no value.
+        (0x03, "sender", 0x51, cbor_encode(<actor id>)),
+        (0x03, "receiver", 0x51, cbor_encode(<actor id>)),
+        (0x03, "token_id", 0x51, cbor_encode(<internal identifier>)),
     ],
 }
 ```
@@ -232,8 +231,8 @@ _Access control_
 Event {
     emitter: 480,
     entries: [
-        (0x01, "denied", null),    // CBOR major type 7, value 22 (0xf6)
-        (0x02, "id", <object id>), // CBOR major type 2
+        (0x01, "denied", 0x0, []), // no codec, no value.
+        (0x02, "id", 0x51, cbor_encode(<object id>)),
     ],
 }
 ```
@@ -248,12 +247,15 @@ Event {
     emitter: 1678,
     entries: [
         (0x03, "type", "approval"),
-        (0x03, "signer", <actor id>),  // CBOR major type 0
-        (0x03, "signer", <actor id>),  // CBOR major type 0
-        (0x03, "signer", <actor id>),  // CBOR major type 0
-        (0x00, "callee", <actor id>),  // CBOR major type 0
-        (0x00, "amount", <token amount in atto precision>),  // CBOR major type 2, BE-encoded BigInt, Not indexed.
-        (0x00, "msg_cid", <message cid>),  // CBOR major type 2
+        (0x03, "signer", 0x51, cbor_encode(<actor id>)),
+        (0x03, "signer", 0x51, cbor_encode(<actor id>)),
+        (0x03, "signer", 0x51, cbor_encode(<actor id>)),
+        // Not indexed.
+        (0x00, "callee", 0x51, cbor_encode(<actor id>)),
+        // BE-encoded BigInt, Not indexed.
+        (0x00, "amount", 0x51, cbor_encode(<token amount in atto precision>)),
+        // Not indexed.
+        (0x00, "msg_cid", 0x51, cbor_encode(<message cid>)),
     ],
 }
 ```
@@ -291,14 +293,14 @@ events accumulator.
 We expect FVM SDKs to offer utilities, macros, and sugar to construct event
 payloads and perform the syscall ergonomically.
 
-### Event validation rules
+### Event validation rules
 
 1. Validate the structural correctness of the input, optionally deserializing
    into an in-memory representation of the `ActorEvent`.
-2. Validate the correctness of entry values, by checking they are well-formed
-   DAG-CBOR and that type restrictions are met (currently, they can only be CBOR
-   Major type 2, i.e. byte strings).
-3. Enforce limits.
+2. Validate that each entry's value codec is acceptable. Currently, only `IPLD_RAW` (0x55) is allowed).
+3. Validate that each entry's key is at most 32 bytes long and is valid utf-8.
+4. Validate that the event has at most 256 entries.
+5. Validate that the total length of all entry data combined is at most 8KiB.
 
 ### Event accumulation and aggregation
 
@@ -470,6 +472,19 @@ The FVM does not write receipts to the blockstore, neither does it write the
 events AMT themselves. Doing so would result in a dangling write. Clients are
 responsible for managing event data as they wish, just like they're responsible
 for managing receipts.
+
+### Event limits
+
+The event limits were chosen to limit:
+
+1. The amount of memory required to process/store an event.
+2. The complexity/time required to process an event.
+
+- The maximum key length of 32 bytes was chosen to allow efficient indexing and to discourage using keys for complex values.
+- The maximum total value size of 8KiB was chosen to keep the event AMT leaf size well below 1MiB.
+- The event entry limit was chosen to be 256 was also chosen to keep the total event size small.
+
+Overall, these limits lead to 8KiB of keys (max) and 8KiB of values (max) in a single event.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Some background:

The previous event structure (as described) was moderately painful to work with, required decoding the event value when processing, and deviated from the message/receipt format (where "values" are encoded as bytes").

Due to this, the reference FVM never correctly implemented the structure as described, instead it:

1. First encoded the value as CBOR.
2. Then stored that CBOR value inside a byte string in the event structure.

This change updates the FIP to match that behavior, with a few tweaks:

1. It adds an explicit codec field to aid block explores.
2. It specifies that the only allowed codec (for now) is _raw_, not cbor with a major-type 2 restriction.

Additionally, this FIP introduces some hard limits for security reasons.