### PR TITLE
FIP-0071: Deterministic State Access (IPLD Reachability)

### DIFF
--- a/FIPS/fip-0071.md
+++ b/FIPS/fip-0071.md
@@ -1,5 +1,5 @@
 ---
-fip: "<to be assigned>" <!--keep the qoutes around the fip number, i.e: `fip: "0001"`-->
+fip: "0071"
 title: Deterministic State Access
 author: Steven (@stebalien)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/764

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -64,6 +64,8 @@ Additionally, it exposes 2 syscalls for manipulating the actor's state-tree itse
 
 Finally, IPLD blocks can be sent between actors by as message parameters/return values (via `send::send`). Such IPLD blocks are sent _by-handle_, not by-cid.
 
+NOTE: the function signatures above are for illustrative purposes. The actual syscalls are defined in [FIP0030](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0030.md#namespace-ipld).
+
 #### Supported IPLD Codecs
 
 The FVM currently supports reading (`ipld::block_open`) and writing (`ipld::block_create`) state with the following IPLD codecs (`SUPPORTED_CODECS`):
@@ -239,6 +241,10 @@ This FIP _could_ have proposed a single "reachable" set maintained across an ent
 This FIP forbids "inlining" blocks into state-root CIDs as we'd _otherwise_ need to perform IPLD Link Analysis on the inlined block when calling `ipld::set_root`.
 
 ### Link Analysis
+
+#### Ignoring v. Rejecting Unknown CIDs
+
+The link analysis algorithm defined in this FIP _rejects_ CIDs with unknown codecs and/or hash functions instead of simply ignoring such CIDs for better forward-compatibility. This way, new codecs and hash functions can be supported in the future without worrying that such CIDs may already be present in the state (where they would have previously not been covered by link analysis).
 
 #### Native v. Wasm
 

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -20,7 +20,12 @@ Where "reachable" means that the state can be "reached" by traversing IPLD links
 
 ## Abstract
 
-TODO
+This FIP introduces additional logic into the FVM's state management system to ensure that:
+
+1. An actor may only read its own state.
+2. When an actor writes new state, that new state may only reference an actors existing state.
+
+This ensures that an actor cannot read and/or reference random IPLD data in the client's blockstore which could lead to network forks (once users are allowed to deploy arbitrary native actors to the network).
 
 ## Change Motivation
 

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -251,7 +251,7 @@ The link analysis algorithm defined in this FIP _rejects_ CIDs with unknown code
 We previously considered performing link analysis in a Wasm module to:
 
 1. Take advantage of our existing Wasm gas accounting rather than manually charging for gas based on the CBOR's structure.
-2. Ensure that all implementations used the exact same wasm parsing and validation logic.
+2. Ensure that all implementations used the exact same Wasm parsing and validation logic.
 
 However, this would have increased implementation complexity and introduced additional runtime costs (switching in and out of Wasm isn't free).
 
@@ -287,7 +287,7 @@ TODO
 ## Security Considerations
 <!--All FIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. FIP submissions missing the "Security Considerations" section will be rejected. A FIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
 
-This FIP primarily aims to increase the security of the FVM and guard against malicious and/or buggy wasm actors. However, as with any code:
+This FIP primarily aims to increase the security of the FVM and guard against malicious and/or buggy Wasm actors. However, as with any code:
 
 1. This FIP increases the complexity of the protocol, potentially introducing bugs.
 2. This FIP proposes algorithms to parse potentially user-specified data. If the parsing algorithms and gas costs are not carefully designed/implemented, this could introduce an attack vector.

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -262,7 +262,7 @@ We made this choice for a few reasons:
 
 To highlight this point:
 
-1. The DagCBOR spec has been tweaked _many_ times and I have little confidence that it won't change again in the future.
+1. The DagCBOR spec has been tweaked _many_ times and may change again in the future.
 2. The validation rules are [complicated](https://github.com/ipld/ipld/blob/master/specs/codecs/dag-cbor/spec.md#strictness).
 3. Most DagCBOR implementations _don't_ (or haven't until recently) correctly implemented this spec.
 

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -260,6 +260,14 @@ We made this choice for a few reasons:
 1. Performance. Fully validating CBOR would require validating UTF-8 (walking all strings byte by byte), map key order, etc.
 2. Security. The validation logic would become a part of the spec. Any deviation from said validation logic in any client implementation would cause forks. Any bug would either reject valid blocks or accept invalid blocks (betraying the user's expectation that all blocks in the state-tree are fully validated CBOR).
 
+To highlight this point:
+
+1. The DagCBOR spec has been tweaked _many_ times and I have little confidence that it won't change again in the future.
+2. The validation rules are [complicated](https://github.com/ipld/ipld/blob/master/specs/codecs/dag-cbor/spec.md#strictness).
+3. Most DagCBOR implementations _don't_ (or haven't until recently) correctly implemented this spec.
+
+So, instead, we went for a small but easily verifiable implementation that can be concisely specified with no strange edge-cases and/or exceptions.
+
 ## Backwards Compatibility
 <!--All FIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The FIP must explain how the author proposes to deal with these incompatibilities. FIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
 

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -273,7 +273,7 @@ This is a necessary step towards allowing arbitrary Wasm/IPLD actors.
 ## Implementation
 <!--The implementations must be completed before any core FIP is given status "Final", but it need not be completed before the FIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
 
-TODO
+https://github.com/filecoin-project/FIPs/pull/763
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -2,7 +2,7 @@
 fip: "<to be assigned>" <!--keep the qoutes around the fip number, i.e: `fip: "0001"`-->
 title: Deterministic State Access
 author: Steven (@stebalien)
-discussions-to: <URL>
+discussions-to: https://github.com/filecoin-project/FIPs/discussions/764
 status: Draft
 type: Technical Core
 created: 2023-07-25

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -1,0 +1,279 @@
+---
+fip: "<to be assigned>" <!--keep the qoutes around the fip number, i.e: `fip: "0001"`-->
+title: Deterministic State Access
+author: Steven (@stebalien)
+discussions-to: <URL>
+status: Draft
+type: Technical Core
+created: 2023-07-25
+---
+
+## Simple Summary
+
+This FIP brings us a step closer to user-defined WebAssembly actors by introducing deterministic rules defining what "state" (IPLD blocks) an actor is and is not allowed to read. Specifically, this FIP specifies that an actor may only read state "reachable" from:
+
+1. The actor's state-tree.
+2. Parameters passed into the actor from other actors.
+3. Blocks returned to the actor from other actors.
+
+Where "reachable" means that the state can be "reached" by traversing IPLD links (CIDs) from the "roots" listed above.
+
+## Abstract
+
+TODO
+
+## Change Motivation
+
+Currently, built-in actors (but not EVM smart contracts) can read arbitrary data "blocks" (IPLD blocks) out of the Filecoin client's "state" store. Nothing ensures that these blocks are actually a part of the current tipset's state-tree, let alone the executing actor's state-tree. Instead, they could be "garbage" left over from previous tipsets and/or forks.
+
+This is currently "safe" as all built-in actors only access "their" state by traversing links (CIDs) down from their state-tree root. However, if a (not currently allowed) user-defined WebAssembly actor were to try to access a random block _not_ in its state-tree, it could cause the Filecoin network to fork as said block may be present in some client's datastores but not others.
+
+## Specification
+
+This FIP proposes to enforce the existing built-in actor behavior in the FVM itself. That is, actors will be required to traverse CIDs from their state-root when accessing state and will not be able to link to "arbitrary" CIDs not present in their state when writing new blocks.
+
+It does this by introducing a "reachable set", the set of currently "accessible" blocks (specifically, the CIDs of said blocks), and the following two rules:
+
+1. The actor may only read (open) blocks in the reachable set. Blocks [referenced by](#block-analysis) newly opened blocks are added to the reachable set.
+2. The actor may only write (create) blocks that [referenced](#block-analysis) blocks currently in the reachable set. Newly created blocks are added to the reachable set.
+
+This should allow for natural manipulation of IPLD state-trees while preventing an actor from reading arbitrary state.
+
+### Background
+
+#### IPLD API
+
+The FVM's exposes 4 syscalls for reading/writing IPLD state to actors:
+
+1. `ipld::block_create(codec, data) -> handle` registers a new IPLD block with the FVM, returning a block "handle" (similar to a file descriptor).
+2. `ipld::block_open(cid) -> handle` "opens" the IPLD block referenced by the passed CID, returning a handle to the block.
+3. `ipld::block_read(handle, offset, length) -> data` reads data from an open block into the actor's memory.
+4. `ipld::block_link(handle, multihash_code, multihash_length)` creates a CID for the block referenced by the given block "handle", using the specified multihash code and length (currently limited to blake2b-256).
+
+Additionally, it exposes 2 syscalls for manipulating the actor's state-tree itself:
+
+1. `self::set_root(cid)` update's the actor's state-root CID.
+2. `self::root() -> cid` returns the actor's current state-root CID.
+
+Finally, IPLD blocks can be sent between actors by as message parameters/return values (via `send::send`). Such IPLD blocks are sent _by-handle_, not by-cid.
+
+#### Supported IPLD Codecs
+
+The FVM currently supports reading (`ipld::block_open`) and writing (`ipld::block_create`) state with the following IPLD codecs (`SUPPORTED_CODECS`):
+
+1. `Raw` (0x55) -- raw data
+2. `CBOR` (0x51) -- [cbor][cbor]-encoded data
+3. `DagCBOR` (0x71) -- cbor-encoded _linked_ (IPLD) data
+
+Of these codecs, only the last one, `DagCBOR`, can "link" to other objects.
+
+### IPLD Block Link Analysis
+[block-analysis]: #ipld-block-link-analysis
+
+IPLD blocks may link to (reference by CID) IPLD blocks with a [`SUPPORTED_CODECS`](#supported-ipld-codecs) using either either of the following multihash constructions:
+
+1. A 32-byte Blake2b-256 hash (code 0xb220). E.g., a cid of the form `cidv1-CODEC-blake2b256-32-DIGEST`.
+2. A "identity" hash (code 0x0) with up to a 64 byte digest, "inlining" the referenced block into the CID itself.
+
+We will call these "allowed CIDs".
+
+Additionally, FVM block link analysis will ignore CIDs of sealed and unsealed commitments, as long as the multihash _digest_ is less than 64 bytes:
+
+- `FILCommitmentSealed` (0xf102)
+- `FILCommitmentUnsealed` (0xf101)
+
+We will call these "ignored CIDs".
+
+For IPLD block link analysis, we define a function that takes in a codec and an IPLD block, and returns the CIDs of all blocks directly "reachable" (linked from) said block. That is:
+
+```go
+func ListReachable(codec u64, block []byte) ([]Cid, error)
+```
+
+This function will parse the provided block according to the specified codec (see below) and:
+
+1. If it encounters an "allowed CID":
+    1. If the CID uses the identity hash function (inlines a block), this function will not return the CID directly but will instead recursively parse the inlined block.
+    2. Otherwise, this function will emit the CID.
+2. Any "ignored CIDs" will be skiped and ignroed.
+3. Any other CIDs will cause this function to signal an error.
+
+#### Codec: Raw & CBOR
+
+Raw & (non-IPLD) CBOR blocks contain no links and will not be parsed. `ListReachable` will simply return an empty list of CIDs and will never error.
+
+#### Codec: DagCBOR
+
+For DagCBOR, we read the CBOR field-by-field according to the [CBOR specification][cbor] with minimal validation. Importantly, we do not require [canonical CBOR][cbor-canonical] although we _do_ reject [indefinite-length][cbor-indefinite] fields.
+
+We start by setting the expected number of fields to 1. If this number would ever exceed `2^64`, we abort processing the block with an error.
+
+Then, while the expected number of fields is non-zero, we:
+
+1. Charge gas for reading a single CBOR field. XXX
+2. Decrement the expected number of fields by 1.
+3. Read the that CBOR field "header" (major type + immediate value):
+    1. We read one byte where the first 3 bits (0-7) are the major type and the remaining 5 are the additional information.
+    2. If the additional information is in the range 0-23 inclusive, we treat it as the immediate value.
+    3. If the additional information is 24, 25, 26, 27; we read an additional 1, 2, 4, 8 bytes respectively; decode said bytes as a big-endian integer; and treat that as the immediate value. We do not validate that such integers are "minimally encoded" (e.g., 0x1 could be encoded in 8 bytes).
+    4. If the additional information is greater than 27, we treat the CBOR as malformed. Importantly, this means that the FVM will not support [indefinite length][cbor-indefinite] strings, maps, arrays, etc.
+4. If the major type is 0 (integer), 1 (negative integer), or 7 (special), we continue.
+5. If the major type is 2 (byte string) or 3 (string), we seek forward "immediate value" bytes and continue. We do not validate the string's encoding.
+6. If the major type is 4 (array) we add the immediate value to the expected number of fields, and continue.
+7. If the major type is 5 (map) we add two times the immediate value to the expected number of fields, and continue. We do not or restrict the allowed key/value types, nor do we validate the order of keys, nor do we check for duplicates.
+8. If the major type is 6 (tag):
+    1. If the immediate value is 42, we:
+        1. Charge gas for reading a single CID from a CBOR field. XXX
+        2. Read the next CBOR header as described in step 3.
+        3. If the field is not a byte-string, abort with an error.
+        4. If the field does not start with a single 0x0 byte, abort with an error.
+        5. We attempt to parse the rest of the byte-string as a CID with a maximum hash digest size of 64 bytes. If that fails, we abort with an error.
+        6. Finally, we handle the CID per the definition of the `ListReachable` function and continue.
+    2. Otherwise, we add we add 1 to the number of expected fields and continue.
+
+Finally, we abort with an error if either:
+
+1. We reach the end of the block unexpectedly.
+2. The number of expected fields reaches zero before we reach the end of the block.
+
+[cbor-indefinite]: https://datatracker.ietf.org/doc/html/rfc7049#section-2.2
+[cbor-canonical]: https://datatracker.ietf.org/doc/html/rfc7049#section-3.9
+[cbor]: https://datatracker.ietf.org/doc/html/rfc7049
+
+### Reachable Set
+
+Next, we define a "reachable set". This is the set of CIDs that can currently be "opened" by a running actor instance.
+
+Importantly, this set is per-actor-instance, not global. For example, if actor A calls actor B calls back into actor A, there are _three_ distinct "reachable sets", one for each actor invocation.
+
+### `ipld::block_create`
+
+On `ipld::block_create(codec, data) -> handle`, the FVM:
+
+1. Validates that the codec is in the `SUPPORTED_CODECS` set.
+2. Calls `ListReachable(codec, data)` validating that all returned CIDs are currently in the reachable set.
+    1. If this function returns an error, the syscall fails with [`Serialization`][err-serialization].
+    2. If this function returns any CIDs not currently in the reachable set, the syscall fails with [`NotFound`][err-notfound].
+3. Continues to create the block as usual, recording the reachable CIDs alongside the block.
+
+[err-serialization]: https://docs.rs/fvm_sdk/latest/fvm_sdk/sys/enum.ErrorNumber.html#variant.Serialization
+[err-notfound]: https://docs.rs/fvm_sdk/latest/fvm_sdk/sys/enum.ErrorNumber.html#variant.Serialization
+
+### `ipld::block_open`
+
+On `ipld::block_open(cid) -> handle`, the FVM:
+
+1. Validates that the requested CID is in the reachable set.
+2. Loads the block from the client's blockstore.
+3. Calls `ListReachable` on the newly opened block, adding the referenced CIDs to the reachable set.
+
+NOTE: The CID must be blake2b-256, not an identity hash. Actors must handle blocks inlined into identity hashes internally as said CIDs are _not_ tracked in the reachable set.
+
+### `ipld::block_link`
+
+On `ipld::block_link(handle, hash_code, hash_len) -> cid`, the FVM:
+
+1. Validates that the handle references an open block and that the hash code/len are exactly blake2b-256 and 32 respectively.
+2. Puts the block into the client's blockstore (or, at least, a write buffer for said blockstore).
+3. Adds the newly created CID to the reachable set.
+
+### `self::root`
+
+On `self::root() -> cid`, the FVM:
+
+1. Adds the root CID to the reachable set.
+2. Returns the root CID.
+
+### `self::set_root`
+
+On `self::set_root(cid)`, the FVM:
+
+1. Validates that the cid is in the reachable set.
+2. Updates the actor's state-root.
+
+NOTE: The root CID _must_ be a blake2b-256 CID, not an identity-hashed inlined block.
+
+### `send::send`
+
+On `send::send(..., parameters_handle, ...) -> (..., return_handle, ...)`, the FVM:
+
+1. Validates that `parameters_handle` is a valid IPLD block handle.
+2. Copies the referenced block into the receiving actor's open block table.
+3. Adds the CIDs reachable from the sent (parameters) block to the receiving actor's reachable set. This operation requires no additional parsing as the reachable CIDs are already recorded alongside the block.
+4. Invokes the receiving actor.
+5. On return, copies the returned block into the caller's open block table.
+6. Adds the CIDs reachable from the returned block to the caller's reachable set.
+7. Returns to the caller.
+
+## Design Rationale
+
+### Per-Instance v. Per-Message "reachable" Sets
+
+This FIP _could_ have proposed a single "reachable" set maintained across an entire top-level message invocation. In many ways this would have been simpler however:
+
+1. Behavior in some actor A would influence the reachability of IPLD blocks in some unrelated block B just because A was invoked before B.
+2. This FIP is written in such a way to enable future optimizations where temporary IPLD blocks may be garbage collected in-between calls if/when they don't end up linked into the actor's state (potentially leading to significant gas/memory savings). Any form of "global" reachable set would make this kind of optimization impossible.
+
+### Inlined blocks as state-root CIDs
+
+This FIP forbids "inlining" blocks into state-root CIDs as we'd _otherwise_ need to perform IPLD Link Analysis on the inlined block when calling `ipld::set_root`.
+
+### Link Analysis
+
+#### Native v. Wasm
+
+We previously considered performing link analysis in a Wasm module to:
+
+1. Take advantage of our existing Wasm gas accounting rather than manually charging for gas based on the CBOR's structure.
+2. Ensure that all implementations used the exact same wasm parsing and validation logic.
+
+However, this would have increased implementation complexity and introduced additional runtime costs (switching in and out of Wasm isn't free).
+
+Instead, for improved performance and simplicity, we chose to make the CBOR parsing logic as _simple_ as possible, forgoing any validation beyond what was strictly necessary to extract the CIDs from a block. This let us define a simple gas model based solely on the number of CBOR fields and CIDs present in the block.
+
+#### Validation
+
+We chose _not_ to perform extensive CBOR validation when creating new DagCBOR blocks and instead do the minimum validation required to extract links. We only guarantee that all written DagCBOR blocks are correctly structured: have valid CBOR major types and can be traversed, field by field.
+
+We made this choice for a few reasons:
+
+1. Performance. Fully validating CBOR would require validating UTF-8 (walking all strings byte by byte), map key order, etc.
+2. Security. The validation logic would become a part of the spec. Any deviation from said validation logic in any client implementation would cause forks. Any bug would either reject valid blocks or accept invalid blocks (betraying the user's expectation that all blocks in the state-tree are fully validated CBOR).
+
+## Backwards Compatibility
+<!--All FIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The FIP must explain how the author proposes to deal with these incompatibilities. FIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+
+This FIP requires a network upgrade to account for changes in the gas model, but it's otherwise backwards compatible and will require no state migration.
+
+## Test Cases
+<!--Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.-->
+
+TODO
+
+## Security Considerations
+<!--All FIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. FIP submissions missing the "Security Considerations" section will be rejected. A FIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
+
+This FIP primarily aims to increase the security of the FVM and guard against malicious and/or buggy wasm actors. However, as with any code:
+
+1. This FIP increases the complexity of the protocol, potentially introducing bugs.
+2. This FIP proposes algorithms to parse potentially user-specified data. If the parsing algorithms and gas costs are not carefully designed/implemented, this could introduce an attack vector.
+
+## Incentive Considerations
+<!--All FIPs must contain a section that discusses the incentive implications/considerations relative to the proposed change. Include information that might be important for incentive discussion. A discussion on how the proposed change will incentivize reliable and useful storage is required. FIP submissions missing the "Incentive Considerations" section will be rejected. An FIP cannot proceed to status "Final" without a Incentive Considerations discussion deemed sufficient by the reviewers.-->
+
+This FIP will _slightly_ increase the gas costs of reading/writing state (due to the IPLD link analysis). However, it is not expected that these costs will be significant: A single IPLD read costs a around 200k gas while link analysis is expected to cost tens of gas per field.
+
+However, further benchmarking will be done before this FIP is considered final.
+
+## Product Considerations
+<!--All FIPs must contain a section that discusses the product implications/considerations relative to the proposed change. Include information that might be important for product discussion. A discussion on how the proposed change will enable better storage-related goods and services to be developed on Filecoin. FIP submissions missing the "Product Considerations" section will be rejected. An FIP cannot proceed to status "Final" without a Product Considerations discussion deemed sufficient by the reviewers.-->
+
+This is a necessary step towards allowing arbitrary Wasm/IPLD actors.
+
+## Implementation
+<!--The implementations must be completed before any core FIP is given status "Final", but it need not be completed before the FIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
+
+TODO
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -99,7 +99,7 @@ IPLD blocks may link to (reference by CID) IPLD blocks with a [`SUPPORTED_CODECS
 
 We will call these "allowed CIDs".
 
-Additionally, FVM block link analysis will ignore CIDs of sealed and unsealed commitments, as long as the multihash _digest_ is less than 64 bytes:
+Additionally, FVM block link analysis will ignore CIDs of sealed and unsealed commitments, as long as the multihash _digest_ is less than 64 bytes. These CIDs already existing the Filecoin state-tree, but the data they refer to (sectors and pieces) aren't considered to be a part of the state-tree itself.
 
 - `FILCommitmentSealed` (0xf102)
 - `FILCommitmentUnsealed` (0xf101)

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -41,6 +41,8 @@ This should allow for natural manipulation of IPLD state-trees while preventing 
 
 ### Background
 
+This section describes the FVM as it exists today. For more context and history, you may want to read about the [IPLD memory model](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0030.md#ipld-memory-model).
+
 #### IPLD API
 
 The FVM's exposes 4 syscalls for reading/writing IPLD state to actors:

--- a/FIPS/fip-XXXX.md
+++ b/FIPS/fip-XXXX.md
@@ -128,11 +128,11 @@ For DagCBOR, we read the CBOR field-by-field according to the [CBOR specificatio
 
 We start by setting the expected number of fields to 1. If this number would ever exceed `2^64`, we abort processing the block with an error.
 
-Then, while the expected number of fields is non-zero, we:
+Then, while the expected number of fields is non-zero (and we are not out of gas), we:
 
 1. Charge gas (`ipld_cbor_scan_per_field`) for reading a single CBOR field.
 2. Decrement the expected number of fields by 1.
-3. Read the that CBOR field "header" (major type + immediate value):
+3. Read the CBOR field "header" (major type + immediate value):
     1. We read one byte where the first 3 bits (0-7) are the major type and the remaining 5 are the additional information.
     2. If the additional information is in the range 0-23 inclusive, we treat it as the immediate value.
     3. If the additional information is 24, 25, 26, 27; we read an additional 1, 2, 4, 8 bytes respectively; decode said bytes as a big-endian integer; and treat that as the immediate value. We do not validate that such integers are "minimally encoded" (e.g., 0x1 could be encoded in 8 bytes).


### PR DESCRIPTION
This FIP brings us a step closer to user-defined WebAssembly actors by introducing deterministic rules defining what "state" (IPLD blocks) an actor is and is not allowed to read. Specifically, this FIP specifies that an actor may only read state "reachable" from:

1. The actor's state-tree.
2. Parameters passed into the actor from other actors.
3. Blocks returned to the actor from other actors.

Where "reachable" means that the state can be "reached" by traversing IPLD links (CIDs) from the "roots" listed above.

Discussions: https://github.com/filecoin-project/FIPs/discussions/764
WIP Implementation: https://github.com/filecoin-project/ref-fvm/pull/1824