### PR TITLE
FIP-0044: Add boolean return value to AuthenticateMessage

### DIFF
--- a/FIPS/fip-0044.md
+++ b/FIPS/fip-0044.md
@@ -9,6 +9,9 @@ created: 2022-08-02
 replaces: [FIP-0035](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0035.md)
 ---
 
+**Change history**
+- February 2023: Added boolean return value to AuthenticateMessage
+
 ## Simple Summary
 
 The Filecoin protocol has entities called "actors" that can be involved in computation on the Filecoin blockchain. 
@@ -21,9 +24,9 @@ If they do implement such a method, it can be used by other actors to authentica
 ## Abstract
 
 There is a need for arbitrary actors to be able to verify (to other actors) that they have approved of a piece of data. This need will become more pressing with the Filecoin Virtual Machine.
-This FIP proposes adding an `Authenticate` method that any actor can choose to implement. 
+This FIP proposes adding an `AuthenticateMessage` method that any actor can choose to implement. 
 This method can be called by any other actor to verify the authenticity of a piece of data. This is a small change to the existing actors, and allows for user-defined actors to flexibly implement this method according to their needs.
-Concretely, we add this method to the built-in `Account` actor, and have the `Storage Market` actor invoke this method,
+Concretely, we add this method to the built-in `Account` actor, and have the built-in `Storage Market` and `Payment Channel` actors invoke this method,
 in lieu of validating signatures directly.
 
 ## Change Motivation
@@ -47,8 +50,9 @@ as well as a template for user-defined actors.
 
 ```
     /// Authenticates whether the provided input is valid for the provided message.
-    /// Errors with USR_ILLEGAL_ARGUMENT if the authentication is invalid.
-    pub fn authenticate_message(params: AuthenticateMessageParams) -> Result<(), ActorError>
+    /// Returns false if the authentication is invalid.
+    /// Any non-zero exit code must also be interpreted as authentication failure.
+    pub fn authenticate_message(params: AuthenticateMessageParams) -> Result<bool, ActorError>
 ```
 
 The params to this method is a wrapper over the message and signature to validate:
@@ -60,7 +64,7 @@ pub struct AuthenticateMessageParams {
 }
 ```
 
-Further, we propose modifying the StorageMarketActor to call this method when validating `ClientDealProposal`s instead of validating signatures directly.
+Further, we propose modifying the built-in `Storage Market` and `Payment Channel` to call this method instead of validating signatures directly.
 
 ## Design Rationale
 
@@ -73,6 +77,8 @@ such as the Storage Power Actor, the System Actor, the Cron Actor, etc. will lik
 
 In order for this method to function as a standard for future actors, it needs a standardized invocation pattern. 
 In the current dispatch model based on method numbers, that would be a standardized method number for `authenticate_message` methods. This FIP does not propose adopting a standard method number, preferring to rely on a new standardized calling convention, such as [FRC-0042](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0042.md) instead.
+
+A non-empty return value is specified in order to avoid a no-op implementation of this method inadvertently being interpreted as a successful message authentication.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
A non-trivial return value prevents a no-op implementation from being inadvertently interpreted as a successful authentication. No-op implementations became common after this FIP was initially accepted with the introduction of placeholder actor in FIP-0048.

Implemented in https://github.com/filecoin-project/builtin-actors/pull/1216