### PR TITLE
Add Batch Balancer parameter recalibration to FIP-0057

### DIFF
--- a/FIPS/fip-0057.md
+++ b/FIPS/fip-0057.md
@@ -33,6 +33,8 @@ This FIP proposes a few adjustments to the gas charging schedule. Specifically:
 This FIP also introduces overall memory limits. However, these memory limits currently only include Wasm memories and table elements (not IPLD blocks, wasm _code_, and other metadata).
 
 Additionally, this FIP introduces a maximum block size limit of 1MiB for all newly created IPLD blocks.
+  
+Since the above changes the estimated gas usage of PreCommit and ProveCommit  messages, this FIP introduces a recalibration of the corresponding parameters in the Batch Balancer mechanism.
 
 Finally, this FIP reduces the maximum recursive call depth limit from 1025 to 1024 to bring it in-line with the initial intentions of this limit and other blockchain VMs.
 
@@ -316,6 +318,24 @@ This FIP introduces a 1MiB limit on all newly created blocks (through the `ipld:
 
 1. Blocks in state.
 2. The size of internal (actor to actor) messages and return values.
+  
+### Batch Balancer Recalibration
+  
+The above changes result in `PreCommit` messages being expected to consume 5% more gas, while `ProveCommit` messages will consume 20% more gas. The gas usage of these messages is used as an input parameter in the batch balancer mechanism, specified in FIP-0024 as `SinglePreCommitGasUsage = 16433324.1825` and `SingleProveCommitGasUsage = 49299972.5475`
+  
+To maintain the current thresholds required for batching, in terms of high enough base fees and number of proofs in a batch, these parameters must be updated, relative to their FIP-0024 values. This FIP updates these parameters to,
+  
+```  
+SinglePreCommitGasUsage = 1.05 * SinglePreCommitGasUsage = 
+SingleProveCommitGasUsage = 1.20 * SingleProveCommitGasUsage
+```  
+or,
+  
+```
+SinglePreCommitGasUsage = 17254990.3916
+SingleProveCommitGasUsage =  59159967.0570 
+```
+  
 
 ## Design Rationale
 


### PR DESCRIPTION
FIP-0057 changes the estimated gas usage for PreCommit and ProveCommit messages, which appear as parameters in the batch balancer mechanism. If parameters are not adjusting accordingly following these changes, this would change the batching thresholds, in terms of high enough base fee and large enough number of proofs in a batch.

This change modifies FIP-0057 to include a corresponding update in the gas usage parameters of the Batch Balancer.

A sentence is added in the **Abstract** section, and a subsection is added at the end of the **Specification** section