### PR TITLE
FIP-0054: elaborate on which timestamp should be passed on null rounds.

### DIFF
--- a/FIPS/fip-0054.md
+++ b/FIPS/fip-0054.md
@@ -833,6 +833,7 @@ New environmental data is required by the FVM to satisfy new data returned in sy
 
 - [EIP-155] [Chain ID](#eip-155-chain-ids-of-filecoin-networks) of the network.
 - Timestamp of the execution epoch.
+  If the execution epoch happens to be a null round (no blocks, and therefore no tipset), the client must pass the timestamp of the epoch at which the null round occurred (i.e. the timestamp that a block would've carried should that epoch not have been a null round).
 
 ### EIP-155 Chain IDs of Filecoin networks
 


### PR DESCRIPTION
Makes the specification more explicit on such edge cases. See https://github.com/filecoin-project/FIPs/discussions/592#discussioncomment-4852715.