### PR TITLE
Update FIP-0083 so that sector update event has piece information

### DIFF
--- a/FIPS/fip-0083.md
+++ b/FIPS/fip-0083.md
@@ -211,7 +211,7 @@ The event payload is defined as:
 | Index Key + Value | “sector”       | <SECTOR_NUMER> (int)        |
 | Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (cid)        |
 | Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)           |
-| Index Key + Value | "piece-size"   | <PIECE_SIZE> (bigint)       |
+| Index Key         | "piece-size"   | <PIECE_SIZE> (bigint)       |
 
 - Note that `piece-cid` and `piece-size` is included for each piece in the sector.
 
@@ -220,10 +220,15 @@ This event is emitted for each CC sector that is updated to contained actual sea
 
 The event payload is defined as:
 
-| flags | key | value                     |
-| --- | --- |---------------------------|
-| Index Key + Value | “$type" | "sector-updated" (string) |
-| Index Key + Value | “sector” | <SECTOR_NUMER> (int)      |
+| flags             | key            | value                       |
+|-------------------|----------------|-----------------------------|
+| Index Key + Value | “$type"        | "sector-updated" (string)   |
+| Index Key + Value | “sector”       | <SECTOR_NUMER> (int)        |
+| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (cid)        |
+| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)           |
+| Index Key         | "piece-size"   | <PIECE_SIZE> (bigint)       |
+
+- Note that `piece-cid` and `piece-size` is included for each piece in the updated sector.
 
 #### Sector Terminated
 The sector termination event is emitted for each sector that is marked as terminated by a storage provider. 


### PR DESCRIPTION
This PR updates[ FIP-0083 ](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0083.md) based on discussion threads at:

- https://github.com/filecoin-project/FIPs/discussions/754#discussioncomment-7994009
   - The `sector-updated` event should have sector piece manifest
  
- https://github.com/filecoin-project/FIPs/discussions/754#discussioncomment-7922110
   - We should not index the piece size value in the sector lifecycle events