### PR TITLE
FIP-0072: Specify validation errors

### DIFF
--- a/FIPS/fip-0072.md
+++ b/FIPS/fip-0072.md
@@ -115,14 +115,16 @@ Deserialization in FVM is done in a similar fashion where we read each `EventEnt
 In the FVM we perform the following validation while deserializing the input:
 
 1. Initial validation:
-    1. Validate that the size of `entries` is 255 or less. Previously 256 entries were accepted but reducing it by 1 ensures that the resulting CBOR encoding can store the length in a single byte.
-    2. Validate that the size of `values` does not exceed 8KiB.
+    1. Validate that the size of `entries` is 255 or less. Previously 256 entries were accepted but reducing it by 1 ensures that the resulting CBOR encoding can store the length in a single byte. Otherwise, fail with `LimitExceeded`.
+    2. Validate that the size of `values` does not exceed 8KiB. Otherwise, fail with `LimitExceeded`.
     3. Validate that the keys are valid utf8 (validate the entire buffer, all at once).
-2. For each event entry `ee` in `entries`:
-    1. Validate that the `ee.flags` bits are valid (see [FIP-0049#New chain types](https://github.com/filecoin-project/FIPs/blob/6c2be9a09a7f03f16aa5f635e4beadeaa9c4fb3b/FIPS/fip-0049.md#new-chain-types) for more details).
-    2. Validate that the `ee.key_size` is 31 bytes or less and starts/ends on unicode character boundaries. Previously 32 byte sized keys were accepted but reducing it by 1 ensures compact CBOR encoding.
-    3. Validate that the `ee.value_size` is 8Kib or less.
-    4. Validate that the `ee.codec` is acceptable. Currently, only `IPLD_RAW` (0x55) is allowed.
+2. Initialize `total_key_size` and `total_value_size` to 0. For each event entry `ee` in `entries`:
+    1. Validate that the `ee.flags` bits are valid (see [FIP-0049#New chain types](https://github.com/filecoin-project/FIPs/blob/6c2be9a09a7f03f16aa5f635e4beadeaa9c4fb3b/FIPS/fip-0049.md#new-chain-types) for more details). Otherwise, fail with `InvalidArgument`.
+    2. Validate that the `ee.key_size` is 31 bytes or less and starts/ends on unicode character boundaries. Previously 32 byte sized keys were accepted but reducing it by 1 ensures compact CBOR encoding. Otherwise, fail with `LimitExceeded`.
+    3. Add `ee.key_size` to `total_key_size`, add `ee.value_size` to `total_value_size`. Fail with `IllegalArgument` if either exceed `key_size` or `value_size` respectively.
+    4. Validate that the `ee.codec` is acceptable. Currently, only `IPLD_RAW` (0x55) is allowed. Otherwise, fail with `IllegalCodec`.
+3. Validate that `total_value_size == value_size` and `total_key_size` == `key_size`. Otherwise,
+   fail with `IllegalArgument`.
 
 ### Gas
 


### PR DESCRIPTION
Previously, we'd just say "validate". Now we specify the errors we fail with and validate one more corner case (passing a keys/value buffers that aren't consumed in their entirety).