### PR TITLE
FRC-0046: Add recipient data to return values from Transfer[From]

### DIFF
--- a/FRCs/frc-0046.md
+++ b/FRCs/frc-0046.md
@@ -89,18 +89,21 @@ fn Balance(owner: Address) -> TokenAmount
 // Transfers tokens from caller to another address.
 // Amount must be non-negative (but can be zero).
 // Transferring to the caller must be treated as a normal transfer.
-// Returns the resulting balances for the from and to addresses.
-// The operatorData is passed through to the receiver hook directly.
+// The operatorData is passed through to the receiver hook of the to address directly.
+// Returns the resulting balances for the from and to addresses, and any data returned by the 
+// receiver hook.
 // Aborts if the receiver hook on the `to` address aborts.
 fn Transfer({to: Address, amount: TokenAmount, operatorData: Bytes}) 
-  -> {fromBalance: TokenAmount, toBalance: TokenAmount}
+  -> {fromBalance: TokenAmount, toBalance: TokenAmount, recipientData: Bytes}
 
 // Transfers tokens from one address to another.
 // The caller must have previously been approved to control at least the sent amount.
 // The caller's allowance is decreased by the transferred amount.
-// Returns the resulting balances for the from and to addresses, and operator's remaining allowance.
+// The operatorData is passed through to the receiver hook of the to address directly.
+// Returns the resulting balances for the from and to addresses, the operator's remaining allowance,
+// and any data returned by the receiver hook.
 fn TransferFrom({from: Address, to: Address, amount: TokenAmount, operatorData: Bytes}) 
-  -> {fromBalance: TokenAmount, toBalance: TokenAmount, allowance: TokenAmount}
+  -> {fromBalance: TokenAmount, toBalance: TokenAmount, allowance: TokenAmount, recipientData: Bytes}
 
 // Atomically increases the amount that an operator can transfer from the caller’s balance.
 // The increase must be non-negative.
@@ -161,8 +164,10 @@ const FRC46TokenType = frc42_hash("FRC46")
 
 // Invoked by a token actor after transfer of tokens to the receiver’s address.
 // The token state must be persisted such that the hook receiver will observe the new balances.
+// Returns any data to be returned to the caller of the transfer method, 
+// the schema of which may be specific to the token and receiver.
 // Aborts if the receiver refuses the transfer.
-fn Receive({type: uint32, payload: []byte})
+fn Receive({type: uint32, payload: []byte}) -> Any
 ```
 
 ### Behaviour


### PR DESCRIPTION
This update matches the code deployed in the Datacap token actor. Receiver hook return data was added during the latter parts of implementation of FIP-0045, where the Datacap actor was introduced.

FYI @alexytsu 