### PR TITLE
Fix FIP number in FIPS 0078/0079/0081

### DIFF
--- a/FIPS/fip-0078.md
+++ b/FIPS/fip-0078.md
@@ -1,5 +1,5 @@
 ---
-fip: "FIP-0078"
+fip: "0078"
 title: "Remove Restrictions on the Minting of Datacap"
 author: Fatman13 (@Fatman13), flyworker (@flyworker), stuberman (@stuberman), Eliovp (@Eliovp), dcasem (@dcasem), and The-Wayvy (@The-Wayvy)
 Discussions-to: https://github.com/filecoin-project/FIPs/discussions/844

--- a/FIPS/fip-0079.md
+++ b/FIPS/fip-0079.md
@@ -1,5 +1,5 @@
 ---
-fip: "FIP-0079"
+fip: "0079"
 title: Add BLS Aggregate Signatures to FVM
 author: "Jake (@drpetervannostrand)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/840

--- a/FIPS/fip-0081.md
+++ b/FIPS/fip-0081.md
@@ -1,5 +1,5 @@
 ---
-fip: "FIP-0081"
+fip: "0081"
 title: Introduce lower bound for sector initial pledge
 author: "Alex North (@anorth), Vik Kalghatgi (@vkalghatgi)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/847


### PR DESCRIPTION
Some recent FIPS have departed from the metadata format and included the string "FIP-" in the FIP number, resulting in inconsistent rendering on fips.filecoin.io. PR removes said strings, but it's something for us to watch out for in the future.

![image](https://github.com/filecoin-project/FIPs/assets/547492/939bfced-cec8-4254-a719-e7fb1a7916fd)
