### PR TITLE
FIP0054: Specify syscall gas

### DIFF
--- a/FIPS/fip-0054.md
+++ b/FIPS/fip-0054.md
@@ -874,6 +874,8 @@ pub struct NetworkContext {
 pub fn context() -> Result<NetworkContext>;
 ```
 
+This syscall charges no gas beyond the base `p_syscall_gas`.
+
 **`network::tipset_cid`**
 
 See [Tipset CID](#tipset-cid) for more context.
@@ -904,6 +906,13 @@ pub fn tipset_cid(
 ) -> Result<u32>;
 ```
 
+The lookback is limited to `[current_epoch - 900, current_epoch - 1]`.
+
+In addition to the base `p_syscall_gas`, this syscall charges:
+
+1. A flat `50,000` gas fee to lookup the tipset CID at the previous epoch.
+2. A flat `215,000` gas fee to lookup the tipset CID at any other epoch.
+
 **`actor::lookup_address`**
 
 ```rust
@@ -933,6 +942,8 @@ pub fn lookup_delegated_address(
 ) -> Result<u32>;
 ```
 
+This syscall charges to lookup the target actor state (see [FIP-0057]), in addition to the base `p_syscall_gas`
+
 **`actor::balance_of`**
 
 ```rust
@@ -952,6 +963,8 @@ pub fn balance_of(
 )  -> Result<super::TokenAmount>;
 ```
 
+This syscall charges to lookup the target actor state (see [FIP-0057]), in addition to the base `p_syscall_gas`
+
 **`actor::next_actor_address`**
 
 ```rust
@@ -960,6 +973,8 @@ pub fn balance_of(
 /// **Privileged:** May only be called by the init actor.
 pub fn next_actor_address(obuf_off: *mut u8, obuf_len: u32) -> Result<u32>;
 ```
+
+This syscall charges no gas beyond the base `p_syscall_gas`.
 
 **`crypto::recover_secp_public_key`**
 
@@ -983,6 +998,8 @@ pub fn recover_secp_public_key(
    sig_off: *const u8,
 ) -> Result<[u8; SECP_PUB_LEN]>;
 ```
+
+This syscall charges 1,637,292 gas (in addition to the base syscall gas), the same as is charged to verify a secp256k1 signature.
 
 **`event::emit_event`**
 
@@ -1011,6 +1028,8 @@ pub fn emit_event(
 pub fn available() -> Result<u64>;
 ```
 
+This syscall charges no gas beyond the base `p_syscall_gas`.
+
 **`vm::exit`**
 
 ```rust
@@ -1035,6 +1054,8 @@ pub fn available() -> Result<u64>;
 /// None. This function doesn't return.
 pub fn exit(code: u32, blk_id: u32, message_off: *const u8, message_len: u32) -> !;
 ```
+
+This syscall charges no gas beyond the base `p_syscall_gas`.
 
 **`vm::message_context`**
 
@@ -1068,6 +1089,8 @@ pub struct MessageContext {
 /// None
 pub fn message_context() -> Result<MessageContext>;
 ```
+
+This syscall charges no gas beyond the base `p_syscall_gas`.
 
 ### Changed syscalls
 
@@ -1142,6 +1165,30 @@ Starting from now, clients must compute and remember the tipset CID of every tip
 This is achieved by inserting the CBOR-serialized tipset key into the chain blockstore, and computing its CID using the Blake2b-256 multihash function.
 
 ## Design Rationale
+
+### Tipset CID Gas
+
+The Tipset CID computation gas was determined by benchmarking Lotus and adding a security factor, but the numbers should hold for most implementations. Specifically, the benchmark assumes that:
+
+1. The last 900 tipsets are cached in-memory.
+2. There exists a skip-list allowing one to skip 20 tipsets at a time.
+
+This true for all major Filecoin clients: Forest, Venus, and Lotus.
+
+Benchmarking yielded:
+
+- ~1,500 gas/20 tipsets (skip list)
+- ~5,800 gas to traverse each tipset directly.
+- ~15,000 gas offset (includes overhead, computing the tipset CID, etc.).
+
+Purely for the client-side operations. We then add on an additional 21,000 gas (`p_extern_gas`) to charge for calling into the client.
+
+To keep the common case of getting the last tipset CID (e.g., for randomness) affordable, we split this charge into:
+
+1. The most recent tipset CID lookup: `15000+5800+21000 = 41800`. We propose `50,000` for security.
+2. Everything else: `(900/20)*1500 + 5800*19 + 15000 + 21000 = 213700`. We propose `215,000` for security.
+
+These charges intentionally leave space for changing the underlying tipset caching algorithm.
 
 ### Transfer Gas Limit
 


### PR DESCRIPTION
Importantly, specify a non-trivial gas schedule for looking up tipset CIDs.