### PR TITLE
FIP-0076: Rename ProveCommitSectors2/ProveReplicaUpdate2 to ProveCommitSectors3/ProveReplicaUpdates3

### DIFF
--- a/FIPS/fip-0076.md
+++ b/FIPS/fip-0076.md
@@ -11,14 +11,14 @@ created: 2023-08-24
 
 ## Simple Summary
 
-Adds new `ProveCommitSectors2` (method 33) and `ProveReplicaUpdates2` (method 34) methods to the miner actor
+Adds new `ProveCommitSectors3` (method 33) and `ProveReplicaUpdates3` (method 34) methods to the miner actor
 which support committing data to sectors and claiming verified allocations without requiring a built-in market (`f05`) deal.
 Adds a provider→sector→deal mapping in the built-in market actor and deprecates the storage of deal IDs in 
 sector metadata in the miner actor.
 Removes the legacy `PreCommitSector` (method 6) and `PreCommitSectorBatch` (method 25)
 in favour of the existing `PreCommitSectorBatch2` (method 28) which requires
 the sector unsealed CID to be specified while pre-committing.
-Removes the legacy and unused `ProveReplicaUpdates2` (method 29) (giving that name to the new method 34).
+Removes the legacy and unused `ProveReplicaUpdates3` (method 29) (giving that name to the new method 34).
 
 Existing onboarding flows that use the built-in market actor remain fully supported, but optional.
 
@@ -114,7 +114,7 @@ The interpretation of some per-sector metadata fields changes slightly.
 ##### SectorPreCommitInfo
 
 The `DealIDs` field remains in use to support existing onboarding methods.
-It is required to be empty by the new `ProveCommitSectors2` method.
+It is required to be empty by the new `ProveCommitSectors3` method.
 
 Pre-commit deal IDs may be removed in a future FIP when deprecating the old methods.
 
@@ -133,11 +133,11 @@ Per-sector deal IDs may be removed from state in a future migration.
 #### Sector activation
 
 The miner actor exports new methods for sector activation:
-`ProveCommitSectors2` (method 33) and `ProveReplicaUpdates2` (method 34).
+`ProveCommitSectors3` (method 33) and `ProveReplicaUpdates3` (method 34).
 These new methods both support either batched or aggregated proofs, though aggregated proofs for
 replica updates are not yet possible (see https://github.com/filecoin-project/FIPs/discussions/752).
 
-##### ProveCommitSectors2
+##### ProveCommitSectors3
 
 This method rejects sectors with deal IDs specified at pre-commit to avoid operator confusion
 between the two distinct ways of specifying deals (one of which would have to be ignored).
@@ -162,7 +162,7 @@ The miner actor will reject attempts to notify any actor other than the built-in
 This restriction may be lifted in a future FIP once the security considerations of calls into
 untrusted code are better understood and mitigated.
 
-In execution of `ProveCommitSectors2`, the miner actor:
+In execution of `ProveCommitSectors3`, the miner actor:
 
 1. validates that the pre-committed sectors are eligible for activation, rejecting any that specified deal IDs;
 2. verifies the sector seal proofs or aggregate proof, and hence the sealed and unsealed CIDs;
@@ -172,7 +172,7 @@ In execution of `ProveCommitSectors2`, the miner actor:
 6. notifies any actors specified in the piece manifests.
 
 ```
-struct ProveCommitSectors2Params {
+struct ProveCommitSectors3Params {
     // Activation manifest for each sector being proven.
     SectorActivations: []SectorActivationManifest,
     // Proofs for each sector, parallel to activation manifests.
@@ -222,7 +222,7 @@ struct DataActivationNotification {
 }
 
 // Note transparent serialization of single-element struct.
-struct ProveCommitSectors2Return {
+struct ProveCommitSectors3Return {
     // Success/fail of each input in order.
     ActivationResults: BatchReturn
 }
@@ -248,18 +248,18 @@ This value was previously a placeholder because the syscall was only ever invoke
 call paths originating in the cron actor, which has unlimited gas budget.
 The new value has been determined empirically following a similar scheme to other gas prices.
 
-##### ProveReplicaUpdates2
+##### ProveReplicaUpdates3
 
-The name `ProveReplicaUpdates2` is taken from the existing and now-deprecated method 29.
-Like `ProveCommitSectors2`, this method does not fetch deal information from the built-in market actor.
+The name `ProveReplicaUpdates3` is taken from the existing and now-deprecated method 29.
+Like `ProveCommitSectors3`, this method does not fetch deal information from the built-in market actor.
 Instead, the pieces of data that comprise the updated sector content are declared as a _manifest_.
-This manifest is similar to the manifest for `ProveCommitSectors2`, with differences being to specify
+This manifest is similar to the manifest for `ProveCommitSectors3`, with differences being to specify
 the existing sector state to be updated rather than a new one.
 
 The specification and semantics of pieces, including verified allocation IDs and notifications,
-is the same as for `ProveCommitSectors2`.
+is the same as for `ProveCommitSectors3`.
 
-In execution of `ProveReplicaUpdates2`, the miner actor:
+In execution of `ProveReplicaUpdates3`, the miner actor:
 
 1. validates that the existing sectors are eligible for update;
 2. computes an unsealed CID from the piece manifests;
@@ -270,7 +270,7 @@ In execution of `ProveReplicaUpdates2`, the miner actor:
 6. notifies any actors specified in the piece manifests.
 
 ```
-struct ProveReplicaUpdates2Params {
+struct ProveReplicaUpdates3Params {
     SectorUpdates: []SectorUpdateManifest,
     // Proofs for each sector, parallel to activation manifests.
     // Exactly one of sector_proofs or aggregate_proof must be non-empty.
@@ -300,7 +300,7 @@ pub struct SectorUpdateManifest {
     Pieces: []PieceActivationManifest,
 }
 
-type ProveReplicaUpdates2Return = ProveCommit2Return;
+type ProveReplicaUpdates3Return = ProveCommit2Return;
 ```
 
 #### SectorContentChanged
@@ -667,8 +667,8 @@ with similar reasoning to that motivating `PreCommitSectorBatch2`.
 However, the specification of piece manifests renders this unnecessary.
 Method 29 is not used by the widely used "Lotus miner" software and has never been invoked on mainnet.
 It is deprecated in order to reduce the number of actively-supported methods.
-The name `ProveReplicaUpdates2` is taken for the new method 34 in order to align the `2` suffix with the
-similarly-behaving `PreCommitSectorBatch2`.
+Note that there is no `ProveCommitSectors2`. 
+The new methods take a consistent `3` suffix to indicate their shared behaviour.
 
 ### Sector deal information moved to market actor
 
@@ -820,7 +820,7 @@ in cron, thus subsidising the SP's gas consumption.
 This is considered to be a protocol bug, expected to be resolved in a future FIP by forcing
 (now much reduced) sector activation costs to be paid by the SP.
 After this proposal, one way to do this would be to simply deprecate `ProveCommitSector`
-in favour of `ProveCommitSectors2`.
+in favour of `ProveCommitSectors3`.
 See https://github.com/filecoin-project/FIPs/discussions/689.
 
 ### Client-initiated workflow for verified data


### PR DESCRIPTION
This rename avoids confusion with the unused deprecated PRU2. Requested by @magik6k 

I don't believe this constitutes a substantive change to the FIP that should interrupt Last Call. Method names are not part of the consensus protocol in any case.

Implemented in https://github.com/filecoin-project/builtin-actors/pull/1485