### PR TITLE
Fix broken preamble on FIP-0073

### DIFF
--- a/FIPS/fip-0073.md
+++ b/FIPS/fip-0073.md
@@ -1,8 +1,8 @@
 ---
 fip: "0073"
 title: Remove beneficiary from the self_destruct syscall
-author: @stebalien
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/524
+author: Steven Allen (@stebalien)
 status: Accepted
 type: Technical Core
 created: 2023-08-29


### PR DESCRIPTION
FIP wasn't rendering correctly on GH due to the author starting with @. Hav ing done a cursory check of the others, seems to be an isolated instance.