### PR TITLE
FIP-0076: Add AggregateProofType parameter to ProveCommitSectors3Params.

### DIFF
--- a/FIPS/fip-0076.md
+++ b/FIPS/fip-0076.md
@@ -183,6 +183,8 @@ struct ProveCommitSectors3Params {
     // Aggregate proof for all sectors.
     // Exactly one of sector_proofs or aggregate_proof must be non-empty.
     AggregateProof: []byte,
+    // The proof type for the aggregate proof (ignored if no aggregate proof).
+    AggregateProofType: RegisteredAggregateProof,
     // Whether to abort if any sector activation fails.
     RequireActivationSuccess: bool,
     // Whether to abort if any notification returns a non-zero exit code.


### PR DESCRIPTION
Adds explicit proof type parameter to ProveCommitSectors2Params, rather than hardcoding SnarkPackV2. This follows the pattern already used by ProveReplicaUpdates[2] and supports development of new proofs without necessarily changing method signature.

I don't believe this is a substantive change that should require restarting Last Call.

Suggested by @Kubuxu 