### PR TITLE
FIP0079: Finalize gas prices

### DIFF
--- a/FIPS/fip-0079.md
+++ b/FIPS/fip-0079.md
@@ -143,7 +143,7 @@ The gas pricing for `verify_bls_aggregate` is dependent upon the number of signa
 The gas cost of BLS aggregate signature verification is computed via:
 
 ```rust
-const BLS_GAS_PER_PLAINTEXT_BYTE: usize = 26;
+const BLS_GAS_PER_PLAINTEXT_BYTE: usize = 7;
 // The gas required to compute one elliptic curve pairing operation for curve BLS12-381.
 const BLS_GAS_PER_PAIRING: usize = 8299302;
 
@@ -155,8 +155,6 @@ fn verify_bls_aggregate_gas(plaintexts: &[&[u8]]) -> usize {
     BLS_GAS_PER_PLAINTEXT_BYTE * total_plaintext_len + BLS_GAS_PER_PAIRING * num_pairings
 }
 ```
-
-NOTE: The above gas numbers were estimated from existing gas charges and were not re-benchmarked.
 
 ## Design Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
@@ -239,10 +237,6 @@ fn verify_bls_aggregate(
 ```
 
 FVM uses the Rust crates [`bls-signatures`](https://github.com/filecoin-project/bls-signatures) for making and verifying BLS signatures, and [`blstrs`](https://github.com/filecoin-project/blstrs) for functionality specific to elliptic curve BLS12-381, which FVM uses for BLS signatures.
-
-## TODO
-
-1. Benchmark gas pricing.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
After re-benchmarking, the pairing price was spot-on but the per-byte cost was an overestimate (likely due to recent optimizations in the libraries we're using, more than anything else).