### PR TITLE
PR template with some guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## Are you drafting a new FIP?
+Please follow these guidelines to help ensure that your proposal is set up for success in the governance process,
+and ease the burden on the FIP editors.
+
+### Start a discussion first
+Changes to the Filecoin core protocol start with open discussion.
+Please open a new discussion topic in the FIPs repository discussion board and outline you motivation and proposal,
+then come back in a few days or weeks to submit your draft FIP.
+
+Don't just paste your FIP draft into a discussion topic.
+The FIP format is suitable for specifying a concrete protocol change for implementation, 
+but your discussion post should describe the background and problem to be solved,
+outline a range of approaches and their tradeoffs, and invite participants to explore other solutions.
+
+Historically, failing to gain some community buy-in before submitting a FIP has often resulted in 
+rejected FIPs and much wasted effort.
+
+### Please use the template
+Please draft your FIP by starting with an appropriate template file from templates directory.
+Do not significantly change the header table format or section headings.
+
+### Don't claim a FIP number
+FIP numbers are allocated by the FIP editors when a draft is ready to be merged into the master branch.
+The editors coordinate to ensure allocations to in-flight drafts don't collide.
+Please do not allocate yourself a FIP number.
+
+Name your file `fip-my_draft_title.md` (replacing the suffix with an abbreviated title)
+and leave "to be assigned" for the FIP number in the header table.
+A FIP editor will either inform you of the appropriate number, or insert it themselves when merging.
+
+### Please add your FIP to the README
+The top-level README.md file contains a table of all FIPs.
+Please add yours there in the same PR that adds the FIP draft itself.
+Use XXXX for the FIP number until it is assigned by an editor.
+
+### Delete this guidance and describe your FIP
+If you've followed the guidance above and are ready to submit your FIP draft,
+please delete this text and replace it with a copy of the _Abstract_ from your draft, 
+and a link to the relevant discussion forum topic.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,12 @@
 ## Are you drafting a new FIP?
-Please follow these guidelines to help ensure that your proposal is set up for success in the governance process,
-and ease the burden on the FIP editors.
+Please follow these guidelines to help ensure that your proposal is set up for success in the governance process.
 
-### Start a discussion first
-Changes to the Filecoin core protocol start with open discussion.
-Please open a new discussion topic in the FIPs repository discussion board and outline you motivation and proposal,
-then come back in a few days or weeks to submit your draft FIP.
+### Open a discussion topic
+Changes to the Filecoin core protocol proceed through open discussion.
+Please open a new discussion topic in the FIPs repository discussion board and outline you motivation and proposal.
 
-Don't just paste your FIP draft into a discussion topic.
 The FIP format is suitable for specifying a concrete protocol change for implementation, 
-but your discussion post should describe the background and problem to be solved,
+but your discussion post should describe more of the background and problem to be solved,
 outline a range of approaches and their tradeoffs, and invite participants to explore other solutions.
 
 Historically, failing to gain some community buy-in before submitting a FIP has often resulted in 
@@ -34,6 +31,6 @@ Please add yours there in the same PR that adds the FIP draft itself.
 Use XXXX for the FIP number until it is assigned by an editor.
 
 ### Delete this guidance and describe your FIP
-If you've followed the guidance above and are ready to submit your FIP draft,
+Once you've followed the guidance above and are ready to submit your FIP draft,
 please delete this text and replace it with a copy of the _Abstract_ from your draft, 
 and a link to the relevant discussion forum topic.

--- a/templates/template.md
+++ b/templates/template.md
@@ -1,7 +1,7 @@
 ---
 fip: "<to be assigned>" <!--keep the qoutes around the fip number, i.e: `fip: "0001"`-->
 title: <FIP title>
-author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
+author: "<a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>"
 discussions-to: <URL>
 status: Draft
 type: <Technical (Core, Networking, Interface, Informational)  | Organizational | Recovery | FRC>


### PR DESCRIPTION
This PR proposed a PR template, which GitHub will auto-fill in the description field of any new PRs ([docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates)). It contains some guidance that I've frequently found myself giving FIP authors after they have already submitted their PR.

@filecoin-project/fips-editors I'd welcome thoughts about anything else that we should say here.