### PR TITLE
Remove duplicate FIP table

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,3 @@ title: Filecoin Improvement Proposals
 
 {% capture readme_include %}{% include_relative README.md %}{% endcapture %}
 {{ readme_include | markdownify }}
-
-<a id="fips"></a>
-{% include fiptable.html %}


### PR DESCRIPTION
https://fips.filecoin.io/ renders the full list of FIPs twice: the first due to including all of `readme.md` and the second by re-rendering from metadata. The content is the same (of course) just with minimal formatting differences. This removes the rendered table and leaves just the readme one. 

The alternative (and probably what was envisioned in https://github.com/filecoin-project/FIPs/commit/535de221a32cd51d461a83f8e3d48365d298a409) would be to not have a FIP table in the readme and instead rely on the web page only, which in turn is generated from the frontmatter. That makes sense from the SSOT perspective, but it's clearly not the path we chose.