### PR TITLE
Set FIP-0047 status to Superseded

### DIFF
--- a/FIPS/fip-0047.md
+++ b/FIPS/fip-0047.md
@@ -3,7 +3,7 @@ fip: "0047"
 title: Proof Expiration & PoRep Security Policy
 author: Jakub Sztandera (@Kubuxu), Irene Giacomelli (@irenegia), Alex North (@anorth), Luca Nizzardo (@lucaniz)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/415
-status: Accepted
+status: Superseded by FIP-0067
 type: Technical
 category: Core
 created: 2022-08-31

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This improvement protocol helps achieve that objective for all members of the Fi
 |[0044](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0044.md)   | Standard Authentication Method for Actors | FIP  |@arajasek, @anorth |Final  |
 |[0045](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0045.md)   | De-couple verified registry from markets | FIP  |@anorth, @zenground0 |Final  |
 |[0046](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0046.md)   | Fungible token standard | FRC  |@anorth, @jsuresh, @alexytsu |Draft  |
-|[0047](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0047.md)   | Proof Expiration & PoRep Security Policy | FIP  |@Kubuxu, @irenegia, @anorth |Accepted  |
+|[0047](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0047.md)   | Proof Expiration & PoRep Security Policy | FIP  |@Kubuxu, @irenegia, @anorth | Superseded  |
 |[0048](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0048.md)   | f4 Address Class | FIP  |@stebalien, @mriise, @raulk | Final  |
 |[0049](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0049.md)   | Actor Events | FIP  |@stebalien, @raulk | Final  |
 |[0050](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0050.md)   | API Between User-Programmed Actors and Built-In Actors | FIP  |@anorth, @arajasek | Final  |


### PR DESCRIPTION
The letter of FIP-0001 says that the replacement FIP should be `Final` before this status can be set, but it's misleading for FIP-0047 to be continually advertised as Accepted and ready for implementation. We're never going to implement it. I would be just as happy for this to become `Rejected` or `WeChangedOurMind`.

We can defer merging this status change if desired.