### PR TITLE
frc(0069): change v2 piece multihashes to enable arbitrarily sized data

### DIFF
--- a/FRCs/frc-0069.md
+++ b/FRCs/frc-0069.md
@@ -77,7 +77,11 @@ A tuple of (v1 Piece CID, Piece size) can be converted into a valid v2 Piece CID
 ## Test Cases
 
 Take data of size 127*4 bytes where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, and the last 127 are 3. The v1 piece CID of this data would be `baga6ea4seaqes3nobte6ezpp4wqan2age2s5yxcatzotcvobhgcmv5wi2xh5mbi`. The multihash-based piece CID would be `bafkzcibcaaces3nobte6ezpp4wqan2age2s5yxcatzotcvobhgcmv5wi2xh5mbi`. With a base16 multibase this would be `f01559120220004496dae0cc9e265efe5a006e80626a5dc5c409e5d3155c13984caf6c8d5cfd605` or equivalently (`(multibase = f) | (CIDv1 prefix = 0x01) | (Raw codec = 0x55) | (fr32-sha2-256-trunc254-padded-binary-tree multihash encoded varint = 0x9120) | (length of digest = 0x22) | (amount of data padding = 0x00) | (tree height = 0x04) | (underlying hash digest = 496...605)`)
+Take payload of size 0 bytes. There MUST be `127` bytes of padding. The v2 piece CID MUST be `bafkzcibcp4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy`.
 
+Take payload of 127 bytes where all bytes are 0. There MUST be `0` bytes of padding. The hight MUST be `2`. The v2 piece CID MUST be `bafkzcibcaabdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy`.
+
+Take payload of 128 bytes where all bytes are 0. There MUST be `126` bytes of padding. The height MUST be `3`. The v2 piece CID MUST be `bafkzcibcpybwiktap34inmaex4wbs6cghlq5i2j2yd2bb2zndn5ep7ralzphkdy`
 Given the piece CID v1 of the empty 32 GiB piece (i.e. 32 * 2^30 * 127/128 bytes of zeros)`baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq` the corresponding mutlihash piece CID would be `bafkzcibcaapao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq`
 
 Given the piece CID v1 of the empty 64 GiB piece (i.e. 64 * 2^30 * 127/128 bytes of zeros)`baga6ea4seaqomqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq` the corresponding piece mutlihash piece CID would be `bafkzcibcaap6mqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq`

--- a/FRCs/frc-0069.md
+++ b/FRCs/frc-0069.md
@@ -43,12 +43,11 @@ The digest for the multihash is a variable number of bytes.
 It can be roughly described as `uvarint padding | uint8 height | 32 byte root data` where `|` means concatenation.
 
 - The first bytes are a [uvarint](https://github.com/multiformats/unsigned-varint) of the number of bytes needed to pad the underlying data such that after FR32 padding it will be a full binary tree
-    - If the data is < 127 bytes then it is padded to 127 bytes. For example, if the data is of size 12 the padding will be `127-12 = 115` (TODO: Is this necessary or would even 32 bytes be ok?)
+    - If the data is < 127 bytes then it is padded to 127 bytes. For example, if the data is of size 12 the padding will be `127-12 = 115` 
     - For example, if the data is of size 254 (i.e. 2^i * 127/128, where i is a positive integer >= 7) then this will be 0
     - For example, if the data is of size 256 then the padding is `508-256=252`
     - Note: because the unsigned-varint spec currently has a maximum representable size of 2^63-1 (and 9 bytes to represent the varint) this puts a cap on the maximum size of data representable by this multihash as well
-    - Note: because this is padding data it must be less than the size of the underlying data
-       - (TODO: this is not true for data less than 64 bytes if padding up to 127)
+    - Note: because this is padding data it must be less than the size of the underlying data (with the exception of data less than 127 bytes which is always padded up to 127 bytes)
 - The next byte defines the height of the tree
     - For example if the first byte is 0 the tree is a single 32-byte leaf
     - Similarly, if the first byte is 30 then the tree is 30 levels deep which, since the leaves must be 32 bytes, represents a piece of size 32*2^30 bytes = 32GiB. 

--- a/FRCs/frc-0069.md
+++ b/FRCs/frc-0069.md
@@ -12,7 +12,7 @@ created: 2023-07-26
 
 ## Simple Summary
 
-Introduces an alternative CID representation for the FR32 padded sha256-trunc254-padded binary merkle trees used in Filecoin Piece Commitments (i.e. CommP). In it we use the [Raw codec](https://github.com/multiformats/multicodec/blob/566eaf857a9d20573d3910221db7b34d98e8a0fc/table.csv#L41) and a new [sha2-256-trunc254-padded-binary-tree multihash (or piece multihash)](https://link.tld) rather than the [Fil-commitment-unsealed codec](https://github.com/multiformats/multicodec/blob/566eaf857a9d20573d3910221db7b34d98e8a0fc/table.csv#L517) and the [sha2-256-trunc254-padded multihash](https://github.com/multiformats/multicodec/blob/566eaf857a9d20573d3910221db7b34d98e8a0fc/table.csv#L149).
+Introduces an alternative CID representation for the FR32 padded sha256-trunc254-padded binary merkle trees used in Filecoin Piece Commitments (i.e. CommP). In it we use the [Raw codec](https://github.com/multiformats/multicodec/blob/566eaf857a9d20573d3910221db7b34d98e8a0fc/table.csv#L41) and a new [sha2-256-trunc254-padded-binary-tree multihash (or piece multihash)](https://github.com/multiformats/multicodec/pull/331) rather than the [Fil-commitment-unsealed codec](https://github.com/multiformats/multicodec/blob/566eaf857a9d20573d3910221db7b34d98e8a0fc/table.csv#L517) and the [sha2-256-trunc254-padded multihash](https://github.com/multiformats/multicodec/blob/566eaf857a9d20573d3910221db7b34d98e8a0fc/table.csv#L149).
 
 
 ## Abstract
@@ -24,7 +24,7 @@ For example, in much of the relevant portions of the Filecoin spec and lotus' Go
 
 This makes it much more natural to work with new concepts like [Deal Aggregates](https://pkg.go.dev/github.com/filecoin-project/go-data-segment@v0.0.0-20230605095649-5d01fdd3e4a1/datasegment#NewAggregate), as proposed in [FRC-0058](https://github.com/filecoin-project/FIPs/blob/7e499523c9c7ed2c48c6a36967f7f011cee1fefd/FRCs/frc-0058.md).
 
-To resolve this we introduce a new multihash type [fr32-sha2-256-trunc254-padded-binary-tree multihash](https://link.tld) which combines the root hash with the tree height and the amount of padding of the data with zeros such that the result is a full and balanced binary tree after the fr32 padding is applied. If this multihash were to be used to reference the full piece as understood by the Filecoin on-chain consensus mechanism, this would involve the special case where the padding is zero is used.
+To resolve this we introduce a new multihash type [fr32-sha2-256-trunc254-padded-binary-tree multihash](https://github.com/multiformats/multicodec/pull/331) which combines the root hash with the tree height and the amount of padding of the data with zeros such that the result is a full and balanced binary tree after the fr32 padding is applied. If this multihash were to be used to reference the full piece as understood by the Filecoin on-chain consensus mechanism, this would involve the special case where a padding of zero is used.
 
 ## Specification
 
@@ -36,18 +36,25 @@ A CIDv1 requires a:
 
 The core component introduce in this specification is a new multihash type fr32-sha2-256-trunc254-padded-binary-tree multihash.
 
-The multihash code for this type is 0x1011 as identifier in the [multicodec code table](https://link.tld).
+The multihash code for this type is 0x1011 as identified in the [multicodec code table](https://github.com/multiformats/multicodec/pull/331).
 
 The digest for the multihash is a variable number of bytes.
-- The first byte defines the height of the tree
-    - For example if the first byte is 0 the tree is a single 32-byte leaf
-    - Similarly, if the first byte is 30 then the tree is 30 levels deep which, since the leaves must be 32 bytes, represents a piece of size 32*2^30 bytes = 32GiB.
-- The next bytes are a [uvarint](https://github.com/multiformats/unsigned-varint) of the number of bytes needed to pad the underlying data such that after FR32 padding it will be a full binary tree
+
+It can be roughly described as `uvarint padding | uint8 height | 32 byte root data` where `|` means concatenation.
+
+- The first bytes are a [uvarint](https://github.com/multiformats/unsigned-varint) of the number of bytes needed to pad the underlying data such that after FR32 padding it will be a full binary tree
     - If the data is < 127 bytes then it is padded to 127 bytes. For example, if the data is of size 12 the padding will be `127-12 = 115` (TODO: Is this necessary or would even 32 bytes be ok?)
     - For example, if the data is of size 254 (i.e. 2^i * 127/128, where i is a positive integer >= 7) then this will be 0
     - For example, if the data is of size 256 then the padding is `508-256=252`
     - Note: because the unsigned-varint spec currently has a maximum representable size of 2^63-1 (and 9 bytes to represent the varint) this puts a cap on the maximum size of data representable by this multihash as well
-    - Note: because this is padding data it must be less than the size of the underlying data 
+    - Note: because this is padding data it must be less than the size of the underlying data
+       - (TODO: this is not true for data less than 64 bytes if padding up to 127)
+- The next byte defines the height of the tree
+    - For example if the first byte is 0 the tree is a single 32-byte leaf
+    - Similarly, if the first byte is 30 then the tree is 30 levels deep which, since the leaves must be 32 bytes, represents a piece of size 32*2^30 bytes = 32GiB. 
+- The last 32 bytes are the value at the root of the binary tree
+
+Note: This structure is such that the last 33 bytes of the multihash are `uint 8 height | 32 byte root data` which is the data that the proofs underlying Filecoin consensus can attest to (i.e. the proofs don't know how much of the padding is padding vs zeros that are part of the user data).
 
 ### Raw codec
 
@@ -70,17 +77,17 @@ A tuple of (v1 Piece CID, Piece size) can be converted into a valid v2 Piece CID
 
 ## Test Cases
 
-Take data of size 127*4 bytes where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, and the last 127 are 3. The v1 piece CID of this data would be `baga6ea4seaqes3nobte6ezpp4wqan2age2s5yxcatzotcvobhgcmv5wi2xh5mbi`. The multihash-based piece CID would be `bafkzcibcaqaes3nobte6ezpp4wqan2age2s5yxcatzotcvobhgcmv5wi2xh5mbi`. With a base16 multibase this would be `f01559120220400496dae0cc9e265efe5a006e80626a5dc5c409e5d3155c13984caf6c8d5cfd605` or equivalently (`(multibase = f) | (CIDv1 prefix = 0x01) | (Raw codec = 0x55) | (fr32-sha2-256-trunc254-padded-binary-tree multihash encoded varint = 0x9120) | (length of digest = 0x22) | (tree height = 0x04) | (amount of data padding = 0x00) | (underlying hash digest = 496...605)`)
+Take data of size 127*4 bytes where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, and the last 127 are 3. The v1 piece CID of this data would be `baga6ea4seaqes3nobte6ezpp4wqan2age2s5yxcatzotcvobhgcmv5wi2xh5mbi`. The multihash-based piece CID would be `bafkzcibcaaces3nobte6ezpp4wqan2age2s5yxcatzotcvobhgcmv5wi2xh5mbi`. With a base16 multibase this would be `f01559120220004496dae0cc9e265efe5a006e80626a5dc5c409e5d3155c13984caf6c8d5cfd605` or equivalently (`(multibase = f) | (CIDv1 prefix = 0x01) | (Raw codec = 0x55) | (fr32-sha2-256-trunc254-padded-binary-tree multihash encoded varint = 0x9120) | (length of digest = 0x22) | (amount of data padding = 0x00) | (tree height = 0x04) | (underlying hash digest = 496...605)`)
 
-Given the piece CID v1 of the empty 32 GiB piece (i.e. 32 * 2^30 * 127/128 bytes of zeros)`baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq` the corresponding mutlihash piece CID would be `bafkzcibcdyaao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq`
+Given the piece CID v1 of the empty 32 GiB piece (i.e. 32 * 2^30 * 127/128 bytes of zeros)`baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq` the corresponding mutlihash piece CID would be `bafkzcibcaapao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq`
 
-Given the piece CID v1 of the empty 64 GiB piece (i.e. 64 * 2^30 * 127/128 bytes of zeros)`baga6ea4seaqomqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq` the corresponding piece mutlihash piece CID would be `bafkzcibcd4aomqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq`
+Given the piece CID v1 of the empty 64 GiB piece (i.e. 64 * 2^30 * 127/128 bytes of zeros)`baga6ea4seaqomqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq` the corresponding piece mutlihash piece CID would be `bafkzcibcaap6mqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq`
 
 Take data of size 127*8 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining `127*4` bytes are 0. There is no padding so the v1 piece CID would be `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` and the v2 would be `bafkzcibcauan42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa`.
 
-Take data of size 128*4 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining 127+4 bytes are 0. There is `377` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibdax4qfxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
+Take data of size 128*4 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining 127+4 bytes are 0. There is `377` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibd7ebalxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
 
-Take the data above and append one more zero (i.e. 127 0s, 127 1s, 127 2s, 127 3s, 132 0s). There are `376` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibdax4afxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
+Take the data above and append one more zero (i.e. 127 0s, 127 1s, 127 2s, 127 3s, 132 0s). There are `376` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibd7abalxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
 
 ## Security Considerations
 Does not impact core Filecoin security.

--- a/FRCs/frc-0069.md
+++ b/FRCs/frc-0069.md
@@ -24,7 +24,7 @@ For example, in much of the relevant portions of the Filecoin spec and lotus' Go
 
 This makes it much more natural to work with new concepts like [Deal Aggregates](https://pkg.go.dev/github.com/filecoin-project/go-data-segment@v0.0.0-20230605095649-5d01fdd3e4a1/datasegment#NewAggregate), as proposed in [FRC-0058](https://github.com/filecoin-project/FIPs/blob/7e499523c9c7ed2c48c6a36967f7f011cee1fefd/FRCs/frc-0058.md).
 
-To resolve this we introduce a new multihash type [fr32-sha2-256-trunc254-padded-binary-tree multihash](https://link.tld) which combines the root hash with the tree height (which in the full and balanced binary trees used in Piece commitments is equivalent to size).
+To resolve this we introduce a new multihash type [fr32-sha2-256-trunc254-padded-binary-tree multihash](https://link.tld) which combines the root hash with the tree height and the amount of padding of the data with zeros such that the result is a full and balanced binary tree after the fr32 padding is applied. For Piece commitments the amount of added padding is zero.
 
 ## Specification
 
@@ -38,9 +38,16 @@ The core component introduce in this specification is a new multihash type fr32-
 
 The multihash code for this type is 0x1011 as identifier in the [multicodec code table](https://link.tld).
 
-The digest for the multihash is 33 bytes. The first byte defines the height of the tree. For example if the first byte is 0 the tree is a single 32-byte leaf. Similarly, if the first byte is 30 then the tree is 30 levels deep which, since the leaves must be 32 bytes, represents a piece of size 32*2^30 bytes = 32GiB.
-
-Note that the data processed by this hash function must be of size `N = 2^i * 127/128` where `i` is any positive integer >=7 and <=255. This means that the minimum hashable amount of data is 127 bytes.
+The digest for the multihash is a variable number of bytes.
+- The first byte defines the height of the tree
+    - For example if the first byte is 0 the tree is a single 32-byte leaf
+    - Similarly, if the first byte is 30 then the tree is 30 levels deep which, since the leaves must be 32 bytes, represents a piece of size 32*2^30 bytes = 32GiB.
+- The next bytes are a [uvarint](https://github.com/multiformats/unsigned-varint) of the number of bytes needed to pad the underlying data such that after FR32 padding it will be a full binary tree
+    - If the data is < 127 bytes then it is padded to 127 bytes. For example, if the data is of size 12 the padding will be `127-12 = 115` (TODO: Is this necessary or would even 32 bytes be ok?)
+    - For example, if the data is of size 254 (i.e. 2^i * 127/128, where i is a positive integer >= 7) then this will be 0
+    - For example, if the data is of size 256 then the padding is `508-256=252`
+    - Note: because the unsigned-varint spec currently has a maximum representable size of 2^63-1 (and 9 bytes to represent the varint) this puts a cap on the maximum size of data representable by this multihash as well
+    - Note: because this is padding data it must be less than the size of the underlying data 
 
 ### Raw codec
 
@@ -63,11 +70,17 @@ A tuple of (v1 Piece CID, Piece size) can be converted into a valid v2 Piece CID
 
 ## Test Cases
 
-Take data of size 127*4 bytes where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, and the last 127 are 3. The v1 piece CID of this data would be `baga6ea4seaqes3nobte6ezpp4wqan2age2s5yxcatzotcvobhgcmv5wi2xh5mbi`. The multihash-based piece CID would be `bafkzcibbarew3lqmzhrgl37fuadoqbrguxofyqe6luyvlqjzqtfpnsgvz7lak`. With a base16 multibase this would be `f015591202104496dae0cc9e265efe5a006e80626a5dc5c409e5d3155c13984caf6c8d5cfd605` or equivalently (`(multibase = f) | (CIDv1 prefix = 0x01) | (Raw codec = 0x55) | (fr32-sha2-256-trunc254-padded-binary-tree multihash encoded varint = 0x9120) | (length of digest = 0x21) | (tree height = 0x04) | (underlying hash digest = 496...605)`)
+Take data of size 127*4 bytes where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, and the last 127 are 3. The v1 piece CID of this data would be `baga6ea4seaqes3nobte6ezpp4wqan2age2s5yxcatzotcvobhgcmv5wi2xh5mbi`. The multihash-based piece CID would be `bafkzcibcaqaes3nobte6ezpp4wqan2age2s5yxcatzotcvobhgcmv5wi2xh5mbi`. With a base16 multibase this would be `f01559120220400496dae0cc9e265efe5a006e80626a5dc5c409e5d3155c13984caf6c8d5cfd605` or equivalently (`(multibase = f) | (CIDv1 prefix = 0x01) | (Raw codec = 0x55) | (fr32-sha2-256-trunc254-padded-binary-tree multihash encoded varint = 0x9120) | (length of digest = 0x22) | (tree height = 0x04) | (amount of data padding = 0x00) | (underlying hash digest = 496...605)`)
 
-Given the piece CID v1 of the empty 32 GiB piece `baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq` the corresponding mutlihash piece CID would be `bafkzcibbdydx4x66gxcqveyduviaty2jrjhl5x7ttrbloefxgdmoy6whv6td4`
+Given the piece CID v1 of the empty 32 GiB piece (i.e. 32 * 2^30 * 127/128 bytes of zeros)`baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq` the corresponding mutlihash piece CID would be `bafkzcibcdyaao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq`
 
-Given the piece CID v1 of the empty 64 GiB piece `baga6ea4seaqomqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq` the corresponding piece mutlihash piece CID would be `bafkzcibbd7teabngx7rxo6ktxcww56j7b7fbasnsaqlfj4vech3xaj4zz3hae`
+Given the piece CID v1 of the empty 64 GiB piece (i.e. 64 * 2^30 * 127/128 bytes of zeros)`baga6ea4seaqomqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq` the corresponding piece mutlihash piece CID would be `bafkzcibcd4aomqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq`
+
+Take data of size 127*8 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining `127*4` bytes are 0. There is no padding so the v1 piece CID would be `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` and the v2 would be `bafkzcibcauan42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa`.
+
+Take data of size 128*4 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining 127+4 bytes are 0. There is `377` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibdax4qfxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
+
+Take the data above and append one more zero (i.e. 127 0s, 127 1s, 127 2s, 127 3s, 132 0s). There are `376` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibdax4afxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
 
 ## Security Considerations
 Does not impact core Filecoin security.
@@ -82,7 +95,7 @@ This also enables the use of IPFS-based tooling for moving around Pieces, with t
 
 ## Implementation
 
-- There is a Go implementation in a [fork of go-fil-commcid](https://github.com/filecoin-project/go-fil-commcid/pull/5) which can get merged [upstream](https://github.com/filecoin-project/go-fil-commcid) upon acceptance of the FRC.
+- There is a Go implementation in a [fork of go-fil-commcid](https://github.com/filecoin-project/go-fil-commcid/pull/6) which can get merged [upstream](https://github.com/filecoin-project/go-fil-commcid) upon acceptance of the FRC.
 - There is a JavaScript implementation in https://github.com/web3-storage/data-segment/
 
 ## Copyright

--- a/FRCs/frc-0069.md
+++ b/FRCs/frc-0069.md
@@ -85,9 +85,9 @@ Given the piece CID v1 of the empty 64 GiB piece (i.e. 64 * 2^30 * 127/128 bytes
 
 Take data of size 127*8 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining `127*4` bytes are 0. There is no padding so the v1 piece CID would be `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` and the v2 would be `bafkzcibcauan42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa`.
 
-Take data of size 128*4 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining 127+4 bytes are 0. There is `377` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibd7ebalxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
+Take data of size 128*4 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining 4 bytes are 0. There is `504` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibd7abqlxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
 
-Take the data above and append one more zero (i.e. 127 0s, 127 1s, 127 2s, 127 3s, 132 0s). There are `376` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibd7abalxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
+Take the data above and append one more zero (i.e. 127 0s, 127 1s, 127 2s, 127 3s, 5 0s). There are `503` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibd64bqlxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
 
 ## Security Considerations
 Does not impact core Filecoin security.

--- a/FRCs/frc-0069.md
+++ b/FRCs/frc-0069.md
@@ -49,7 +49,8 @@ It can be roughly described as `uvarint padding | uint8 height | 32 byte root da
     - Note: because the unsigned-varint spec currently has a maximum representable size of 2^63-1 (and 9 bytes to represent the varint) this puts a cap on the maximum size of data representable by this multihash as well
     - Note: because this is padding data it must be less than the size of the underlying data (with the exception of data less than 127 bytes which is always padded up to 127 bytes)
 - The next byte defines the height of the tree
-    - For example if the first byte is 0 the tree is a single 32-byte leaf
+    - For example if the first byte is 0 the tree is a single 32-byte node
+
     - Similarly, if the first byte is 30 then the tree is 30 levels deep which, since the leaves must be 32 bytes, represents a piece of size 32*2^30 bytes = 32GiB. 
 - The last 32 bytes are the value at the root of the binary tree
 

--- a/FRCs/frc-0069.md
+++ b/FRCs/frc-0069.md
@@ -24,7 +24,7 @@ For example, in much of the relevant portions of the Filecoin spec and lotus' Go
 
 This makes it much more natural to work with new concepts like [Deal Aggregates](https://pkg.go.dev/github.com/filecoin-project/go-data-segment@v0.0.0-20230605095649-5d01fdd3e4a1/datasegment#NewAggregate), as proposed in [FRC-0058](https://github.com/filecoin-project/FIPs/blob/7e499523c9c7ed2c48c6a36967f7f011cee1fefd/FRCs/frc-0058.md).
 
-To resolve this we introduce a new multihash type [fr32-sha2-256-trunc254-padded-binary-tree multihash](https://link.tld) which combines the root hash with the tree height and the amount of padding of the data with zeros such that the result is a full and balanced binary tree after the fr32 padding is applied. For Piece commitments the amount of added padding is zero.
+To resolve this we introduce a new multihash type [fr32-sha2-256-trunc254-padded-binary-tree multihash](https://link.tld) which combines the root hash with the tree height and the amount of padding of the data with zeros such that the result is a full and balanced binary tree after the fr32 padding is applied. If this multihash were to be used to reference the full piece as understood by the Filecoin on-chain consensus mechanism, this would involve the special case where the padding is zero is used.
 
 ## Specification
 


### PR DESCRIPTION
This is an alternative building off of #758 that enables piece CIDs that refer to arbitrarily sized data rather than just data of size `N= 2^i * 127/128` where `N` and `i` are integers.

This is option 3 from the FRC Discussion https://github.com/filecoin-project/FIPs/discussions/759#discussioncomment-6554646.

## What this gives us

This means that data of basically any size (there is a maximum of around 2^63) can be represented by a piece CID. As a result:
1. It is possible to reference user data bytes using a piece CID alone (i.e. there's no magic sniffing of zeros or external length metadata required to validate the data)
   - For example, if a 100 MiB CAR file is referenced in a piece aggregate that data could be referenced and verified by CID exactly without having to **also** parse the CAR file to figure out how many zeros are supposed to be at the end of the piece aggregate.
   - For example, if a 6 MiB jpeg was embedded as raw bytes inside of a piece aggregate that jpeg could be referenced loaded and verified directly.
2. It would be possible to create IPLD data structures like UnixFS directories and files that reference piece CID objects
   - This allows existing IPLD tooling to enable referring to groups of piece CIDs and/or mixing piece CID data with other data in ways that have not been previously doable. While the prior proposal would allow embedding a piece CID + the data size (for data that needed zero padding at the end in addition to the fr32 padding) that would not compose with existing formats like UnixFS
   - Note: This capability is not immediately unlocked across the ecosystem because most IPFS implementations are unable to deal with large blocks, however this is an area of active interest as it enables IPFS implementations such as [iroh](https://github.com/n0-computer/iroh) that are heavily dependent on large Blake3 blocks to be compatible with other implementations.
4. Some very common IPFS tooling such as the [IPFS Gateway API](https://specs.ipfs.tech/http-gateways/) (and `ipfs:// URIs) could be used to refer to and load assets (e.g. jpegs, videos, tar files, ...) by their piece CID directly.
   - Note: While their are lots of reasons why piece CIDs are not necessarily as good at representing flat files as using UnixFS with small blocks, a single large blake3 block, the BitTorrent-v2 file format or others there are also reasons why CommP could be useful and this capability is unlocked here.
5. When more generic IPFS tooling for large blocks (e.g. Blake3, SHA2, etc.) comes along (e.g. extending the CAR format to handle large blake3 and sha2 blocks) it will be possible to ship verifiable large CommP blocks without needing separate handling for all the zero padding at the end.

## What it costs us

1. Users may have to understand whether the piece CID they're getting is for data that has been padded (i.e. if someone took chain deal information with padded-size + digest and created a CID out of it) or if it's for data before the padding has been applied.
   - To some extent they need to know this kind of thing anyway and understand both how padding works and handle the processing of CAR files and understand the Filecoin-specific null terminated endings that are implied in the storage formats used in tools like Boost and lotus
2. The CIDs are larger (since the padding information has to be included in the multihash)
3. The implementation is slightly more complicated
4. In this particular iteration (that obeys the unsigned-varint spec) the maximum piece size is smaller (although still in the EiB range so plenty large)

Note: This is true in the current version as well, but by having the multihash do the fr32 padding for us it means we cannot have a v2 piece CID that leverages data in fr32 but doesn't require the padding (while I'm not familiar with the internals here it seems to be indicated by https://spec.filecoin.io/#section-systems.filecoin_files.piece.data-representation that this is possible). Given that AFAIK all data today uses fr32 padding and I've heard of no plans for not requiring the padding this doesn't seem like a loss.

## Outstanding questions

There are some minor questions around formatting tagged in the PR for threaded discussion, but mostly the question is whether there are issues with this feature or if it's sufficiently desirable to move ahead.

Some people who might be interested in review:

@Stebalien + @gozala (you both asked for this 😄),  @ribasushi, @Kubuxu, @willscott, @masih (this seems relevant for your CommPact proposal)