### PR TITLE
Update fip-0057.md

### DIFF
--- a/FIPS/fip-0057.md
+++ b/FIPS/fip-0057.md
@@ -54,7 +54,7 @@ Notes:
 
 - Filecoin targets 10 gas/ns. That is, an operation that takes 1 nanosecond should cost 10 gas.
 - The FVM supports gas charges with _milligas_ precision. That is, we can charge for gas in increments of 0.001 gas.
-- In terms of chain throughput (gas per unit time), there's about 222 Filecoin gas to every 1 Ethereum gas. This ratio should be kept in mind when comparing Filecoin gas costs to Ethereum gas costs.
+- In terms of chain throughput (gas per unit time), there's about 444 Filecoin gas to every 1 Ethereum gas. This ratio should be kept in mind when comparing Filecoin gas costs to Ethereum gas costs.
 
 ### Adjustments to FIP-0032
 
@@ -330,7 +330,7 @@ Specifically, in terms of chain bandwidth, Ethereum storage gas costs ported to 
 1. ~120,000 gas for new state.
 2. ~30,000 gas for state updates.
 
-Calculated as: `EVM_GAS_COST/(32+log2(32)) * 222`.
+Calculated as: `EVM_GAS_COST/(32+log2(32)) * 444`.
 
 Two things have changed:
 


### PR DESCRIPTION
@Stebalien has suggested that 444 is the actual right ratio according to filecoin & Ethereum block limits