### PR TITLE
Update FIP0056 based on implementation

### DIFF
--- a/FIPS/fip-0056.md
+++ b/FIPS/fip-0056.md
@@ -14,10 +14,10 @@ replaces: (https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0052.md
 - A longer sector will have a higher Quality Adjusted Power (QAP) than a shorter sector, all things equal.
 - The Duration Multiplier is multiplicative on the existing Quality Multiplier incentive (Filecoin Plus incentive). [Filecoin Plus](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0003.md) already offers up to a 10x multiplier for proving storage of data from verified clients. This FIP introduces an independent Duration Multiplier up to 2x. Thus, the maximum multiplier available to any sector will increase from 10x to 20x.
 - Sectors with higher Quality Adjusted Power as a result of the Sector Duration Multiplier and Quality Multiplier will require higher initial pledge collateral.
-- The minimum sector duration time will increase from 6 months to 1 year and the maximum sector duration will increase from 1.5 years to 5 years. The upper bound of [Deal Duration Bounds](https://github.com/filecoin-project/builtin-actors/blob/b5c101ab94f562ba43c1eca31bd1e73c6fc35794/actors/market/src/policy.rs#L33-L35) will increase to 5 years as well. 
+- The minimum sector duration time will increase from 180 days to 1 year and the maximum sector duration will increase from 540 days to 5 years. The upper bound of [Deal Duration Bounds](https://github.com/filecoin-project/builtin-actors/blob/b5c101ab94f562ba43c1eca31bd1e73c6fc35794/actors/market/src/policy.rs#L33-L35) will increase to 5 years as well.
 - CEL and the community will monitor the network and look to increase the maximum sector duration in a future FIP if network conditions merit, pending community-driven support for such measures.
 - The SDM policy will apply at sector commitment, extension, and replica update
-- The termination fee cap will scale with the duration multiplier. 
+- The termination fee cap will scale with the lifetime of the sector beyond 540 days.
 
 ## Problem Motivation
 Currently, Storage Providers do not receive any additional compensation or incentives for committing longer term sectors (whether that be CC or storage deals) to the network. The protocol places equal value on 180 to 540 day sectors in terms of storage mining rewards. However, in making an upfront commitment to longer-term sectors, Storage Providers take on additional operational risks (more can go wrong in a longer time period), and lock rewards for longer. Furthermore, in committing longer term sectors/deals, Storage Providers demonstrate their long-term commitment to the mission and growth of the Filecoin Network, and are more aligned with client preference for persistent storage. Therefore, the added value of longer-term sector commitments, coupled with the compounded operational/liquidity risks Storage Providers incur for committing longer term sectors should be compensated for in the form of increased rewards.
@@ -32,32 +32,49 @@ The following aims to help better align the economic incentives of the network w
 ## Specification
 
 ### Change to Miner Sector Info's
-- Add an `last_extension_epoch` field to miner_sector_infos. This field contains the epoch a sector is extended by a Storage Provider. Upon Initial Sector Commitment, we can initialize this field such that `last_extension_epoch := activation_epoch`.
+- Add a `power_base_epoch` field to miner_sector_infos. This field contains the epoch a sector power was last updated (sector commitment, extension, or replica update).
 
 ### SDM Function
-The SDM should scale initial pledge and power via the SDM function specified in pseudocode) below. Note, this will have to be implemented in fixed point arithmetic: 
+The SDM should scale initial pledge and power via the SDM function specified in pseudocode below. Specifically, it scales linearly from a 1x multiplier at 540 days to a 2x multiplier at 5 years.
 
 ```
-fn sdm(duration_commitment: float) -> float {
-    if duration_commitment <= (3/2 * EPOCHS_IN_YEAR) {
+fn sdm_scale(base_power: int, duration_commitment: int) -> int {
+    const EPOCHS_IN_DAY = 86400:
+    const EPOCHS_IN_YEAR = 1051897;
+    const SDM_MIN_DURATION = 540 * EPOCHS_IN_DAY;
+    const SDM_MAX_DURATION = 5 * EPOCHS_IN_YEAR;
+    const SDM_MAX_MULTIPLIER = 2;
+    if duration_commitment <= SDM_MIN_DURATION {
         1
+    } else if duration_commitement >= SDM_MAX_DURATION {
+        SDM_MAX_MULTIPLIER
     } else {
-        2/7*(duration_commitment + 2)
+        // Scale the multiplier from  1 to SDM_MAX_MULTIPLIER starting at a duration_commitment of
+        // SDM_MIN_DURATION and ending at a commitment_duration of SDM_MAX_DURATION.
+        let denominator = SDM_MAX_DURATION - SDM_MIN_DURATION;
+        let numerator = (SDM_MAX_MULTIPLIER - 1)
+            * (duration_commitment - SDM_MIN_DURATION)
+            + denominator;
+        (base_power * numerator) / denominator
     }
 }
 ```
-### SDM Upon Sector Onboarding 
-Upon onboarding, the SDM applies from activaion epoch to expiration epoch: 
 
-```
-let duration_commitment = expiration_epoch - activation_epoch
-```
-### SDM Upon Sector Extension
-Upon extension, SDM applies to a commitment duration between current extension epoch and new expiration epoch: 
+### SDM Power Updates
 
-``` 
-let duration_commitment = expiration_epoch - extension_epoch; 
-```
+Upon activation, extension, and replica update (snapping):
+
+1. The power-base epoch is updated to the current epoch (activation, extension, replica update).
+2. The SDM is calculated from the new power base epoch to the new expiration epoch. That is, `sdm_scale(old_qap, new_expiration - power_base_epoch)`.
+
+On sector updates (extension and replica update), the power is re-calculated and:
+
+1. The "initial pledge" is re-calculated and updated if the new value exceeds the current initial pledge. The initial pledge is never reduced. If the initial pledge increases, the delta is "locked". If insufficient funds are available, the operation fails.
+2. The "expected storage pledge" (used in termination penalty calculations) is updated to the maximum of its new value (given the new power from, e.g., SDM) and its previous value.
+3. The "replaced sector day reward" is updated to the max of the previous "replaced sector day reward" and the to be replaced "expected sector day reward".
+4. The "expected sector day reward" is updated based on the newly calculated power.
+
+### SDM Sector Extension
 
 The minimum sector extension time is 1 year. In the [policy actor](https://github.com/filecoin-project/builtin-actors/blob/45c56ed57190349f1856d3258af6c09a24ea1395/runtime/src/runtime/policy.rs#L358): 
 
@@ -71,41 +88,12 @@ Note that sector extension should not support pledge release. As such:
 new_pledge = max(old_pledge, new_pledge)
 ```
 
-### SDM Recalculation Upon Replica Update 
-
-In the [miner actor](https://github.com/filecoin-project/builtin-actors/blob/master/actors/miner/src/lib.rs#L1304) implementation for resnapping, `duration` is already defined as such: 
-```
-let duration = new_sector_info.expiration - new_sector_info.activation
-```
-
-We adjust the calculations for 
-- `new_sector_info.expected_day_reward` 
-- `new_sector_info.expected_storage_pledge` 
-
-in the [miner actor](https://github.com/filecoin-project/builtin-actors/blob/master/actors/miner/src/lib.rs#L1304) to include the SDM
-
-```
-new_sector_info.expected_day_reward = expected_reward_for_power(
-    &rew.this_epoch_reward_smoothed,
-    &pow.quality_adj_power_smoothed,
-    &qa_pow,
-    fil_actors_runtime::network::EPOCHS_IN_DAY,
-) * sdm(duration);
-```
-```
-new_sector_info.expected_storage_pledge = expected_reward_for_power(
-    &rew.this_epoch_reward_smoothed,
-    &pow.quality_adj_power_smoothed,
-    &qa_pow,
-    INITIAL_PLEDGE_PROJECTION_PERIOD,
-) * sdm(duration);
-```
 ### Termination Fee Cap
 
 The [monies actor](https://github.com/filecoin-project/builtin-actors/blob/b7ad2c55363c363f61275ca45ef255e28f305254/actors/miner/src/monies.rs) termination penalty should be changed to: 
 
 ```
-let penalized_reward =  max(SP(t), BR(StartEpoch, 20d) + BR(StartEpoch, 1d) * terminationRewardFactor * min(SectorAgeInDays, 140*sdm(duration)))
+let penalized_reward =  max(SP(t), BR(StartEpoch, 20d) + BR(StartEpoch, 1d) * terminationRewardFactor * min(SectorAgeInDays, sdm_scale(140, sector_expiration - sector_activation)))
 ```
 
 ### Sector Duration Multiplier 
@@ -146,14 +134,14 @@ Introduce a multiplier based on sector duration
 **This SDM function proposed is linear with a maximum 2x reward multiplier for 5-year commitments**. See below for the function proposed. 
 ![SDM_Function](../resources/fip-00XX/SDM_Function.png)
 
-The rationale to select this linear function is based on a principle that the selected parameters should maximize the effectiveness of the duration incentive, subject to SP’s collateral availability constraints, while taking into account micro and macroeconomic consequences with minimal added implementation complexity. The SDM function results in sectors with initial sector commitments between 1 and 1.5 years receiving a 1x Quality multiplier so as to not disadvantage SP's who had already committed sectors for 1.5 years. 
+The rationale to select this linear function is based on a principle that the selected parameters should maximize the effectiveness of the duration incentive, subject to SP’s collateral availability constraints, while taking into account micro and macroeconomic consequences with minimal added implementation complexity. The SDM function results in sectors with initial sector commitments between 1 year and 540 days receiving a 1x Quality multiplier so as to not disadvantage SP's who had already committed sectors for 540 days.
 
 Therefore, the new suggested *Sector Quality Adjusted Power* is: 
 
 $sectorQuality = (avgQuality \cdot sectorSize) \cdot SDM$
 
 ### Change to Minimum Sector Commitmnent
-We propose a minimum sector commitment of 1 year. This is a ~180-day increase from the current minimum of 6 months. This will not change the mechanics of sector pre-commit and proving; it will just adjust the minimum sector commitment lifetime to 1-year.
+We propose a minimum sector commitment of 1 year. This is a ~180-day increase from the current minimum of 180 days. This will not change the mechanics of sector pre-commit and proving; it will just adjust the minimum sector commitment lifetime to 1-year.
 
 ### Change to Maximum Sector Commitment 
 We propose a maximum sector commitment of 5 years. This is an increase from the current maximum sector commitment of 540 days. Note, the protocol currently sets a maximum sector lifetime to 5 years (i.e sectors can be extended up to 5 years). This FIP would not adjust that.
@@ -169,9 +157,9 @@ This change shouldn’t be seen as precluding future termination fee changes. As
 ## Design Rationale
 
 ### Supporting Longer-Term Commitments
-The current maximum commitment of 1.5 years limits the ability for SPs to make a long-term commitment to the network (or get rewarded for it). We expect that increasing the maximum allowable commitment to 5 years, while also introducing incentives to seal sectors for longer, can increase the stability of storage and predictability of rewards for SP’s. This is further discussed in the sections below.
+The current maximum commitment of 540 days limits the ability for SPs to make a long-term commitment to the network (or get rewarded for it). We expect that increasing the maximum allowable commitment to 5 years, while also introducing incentives to seal sectors for longer, can increase the stability of storage and predictability of rewards for SP’s. This is further discussed in the sections below.
 
-Note, that [FIP-0052](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0052.md) increases the maximum sector commitment duration from 1.5 years to 3.5 years as well, but does not introduce additional cryptoeconomic incentives for longer commitments. If this SDM proposal were to be accepted, then FIP-0052 would be withdrawn as it is a subset of the protocol changes outlined in this FIP. 
+Note, that [FIP-0052](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0052.md) increases the maximum sector commitment duration from 540 days to 3.5 years as well, but does not introduce additional cryptoeconomic incentives for longer commitments. If this SDM proposal were to be accepted, then FIP-0052 would be withdrawn as it is a subset of the protocol changes outlined in this FIP.
 
 ### Incentivizing Longer-Term Commitments
 Longer term commitments are incentivized by a rewards multiplier. The multiplier increases the amount of FIL expected to be won per sector per unit time based on the duration the sector is committed for.


### PR DESCRIPTION
- The minimum duration is 540 days, not 1.5 years. It's a small difference, but important.
- The implementation recalculates SDM from the current epoch on replica update (see https://github.com/filecoin-project/FIPs/discussions/554#discussioncomment-5232396).
- The `sdm` pseudo code lead to a maximum multiplier of 1e6, which was clearly a mistake.
- This now documents the update to replaced day rewards, etc.
- This now documents the correct termination penalty calculation (still under discussion, but the old version was broken).