### PR TITLE
FIP-0084: Drop ProveCommitSectors message after ProveCommitSectors2 inclusion

### DIFF
--- a/FIPS/fip-0084.md
+++ b/FIPS/fip-0084.md
@@ -1,6 +1,6 @@
 ---
 
-fip: "<to be assigned>" <!--keep the qoutes around the fip number, i.e: `fip: "0001"`-->
+fip: "0084"
 title:  Remove Storage Miner Actor Method `ProveCommitSectors`  
 author: Jennifer Wang (@jennijuju)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/899
@@ -11,9 +11,11 @@ created: 2023-09-03
 requires: FIP-0076
 ---
 
+# Remove Storage Miner Actor Method `ProveCommitSectors`
+
 ## Simple Summary
 
-Remove *`ProveCommitSector` (method 7)* in favor of `ProveCommitSectors2` and `ProveCommitAggregate`. This change ensures that single PoRep validations and single sector activations are executed synchronously and billed to the caller, instead of being executed asynchronously via a cron call to the actor.
+Remove *`ProveCommitSector` (method 7)* in favor of `ProveCommitSectors3` (method 34) and `ProveCommitAggregate`. This change ensures that single PoRep validations and single sector activations are executed synchronously and billed to the caller, instead of being executed asynchronously via a cron call to the actor.
 
 ## Abstract
 

--- a/FIPS/fip-drop-provecommit1.md
+++ b/FIPS/fip-drop-provecommit1.md
@@ -14,82 +14,61 @@ requires (*optional):  [FIP-0076](https://github.com/filecoin-project/FIPs/blob/
 
 ## Simple Summary
 
-<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the FIP.-->
-
-Deprecate *`ProveCommitSectors` (method 7)* in favour of `ProveCommitSectors2` and `ProveCommitAggregate` to enforce single PoRep validations and single sector activations are synchronously executed and billed to the caller, rather than executed asynchronously via a cron call to the actori.
+Deprecate *`ProveCommitSector` (method 7)* in favor of `ProveCommitSectors2` and `ProveCommitAggregate`. This change ensures that single PoRep validations and single sector activations are executed synchronously and billed to the caller, instead of being executed asynchronously via a cron call to the actor.
 
 ## Abstract
 
-<!--A short (~200 word) description of the technical issue being addressed.-->
-A short (~200 word) description of the technical issue being addressed.
+Currently, `ProveCommitSector` accepts a single PoRep proof for an individual sector, validates the proof, and activates the sector along with the deals inside it via a cron call to the power actor. In contrast, when submitting an aggregated PoRep with `ProveCommitAggregate`, all proof validation and sector activation are executed synchronously and the costs are billed to the caller. This creates an imbalance in the sector activation gas subsidy available to different onboarding methods, and also adds unnecessary work to unpaid network cron jobs.
 
-Currently, `ProveCommitSectors` takes single PoRep proof for individual sectors, validates the proof and activate the sectors along with the deals inside of the sectors via a cron call to the power actor. By contrast, when submitting an aggregated PoRep, all of the proof validation and sector activation are executed synchronously and billed to the caller. We want to resolve this imbalance in the improper sector activation gas subsidy available to the different onboarding methods, and also removes unnecessary work from unpaid network cron jobs.
-
-To address this issue, we propose to drop `ProveCommitSectors` method after the upgrade that introduces `ProveComitSectors2` ’s inclusion.
+To address this issue, we propose to deprecate the `ProveCommitSector` method after the network upgrade that includes the `ProveCommitSectors2` method, which is planned as part of [FIP-0076 - Direct Data Onboarding](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md) and is expected to be in scope for upcoming network upgrades.
 
 ## Change Motivation
 
-<!--The motivation is critical for FIPs that want to change the Filecoin protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the FIP solves. FIP submissions without sufficient motivation may be rejected outright.-->
+Since the FVM launch, all computations are properly charged and storage providers have started to realize that even below the batch balancer base fee threshold, the per sector commit cost via `ProveCommitAggregate` is higher than `ProveCommitSector`.
 
-Since FVM launch, all computation are properly charged and storage providers started to realize that even below the batch balancer base fee threshold, per sector commit cost via  `ProveCommitAggregate`  is still much higher than `ProveCommitSectors` .
+As @anorth laid out [here](https://github.com/filecoin-project/FIPs/discussions/689#discussioncomment-5680517):
 
-As @anorth laid out [here](https://github.com/filecoin-project/FIPs/discussions/689#discussioncomment-5680517),”We explicitly charge gas (discounted) for the single proof validation when it is submitted, so it’s both bounded and paid for. However, the **state updates associated with sector activation are not metered**, because they execute in cron. The execution cost of this activation varies significantly with the deal content of the sector, but the storage provider doesn’t pay gas for this. On the other hand, aggregated proof validation also activates the sector synchronously, for which the SP pays the gas cost. Thus single-sector onboarding is subsidised relative to aggregation, but aggregation would otherwise efficiently support much higher onboarding rates.”
+> "We explicitly charge gas (discounted) for the single proof validation when it is submitted, so it’s both bounded and paid for. However, the **state updates associated with sector activation are not metered**, because they execute in cron. The execution cost of this activation varies significantly with the deal content of the sector, but the storage provider doesn’t pay gas for this. On the other hand, aggregated proof validation also activates the sector synchronously, for which the SP pays the gas cost. Thus, single-sector onboarding is subsidized relative to aggregation, but aggregation would otherwise efficiently support much higher onboarding rates.”
 
-Thus, we would like to resolve the imbalance in the sector activation and make proof aggregation financially make sense again.
+Thus, we would like to resolve the imbalance in sector activation and make proof aggregation financially sensible again.
 
-This change also removes unnecessary yet expensive sector and deal activation work out of the network cron, in which prevent the network from potential cron blowup in the long term. 
+This change also removes unnecessary yet expensive sector and deal activation work from the network cron, which prevents the network from potential cron blowup in the long term.
 
 ## Specification
 
-<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Filecoin implementations. -->
-
-Drop `ProveCommitSectors` function, https://github.com/filecoin-project/builtin-actors/blob/807630512ba0df9a2d41836f7591c3607ddb0d4f/actors/miner/src/lib.rs#L1775C17-L1828. 
+Drop the `ProveCommitSector` function, https://github.com/filecoin-project/builtin-actors/blob/807630512ba0df9a2d41836f7591c3607ddb0d4f/actors/miner/src/lib.rs#L1775C17-L1828. 
 
 ## Design Rationale
 
-<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
-
-There are other ways to achieve our goal, like modify `ProveCommitSectors` to active sectors and deals asynchronously. However, the required protocol functionality can be achieved by other methods already, so deprecating the `ProveCommitSectors` is the simplest way and also reduce the actor code needs to be maintained.
+There are other ways to achieve our goal, like modifying `ProveCommitSector` to activate sectors and deals asynchronously. However, the required protocol functionality can be achieved by other methods already, so deprecating the `ProveCommitSector` is the simplest way and also reduces the actor code that needs to be maintained.
 
 ## Backwards Compatibility
 
-<!--All FIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The FIP must explain how the author proposes to deal with these incompatibilities. FIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
-
 The deprecation of this method MUST happen after `ProveCommitSectors2` is available in the network and being adapted by the client.  
 
-This proposal requires a network upgrade to deploy the new built-in actor code.****
+This proposal requires a network upgrade to deploy the new built-in actor code.
 
 ## Test Cases
 
-<!--Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.-->
 Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.
 
-Calling `ProveCommitSectors` will fail with ***USR_UNHANDLED_MESSAGE.***
+Calling `ProveCommitSector` will fail with ***USR_UNHANDLED_MESSAGE.***
 
 ## Security Considerations
 
-<!--All FIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. FIP submissions missing the "Security Considerations" section will be rejected. A FIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
-
-This FIP avoids single PoRep proof verification in cron, which reduces the free computations that occupying the network bandwidth  and the possibility of unexpected network performance issue.  
+This FIP avoids single PoRep proof verification in cron, which reduces the free computations that are occupying the network bandwidth and the possibility of unexpected network performance issues.
 
 ## Incentive Considerations
 
-<!--All FIPs must contain a section that discusses the incentive implications/considerations relative to the proposed change. Include information that might be important for incentive discussion. A discussion on how the proposed change will incentivize reliable and useful storage is required. FIP submissions missing the "Incentive Considerations" section will be rejected. An FIP cannot proceed to status "Final" without a Incentive Considerations discussion deemed sufficient by the reviewers.-->
-
-This FIP will enforce storage activation fees to be paid by the callers rather than having imbalanced network subsidy. This means storage providers who only onboard sectors via `ProveCommitSectors` will start to pay for sector proof validation and sector/deal activation, which is a gas cost increase from ~71M to ~196M based on the current implementation. However, the activation cost is expected to be lower with the direct data onboarding flow via `ProveCommitSectors2` method, and storage providers and their data clients may chose to opt-out f05 deal activation, which also means way less gas usage.
+This FIP will enforce storage activation fees to be paid by the callers rather than having an imbalanced network subsidy. This means storage providers who only onboard sectors via `ProveCommitSector` will start to pay for sector proof validation and sector/deal activation, which is a gas cost increase from ~71M to ~196M based on the current implementation. However, the activation cost is expected to be lower with the direct data onboarding flow via the `ProveCommitSectors2` method, and storage providers and their data clients may choose to opt-out of f05 deal activation, which would result in significantly less gas cost.
 
 ## Product Considerations
 
-<!--All FIPs must contain a section that discusses the product implications/considerations relative to the proposed change. Include information that might be important for product discussion. A discussion on how the proposed change will enable better storage-related goods and services to be developed on Filecoin. FIP submissions missing the "Product Considerations" section will be rejected. An FIP cannot proceed to status "Final" without a Product Considerations discussion deemed sufficient by the reviewers.-->
-
-All functionalities of Filecoin remains with this change. 
+All features provided by Filecoin continue to function as expected.
 
 ## Implementation
 
-<!--The implementations must be completed before any core FIP is given status "Final", but it need not be completed before the FIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
-The implementations must be completed before any core FIP is given status "Final", but it need not be completed before the FIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.
-
-Drop `ProveCommitSectors` function, https://github.com/filecoin-project/builtin-actors/blob/807630512ba0df9a2d41836f7591c3607ddb0d4f/actors/miner/src/lib.rs#L1775C17-L1828. 
+The implementation involves dropping the [`ProveCommitSector` function](https://github.com/filecoin-project/builtin-actors/blob/807630512ba0df9a2d41836f7591c3607ddb0d4f/actors/miner/src/lib.rs#L1775C17-L1828). 
 
 ## TODO
 

--- a/FIPS/fip-drop-provecommit1.md
+++ b/FIPS/fip-drop-provecommit1.md
@@ -1,0 +1,100 @@
+---
+
+fip: "<to be assigned>" <!--keep the qoutes around the fip number, i.e: `fip: "0001"`-->
+title:  Deprecate  `ProveCommitSectors`  to Avoid Single PoRep Proof Verification in Cron 
+author: Jennifer Wang (@jennijuju)
+discussions-to: [<URL>](https://github.com/filecoin-project/FIPs/discussions/689)
+status: Draft
+type: Technical 
+category (*only required for Standard Track): Core
+created: 2023-09-03
+requires (*optional):  (currently in Draft https://github.com/filecoin-project/FIPs/pull/804)
+
+---
+
+## Simple Summary
+
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the FIP.-->
+
+Deprecate *`ProveCommitSectors` (method 7)*  in favour of `ProveCommitSectors2` and `ProveCommitAggregate`  to enforce single PoRep validations and single sector activations are  synchronously executed and billed to the caller, rather than executed asynchronously via a cron call to the actor.
+
+## Abstract
+
+<!--A short (~200 word) description of the technical issue being addressed.-->
+A short (~200 word) description of the technical issue being addressed.
+
+Currently, `ProveCommitSectors` takes single PoRep proof for individual sectors, validates the proof and activate the sectors along with the deals inside of the sectors via a cron call to the power actor. By contrast, when submitting an aggregated PoRep, all of the proof validation and sector activation is executed synchronously and billed to the caller. We want to resolve this imbalance in the improper sector activation gas subsidy available to the different onboarding methods, and also removes unnecessary work from unpaid network cron jobs.
+
+To address this issue, we propose to drop `ProveCommitSectors` method the upgrade after `ProveComitSectors2` ’s inclusion.
+
+## Change Motivation
+
+<!--The motivation is critical for FIPs that want to change the Filecoin protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the FIP solves. FIP submissions without sufficient motivation may be rejected outright.-->
+
+Since FVM launch, all computation are properly charged and storage providers started to realize that even below the batch balancer base fee threshold, per sector commit cost via  `ProveCommitAggregate`  is still much higher than `ProveCommitSectors` .
+
+As mentioned by @anorth laid out [here](https://github.com/filecoin-project/FIPs/discussions/689#discussioncomment-5680517),”We explicitly charge gas (discounted) for the single proof validation when it is submitted, so it’s both bounded and paid for. However, the **state updates associated with sector activation are not metered**, because they execute in cron. The execution cost of this activation varies significantly with the deal content of the sector, but the storage provider doesn’t pay gas for this. On the other hand, aggregated proof validation also activates the sector synchronously, for which the SP pays the gas cost. Thus single-sector onboarding is subsidised relative to aggregation, but aggregation would otherwise efficiently support much higher onboarding rates.”
+
+Thus, we would like to resolves the imbalance in the sector activation and make proof aggregation financially make sense again.
+
+This change also removes unnecessary yet expensive sector and deal activation work out of the network cron, in which prevent the network from potential cron blowup in the long term. 
+
+## Specification
+
+<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Filecoin implementations. -->
+
+Drop `ProveCommitSectors` function, https://github.com/filecoin-project/builtin-actors/blob/807630512ba0df9a2d41836f7591c3607ddb0d4f/actors/miner/src/lib.rs#L1775C17-L1828. 
+
+## Design Rationale
+
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
+There are other ways to achieve our goal, like modify `ProveCommitSectors` to active sectors and deals asynchronously. However, the required protocol functionality can be achieved by other methods already, so deprecating the `ProveCommitSectors` is the simplest way and also reduce the actor code needs to be maintained.
+
+## Backwards Compatibility
+
+<!--All FIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The FIP must explain how the author proposes to deal with these incompatibilities. FIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+
+The deprecation of this method MUST happen after `ProveCommitSectors2` is available in the network and being adapted by the client.  
+
+This proposal requires a network upgrade to deploy the new built-in actor code.****
+
+## Test Cases
+
+<!--Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.-->
+Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.
+
+Calling `ProveCommitSectors` will fail with ***USR_UNHANDLED_MESSAGE.***
+
+## Security Considerations
+
+<!--All FIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. FIP submissions missing the "Security Considerations" section will be rejected. A FIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
+
+This FIP avoids single PoRep proof verification in cron, which reduces the free computations that occupying the network bandwidth  and the possibility of unexpected network performance issue.  
+
+## Incentive Considerations
+
+<!--All FIPs must contain a section that discusses the incentive implications/considerations relative to the proposed change. Include information that might be important for incentive discussion. A discussion on how the proposed change will incentivize reliable and useful storage is required. FIP submissions missing the "Incentive Considerations" section will be rejected. An FIP cannot proceed to status "Final" without a Incentive Considerations discussion deemed sufficient by the reviewers.-->
+
+This FIP will enforce storage activation fees to be paid by the callers rather than having imbalanced network subsidy. This means storage providers who only onboard sectors via `ProveCommitSectors` will start to pay for sector proof validation and sector/deal activation, which is a gas cost increase from ~71M to ~196M based on the current implementation. However, the activation cost is expected to be lower with the direct data onboarding flow via `ProveCommitSectors2` method, and storage providers and their data clients may chose to opt-out f05 deal activation, which also means way less gas usage.
+
+## Product Considerations
+
+<!--All FIPs must contain a section that discusses the product implications/considerations relative to the proposed change. Include information that might be important for product discussion. A discussion on how the proposed change will enable better storage-related goods and services to be developed on Filecoin. FIP submissions missing the "Product Considerations" section will be rejected. An FIP cannot proceed to status "Final" without a Product Considerations discussion deemed sufficient by the reviewers.-->
+
+All functionalities of Filecoin remains with this change. 
+
+## Implementation
+
+<!--The implementations must be completed before any core FIP is given status "Final", but it need not be completed before the FIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
+The implementations must be completed before any core FIP is given status "Final", but it need not be completed before the FIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.
+
+Drop `ProveCommitSectors` function, https://github.com/filecoin-project/builtin-actors/blob/807630512ba0df9a2d41836f7591c3607ddb0d4f/actors/miner/src/lib.rs#L1775C17-L1828. 
+
+## TODO
+
+<!--A section that lists any unresolved issues or tasks that are part of the FIP proposal. Examples of these include performing benchmarking to know gas fees, validate claims made in the FIP once the final implementation is ready, etc. A FIP can only move to a “Last Call” status once all these items have been resolved.-->
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/FIPS/fip-drop-provecommit1.md
+++ b/FIPS/fip-drop-provecommit1.md
@@ -8,7 +8,7 @@ status: Draft
 type: Technical 
 category (*only required for Standard Track): Core
 created: 2023-09-03
-requires (*optional):  (currently in Draft https://github.com/filecoin-project/FIPs/pull/804)
+requires (*optional):  [FIP-0076](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md)
 
 ---
 
@@ -16,16 +16,16 @@ requires (*optional):  (currently in Draft https://github.com/filecoin-project/F
 
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the FIP.-->
 
-Deprecate *`ProveCommitSectors` (method 7)*  in favour of `ProveCommitSectors2` and `ProveCommitAggregate`  to enforce single PoRep validations and single sector activations are  synchronously executed and billed to the caller, rather than executed asynchronously via a cron call to the actor.
+Deprecate *`ProveCommitSectors` (method 7)* in favour of `ProveCommitSectors2` and `ProveCommitAggregate` to enforce single PoRep validations and single sector activations are synchronously executed and billed to the caller, rather than executed asynchronously via a cron call to the actori.
 
 ## Abstract
 
 <!--A short (~200 word) description of the technical issue being addressed.-->
 A short (~200 word) description of the technical issue being addressed.
 
-Currently, `ProveCommitSectors` takes single PoRep proof for individual sectors, validates the proof and activate the sectors along with the deals inside of the sectors via a cron call to the power actor. By contrast, when submitting an aggregated PoRep, all of the proof validation and sector activation is executed synchronously and billed to the caller. We want to resolve this imbalance in the improper sector activation gas subsidy available to the different onboarding methods, and also removes unnecessary work from unpaid network cron jobs.
+Currently, `ProveCommitSectors` takes single PoRep proof for individual sectors, validates the proof and activate the sectors along with the deals inside of the sectors via a cron call to the power actor. By contrast, when submitting an aggregated PoRep, all of the proof validation and sector activation are executed synchronously and billed to the caller. We want to resolve this imbalance in the improper sector activation gas subsidy available to the different onboarding methods, and also removes unnecessary work from unpaid network cron jobs.
 
-To address this issue, we propose to drop `ProveCommitSectors` method the upgrade after `ProveComitSectors2` ’s inclusion.
+To address this issue, we propose to drop `ProveCommitSectors` method after the upgrade that introduces `ProveComitSectors2` ’s inclusion.
 
 ## Change Motivation
 
@@ -33,9 +33,9 @@ To address this issue, we propose to drop `ProveCommitSectors` method the upgrad
 
 Since FVM launch, all computation are properly charged and storage providers started to realize that even below the batch balancer base fee threshold, per sector commit cost via  `ProveCommitAggregate`  is still much higher than `ProveCommitSectors` .
 
-As mentioned by @anorth laid out [here](https://github.com/filecoin-project/FIPs/discussions/689#discussioncomment-5680517),”We explicitly charge gas (discounted) for the single proof validation when it is submitted, so it’s both bounded and paid for. However, the **state updates associated with sector activation are not metered**, because they execute in cron. The execution cost of this activation varies significantly with the deal content of the sector, but the storage provider doesn’t pay gas for this. On the other hand, aggregated proof validation also activates the sector synchronously, for which the SP pays the gas cost. Thus single-sector onboarding is subsidised relative to aggregation, but aggregation would otherwise efficiently support much higher onboarding rates.”
+As @anorth laid out [here](https://github.com/filecoin-project/FIPs/discussions/689#discussioncomment-5680517),”We explicitly charge gas (discounted) for the single proof validation when it is submitted, so it’s both bounded and paid for. However, the **state updates associated with sector activation are not metered**, because they execute in cron. The execution cost of this activation varies significantly with the deal content of the sector, but the storage provider doesn’t pay gas for this. On the other hand, aggregated proof validation also activates the sector synchronously, for which the SP pays the gas cost. Thus single-sector onboarding is subsidised relative to aggregation, but aggregation would otherwise efficiently support much higher onboarding rates.”
 
-Thus, we would like to resolves the imbalance in the sector activation and make proof aggregation financially make sense again.
+Thus, we would like to resolve the imbalance in the sector activation and make proof aggregation financially make sense again.
 
 This change also removes unnecessary yet expensive sector and deal activation work out of the network cron, in which prevent the network from potential cron blowup in the long term. 
 

--- a/FIPS/fip-drop-provecommit1.md
+++ b/FIPS/fip-drop-provecommit1.md
@@ -23,11 +23,11 @@ FIP-0076 provides an alternative, synchronous activation path for non-aggregated
 
 ## Change Motivation
 
-Since the FVM launch, all computations are properly charged and storage providers have started to realize that even below the batch balancer base fee threshold, the per sector commit cost via `ProveCommitAggregate` is higher than `ProveCommitSector`.
+Since the FVM launch, all computations are properly charged and it has become evident that even below the batch balancer base fee threshold, the per sector commit cost via `ProveCommitAggregate` is higher than `ProveCommitSector`.
 
 The chain explicitly charge gas (discounted) for the single proof validation when it is submitted, so it’s both bounded and paid for. However, the **state updates associated with sector activation are not metered**, because they execute in cron. The execution cost of this activation varies significantly with the deal content of the sector, but the storage provider doesn’t pay gas for this. On the other hand, aggregated proof validation also activates the sector synchronously, for which the SP pays the gas cost. Thus, single-sector onboarding is subsidized relative to aggregation, but aggregation would otherwise efficiently support much higher onboarding rates. The proposed change will resolve the imbalanced cost of sector activation using different onboarding methods and make proof aggregation financially sensible again.
 
-In addition, the activation jobs are being executed in cron which means the chain is subsidying the job cost. This is not a desireable subsidy incentive as it leads to the inefficient use of the chain validation resources by discouraging aggregation of proofs. Thus, the proposed the change also removes unnecessary yet expensive sector and deal activation work from the network cron, which prevents the network from potential cron blowup in the long term as well.
+In addition, the activation jobs are being executed in cron which means the chain is subsidi[sz]ing the job cost. This is not a desirable subsidy incentive as it leads to the inefficient use of the chain validation resources by discouraging aggregation of proofs. Thus, the proposed the change also removes unnecessary yet expensive sector and deal activation work from the network cron, which prevents the network from potential cron blowup in the long term as well.
 
 - <TODO add fvm syscall  to be removed>  
 
@@ -41,7 +41,7 @@ There are other ways to achieve our goal, like modifying `ProveCommitSector` to 
 
 ## Backwards Compatibility
 
-The deprecation of this method MUST happen after `ProveCommitSectors2` is available in the network and adopted by the clients.  
+The deprecation of this method MUST happen after the methods from FIP-0076 are available in the network and adopted by the clients.  
 
 This proposal requires a network upgrade to deploy the new built-in actor code.
 

--- a/FIPS/fip-drop-provecommit1.md
+++ b/FIPS/fip-drop-provecommit1.md
@@ -1,25 +1,25 @@
 ---
 
 fip: "<to be assigned>" <!--keep the qoutes around the fip number, i.e: `fip: "0001"`-->
-title:  Deprecate  `ProveCommitSectors`  to Avoid Single PoRep Proof Verification in Cron 
+title:  Remove Storage Miner Actor Method `ProveCommitSectors`  
 author: Jennifer Wang (@jennijuju)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/689
 status: Draft
 type: Technical 
-category (*only required for Standard Track): Core
+category: Core
 created: 2023-09-03
 requires: FIP-0076
 ---
 
 ## Simple Summary
 
-Deprecate *`ProveCommitSector` (method 7)* in favor of `ProveCommitSectors2` and `ProveCommitAggregate`. This change ensures that single PoRep validations and single sector activations are executed synchronously and billed to the caller, instead of being executed asynchronously via a cron call to the actor.
+Remove *`ProveCommitSector` (method 7)* in favor of `ProveCommitSectors2` and `ProveCommitAggregate`. This change ensures that single PoRep validations and single sector activations are executed synchronously and billed to the caller, instead of being executed asynchronously via a cron call to the actor.
 
 ## Abstract
 
 Currently, `ProveCommitSector` accepts a single PoRep proof for an individual sector, validates the proof, and activates the sector along with the deals inside it via a cron call to the power actor. In contrast, when submitting an aggregated PoRep with `ProveCommitAggregate`, all proof validation and sector activation are executed synchronously and the costs are billed to the caller. This creates an imbalance in the sector activation gas subsidy available to different onboarding methods, and also adds unnecessary work to unpaid network cron jobs.
 
-To address this issue, we propose to deprecate the `ProveCommitSector` method after the network upgrade that includes the `ProveCommitSectors2` method, which is planned as part of [FIP-0076 - Direct Data Onboarding](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md) and is expected to be in scope for upcoming network upgrades.
+FIP-0076 provides an alternative, synchronous activation path for non-aggregated proofs. This proposal subsequently removes the ProveCommitSector method and thus the imbalance.
 
 ## Change Motivation
 

--- a/FIPS/fip-drop-provecommit1.md
+++ b/FIPS/fip-drop-provecommit1.md
@@ -3,13 +3,12 @@
 fip: "<to be assigned>" <!--keep the qoutes around the fip number, i.e: `fip: "0001"`-->
 title:  Deprecate  `ProveCommitSectors`  to Avoid Single PoRep Proof Verification in Cron 
 author: Jennifer Wang (@jennijuju)
-discussions-to: [<URL>](https://github.com/filecoin-project/FIPs/discussions/689)
+discussions-to: https://github.com/filecoin-project/FIPs/discussions/689
 status: Draft
 type: Technical 
 category (*only required for Standard Track): Core
 created: 2023-09-03
-requires (*optional):  [FIP-0076](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md)
-
+requires: FIP-0076
 ---
 
 ## Simple Summary
@@ -40,17 +39,16 @@ Drop the `ProveCommitSector` [function](https://github.com/filecoin-project/buil
 
 ## Design Rationale
 
-There are other ways to achieve our goal, like modifying `ProveCommitSector` to activate sectors and deals asynchronously. However, the required protocol functionality can be achieved by other methods already, so deprecating the `ProveCommitSector` is the simplest way and also reduces the actor code that needs to be maintained.
+There are other ways to achieve our goal, like modifying `ProveCommitSector` to activate sectors and deals synchronously. However, the required protocol functionality can be achieved by other methods already, so deprecating the `ProveCommitSector` is the simplest way and also reduces the actor code that needs to be maintained.
 
 ## Backwards Compatibility
 
-The deprecation of this method MUST happen after `ProveCommitSectors2` is available in the network and being adapted by the client.  
+The deprecation of this method MUST happen after `ProveCommitSectors2` is available in the network and adopted by the clients.  
 
 This proposal requires a network upgrade to deploy the new built-in actor code.
 
 ## Test Cases
 
-Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.
 
 Calling `ProveCommitSector` will fail with ***USR_UNHANDLED_MESSAGE.***
 
@@ -60,7 +58,7 @@ This FIP avoids single PoRep proof verification in cron, which reduces the free 
 
 ## Incentive Considerations
 
-This FIP will enforce storage activation fees to be paid by the callers rather than having an imbalanced network subsidy. This means storage providers who only onboard sectors via `ProveCommitSector` will start to pay for sector proof validation and sector/deal activation, which is a gas cost increase from ~71M to ~196M based on the current implementation. However, the activation cost is expected to be lower with the direct data onboarding flow via the `ProveCommitSectors2` method, and storage providers and their data clients may choose to opt-out of f05 deal activation, which would result in significantly less gas cost.
+This FIP will enforce storage activation fees to be paid by the callers rather than having an imbalanced network subsidy. This means storage providers who only onboard sectors via `ProveCommitSector` will start to pay for sector proof validation and sector/deal activation, which is a gas cost increase from ~71M to ~196M based on the current implementation. However, the activation cost is expected to be lower with the direct data onboarding flow via the `ProveCommitSectors2` method, and storage providers and their data clients may opt-out of f05 deal activation, which would result in significantly lower gas cost.
 
 ## Product Considerations
 

--- a/FIPS/fip-drop-provecommit1.md
+++ b/FIPS/fip-drop-provecommit1.md
@@ -36,7 +36,7 @@ This change also removes unnecessary yet expensive sector and deal activation wo
 
 ## Specification
 
-Drop the `ProveCommitSector` function, https://github.com/filecoin-project/builtin-actors/blob/807630512ba0df9a2d41836f7591c3607ddb0d4f/actors/miner/src/lib.rs#L1775C17-L1828. 
+Drop the `ProveCommitSector` [function](https://github.com/filecoin-project/builtin-actors/blob/807630512ba0df9a2d41836f7591c3607ddb0d4f/actors/miner/src/lib.rs#L1775-L1828). 
 
 ## Design Rationale
 

--- a/README.md
+++ b/README.md
@@ -121,3 +121,4 @@ This improvement protocol helps achieve that objective for all members of the Fi
 |[0081](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0081.md)  | Introduce lower bound for sector initial pledge | FIP | @anorth, @vkalghatgi | Draft |
 |[0082](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0082.md)  | Add support for aggregated replica update proofs | FIP | nemo (@cryptonemo), Jake (@drpetervannostrand), @anorth | Draft |
 |[0083](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0083.md) | Add built-in Actor events in the Verified Registry, Miner and Market Actors | FIP | Aarsh (@aarshkshah1992)| Draft |
+|[0084](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0084.md) | Remove Storage Miner Actor Method `ProveCommitSectors`   | FIP | Jennifer Wang (@jennijuju)| Draft |


### PR DESCRIPTION
I wanna start this FIP early so to suggest the implementation clients to move away from `ProveCommitSectors` sooner rather than later - so that we can resolve the imbalanced sector activation  charges and move more jobs outside of the network cron.

This will addressed the bug where aggregation is more expensive than single prove commit post FVM and FIP-45  - this is a bug requested to be fixed by a handful SPs  https://github.com/filecoin-project/FIPs/discussions/689


This FIP is dependent on the [`ProveCommitSectors2` ](https://github.com/filecoin-project/FIPs/blob/5448ea5c8bb2a0010090649aff429d4da9d17001/FIPS/fip-direct-onboarding.md#provecommitsectors2)thats being introduced in the new direct data onboarding pipeline. 