### PR TITLE
FIP0057: Increase storage gas to 3340gas/byte

### DIFF
--- a/FIPS/fip-0057.md
+++ b/FIPS/fip-0057.md
@@ -28,6 +28,7 @@ This FIP proposes a few adjustments to the gas charging schedule. Specifically:
 - Variable charges for memory initialization, copying, and allocation.
 - New charges for state-tree reads and writes.
 - New charges for actor address resolution.
+- Increase the _state_ storage gas cost from 1,300 to 3,340 gas.
 
 This FIP also introduces overall memory limits. However, these memory limits currently only include Wasm memories and table elements (not IPLD blocks, wasm _code_, and other metadata).
 
@@ -45,6 +46,7 @@ With a FEVM contract, users can:
 2. Make state read and write operations that have not been re-priced since network launch. These prices were estimated before the FVM existed, and while the state-tree was quite small.
 3. Make syscalls that were previously expected to have their costs amortized over the execution of the transaction as a whole. Unfortunately, with FEVM, prices must assume random pathological access.
 4. Allocate arbitrary amounts of memory. Existing built-in actors have explicit limits to avoid running out of memory, but FEVM requires system-imposed global memory limits.
+5. Store arbitrary state, potentially bloating the state-tree.
 
 ## Specification
 
@@ -60,6 +62,12 @@ First and foremost, this FIP makes a few adjustments to FIP-0032.
 
 - Memory copy costs `p_memcpy_per_byte` have been reduced from 0.5gas/byte to 0.4gas/byte to more accurately match benchmarks. We're reasonably confident in this number as it exactly matches the expected speed of 3200 MT/s memory.
 - The explicit "extern" cost (`p_extern_gas`) of 21,000 gas has been rolled into the various syscall costs themselves to make it easier to reason about the costs of the individual syscalls. This change has no affect on the gas _charged_, it simply makes it easier to benchmark and discuss changes to gas charges.
+
+### Adjustments to Storage Gas
+
+Filecoin has historically under-priced storage costs. This hasn't been a huge issue because all state was "managed" by built-in actors, but FEVM introduces userspace contracts.
+
+Specifically, the per-byte storage cost for on-chain state (excluding messages and receipts) is increasing from 1,300 to 3,440 gas/byte.
 
 ### System Call Gas Adjustments
 
@@ -105,17 +113,15 @@ Specifically, this FIP proposes the following:
 1. A `2.4 gas/byte` fee for to allocate and copy the block into temporary storage.
 2. A per-byte hashing fee according to the price list defined in the hashing section below.
 3. A fixed per-block fee of 172,000 (`p_blocklink_base_gas`) gas to account for the cost of "flushing" blocks at the end of an epoch.
-4. A fixed 130,000 per-block storage fee to account for metadata overhead.
-5. A per-byte storage fee of 1,300 gas/byte.
+4. A fixed 334,000 per-block storage fee to account for metadata overhead.
+5. A per-byte storage fee of 3,340 gas/byte.
 
 These fees supersede the current prices:
 
 1. A 1,300 gas/byte storage fee.
 2. A fixed 353,640 per-block fee.
 
-Overall, blocks under ~4KiB are actually cheaper under this model, as the fixed cost is reduced from 353,640 to 302,000.
-
-This syscall now charges `172,000 + 130,000 + (2.4 + per_byte_hash_fee + 1,300) * block_size`  (in addition to `p_syscall_gas`).
+This syscall now charges `172,000 + 334,000 + (2.4 + per_byte_hash_fee + 3,340) * block_size`  (in addition to `p_syscall_gas`).
 
 #### Send
 
@@ -213,7 +219,7 @@ The FVM will apply these charges during the following operations:
 
 #### Actor Creation
 
-The generic "actor creation" compute cost of 1,108,454 is removed and the actor creation _storage_ cost is increased from 98,800 gas to 250,000 gas (`p_actor_create_storage`).
+The generic "actor creation" compute cost of 1,108,454 is removed and the actor creation _storage_ cost is increased from 98,800 gas to 650,000 gas (`p_actor_create_storage`).
 
 Whenever a new actor is created via the init actor (i.e., via the `actor::create_actor` syscall), we charge for the new actor's state-tree update and storage:
 
@@ -221,7 +227,7 @@ Whenever a new actor is created via the init actor (i.e., via the `actor::create
   p_actor_update + p_actor_lookup
 + p_actor_create_storage
 -----------------------------------------
-= 1,225,000
+= 1,625,000
 ```
 
 When an actor is implicitly created due to a send, we charge an additional `p_address_assignment` (1,000,000) and `p_address_lookup` and because, in this case, the FVM assigns addresses directly, bypassing the init actor.
@@ -231,7 +237,7 @@ When an actor is implicitly created due to a send, we charge an additional `p_ad
   p_address_assignment + p_address_lookup
 + p_actor_create_storage
 -----------------------------------------
-= 3,375,000
+= 3,775,000
 ```
 
 #### Actor Deletion
@@ -314,6 +320,27 @@ This FIP introduces a 1MiB limit on all newly created blocks (through the `ipld:
 ## Design Rationale
 
 Execution fidelity, accuracy, and security are the overarching principles that motivates this FIP. Fees have been revised to deliver a more accurate gas model while preserving the security properties of the network, which revolve around the baseline cost of 10 gas/ns.
+
+### Storage Gas Costs
+
+Filecoin has, historically, charged very little for on-chain state storage. Attempts to change this in the past have been met with resistance as doing so would increase gas fees and reduce chain bandwidth.
+
+Specifically, in terms of chain bandwidth, Etherium storage gas costs ported to Filecoin would be:
+
+1. ~120,000 gas for new state.
+2. ~30,000 gas for state updates.
+
+Calculated as: `EVM_GAS_COST/(32+log2(32)) * 222`.
+
+Two things have changed:
+
+1. FEVM is introducing user-specified contracts which can arbitrarily bloat the state.
+2. Optimizations to the built-in actors _reducing_ gas costs by 30% on average.
+
+While we can't increase the storage costs to where they should be with respect to the EVM, we have an opportunity to increase them _a bit_ while leaving the average gas burn the same.
+
+Specifically, by setting the storage gas to 3,340gas/byte, we see a net change of -0.5% gas usage
+overall. Further details can be found in the product consideration section.
 
 ### Cumulative Memory Limits
 
@@ -401,7 +428,7 @@ Previously, Filecoin charged for `32+40 = 72` bytes when creating new actors. Ho
 = 160
 ```
 
-We then round this up to 192 to account for structure and state-tree overhead, which yields `192 * 1300 = 249600 ~= 250,000` gas.
+We then round this up to 192 to account for structure and state-tree overhead, which yields `192 * 3,340 = 641,280 ~= 650,000` gas.
 
 ### Actor Deletion Refund
 
@@ -473,7 +500,7 @@ As with all gas schedule changes, this FIP introduces changes to the operation c
 
 ## Product Considerations
 
-Overall, due to optimizations in the built-in actors, gas usage for most storage provider messages is expected to _decrease_ by ~30% on average (40% for  `PublishStorageDeals`).
+Overall, this FIP changes average gas usage by -0.5% after taking other actor optimizations into account.
 
 However, there are a couple of important cases to note:
 
@@ -485,30 +512,45 @@ Furthermore, with respect to `PublishStorageDeals`:
 
 - PSD messages with multiple clients will be more expensive than PSD messages with fewer clients as there's a per-client 500k gas charge to lookup the client in question. However, this effect is minimal compared to the overall cost of these messages.
 - PSD messages that address clients by f1-f4 addressees will cost more than PSD messages that address said clients by their ID (f0 address) due to the cost of the additional lookup. However, again, the effects of this cost are minimal compared to the overall cost of these messages.
-  
-See table attached below for overview on impact of this FIP on cost of messages.
 
-| Code | Method | Event Count | Existing gas usage | Gas usage with FIP-0057 | % Change |
+All together, when benchmarking with the new gas numbers, we see the following costs (on average):
+
+| Code | Method | GasNew_count | GasOld_mean | GasNew_mean | change |
 | --- | --- | --- | --- | --- | --- |
-| fil/9/account | 0 | 170 | 399235.24 | 953667.37 | 138.87 |
-| fil/9/cron | 2 | 130 | 83064254907.19 | 139641576916.46 | 68.11 |
-| fil/9/multisig | 2 | 37 | 6035232.24 | 7416593.21 | 22.88 |
-| fil/9/multisig | 3 | 1 | 11898828.00 | 10824014.00 | -9.03 |
-| fil/9/reward | 2 | 618 | 40868935.57 | 29603957.24 | -27.56 |
-| fil/9/storagemarket | 2 | 137 | 25117648.78 | 14589340.89 | -41.91 |
-| fil/9/storagemarket | 4 | 1682 | 562331981.74 | 328621163.79 | -41.56 |
-| fil/9/storageminer | 11 | 57 | 261916512.29 | 138428260.52 | -47.14 |
-| fil/9/storageminer | 16 | 10 | 24947347.30 | 18390893.10 | -26.28 |
-| fil/9/storageminer | 25 | 205 | 396350787.23 | 257868234.90 | -34.93 |
-| fil/9/storageminer | 26 | 72 | 1794289536.83 | 1284088154.79 | -28.43 |
-| fil/9/storageminer | 27 | 76 | 301809520.72 | 237530054.05 | -21.29 |
-| fil/9/storageminer | 5 | 6146 | 48953943.02 | 34808585.27 | -28.89 |
-| fil/9/storageminer | 6 | 5108 | 48493017.10 | 35342978.14 | -27.11 |
-| fil/9/storageminer | 7 | 5965 | 64223280.35 | 58921202.38 | -8.25 |
-| fil/9/storageminer | 8 | 18 | 252652762.44 | 168120034.66 | -33.45 |
+| fil/9/account | 0 | 1223 | 291660.72 | 645124.08 | 121.18 |
+| fil/9/multisig | 2 | 40 | 5938757.07 | 8710765.85 | 46.67 |
+| fil/9/multisig | 3 | 2 | 24906502.50 | 29119872.00 | 16.91 |
+| fil/9/reward | 2 | 5547 | 40317641.00 | 43873338.19 | 8.81 |
+| fil/9/storagemarket | 2 | 1650 | 24982007.47 | 23173395.18 | -7.23 |
+| fil/9/storagemarket | 4 | 11953 | 606009920.31 | 541451416.73 | -10.65 |
+| fil/9/storageminer | 0 | 7 | 216405.00 | 481000.00 | 122.26 |
+| fil/9/storageminer | 3 | 1 | 3146882.00 | 6040850.00 | 91.96 |
+| fil/9/storageminer | 4 | 10 | 2601772.10 | 4474645.00 | 71.98 |
+| fil/9/storageminer | 5 | 46986 | 52907581.11 | 49981422.43 | -5.53 |
+| fil/9/storageminer | 6 | 49513 | 46352972.94 | 48949895.13 | 5.60 |
+| fil/9/storageminer | 7 | 55086 | 63102326.38 | 75481067.70 | 19.61 |
+| fil/9/storageminer | 8 | 646 | 523704602.86 | 514605025.93 | -1.73 |
+| fil/9/storageminer | 11 | 406 | 429599995.23 | 232335284.18 | -45.91 |
+| fil/9/storageminer | 16 | 140 | 27477805.81 | 32683070.28 | 18.94 |
+| fil/9/storageminer | 18 | 5 | 2571314.40 | 4440263.80 | 72.68 |
+| fil/9/storageminer | 23 | 6 | 2593594.83 | 4469491.16 | 72.32 |
+| fil/9/storageminer | 24 | 1 | 4096410066.00 | 2142130910.00 | -47.70 |
+| fil/9/storageminer | 25 | 1517 | 260234684.68 | 278624611.67 | 7.06 |
+| fil/9/storageminer | 26 | 510 | 2255779780.47 | 2582969572.70 | 14.50 |
+| fil/9/storageminer | 27 | 967 | 270460447.84 | 318397920.82 | 17.72 |
 
+In terms of the market actor, PublishStorageDeals is ~10% cheaper.
 
-  
+In terms of the miner actor (storage provider operations):
+
+1. Window post messages are ~5.5% cheaper on average.
+2. Window post disputes (security critical) are ~47% cheaper on average.
+3. PreCommit is ~5% more expensive.
+4. ProveCommit is ~20% more expensive.
+5. PreCommitAggregate is ~7% more expensive.
+6. ProveCommitAggregate is ~15% more expensive.
+7. ProveReplica is ~17% more expensive.
+
 ## Implementation
 
 These changes have been implemented in the [reference implementation of the FVM](https://github.com/filecoin-project/ref-fvm).


### PR DESCRIPTION
We now have a _chance_ to do this and if we don't take it now, it'll be much harder to do in the future. Filecoin is still charging significantly less for storage than other chains.