### PR TITLE
FRC-0053: Remove redundant owner parameter from optional enumeration methods

### DIFF
--- a/FRCs/frc-0053.md
+++ b/FRCs/frc-0053.md
@@ -183,18 +183,18 @@ fn ListOwnedTokens({owner: Address, cursor: byte[], limit: u64})
 An actor may choose to implement the following methods to support enumeration of operators.
 
 ```rust
-/// Returns all the operators approved by an owner for a specific token.
+/// Returns all the operators approved for a specific token.
 /// The result does not include account-level operators unless such operators are also
 /// explicitly approved for the token.
-fn ListTokenOperators({owner: Address, tokenID: TokenID, cursor: byte[], limit: u64}) 
+fn ListTokenOperators({tokenID: TokenID, cursor: byte[], limit: u64}) 
     -> {operators: ActorIDSet, next_cursor: Option<byte[]>}
 
-/// Enumerates tokens for which an account is an explicit operator for an owner.
+/// Enumerates tokens for which an account is an explicit operator.
 /// For account-level operators, the result only includes tokens for which the address would
 /// be an operator even if account-level approval were revoked.
-/// (Use ListTokens to enumerate the tokens an account-level operator can control,
+/// (Use ListOwnedTokens to enumerate the tokens an account-level operator can control,
 /// which is all of them).
-fn ListOperatorTokens({owner: Address, operator: Address, cursor: byte[], limit: u64})
+fn ListOperatorTokens({operator: Address, cursor: byte[], limit: u64})
   -> {tokens: TokenSet, next_cursor: Option<byte[]>}
 
 /// Returns all the account-level operators approved by an owner.


### PR DESCRIPTION
@alexytsu discovered this parameter was not needed during implementation.