### PR TITLE
FIP-0082: Note FIP-0076 as dependency and propagate upstream changes

### DIFF
--- a/FIPS/fip-0082.md
+++ b/FIPS/fip-0082.md
@@ -7,6 +7,7 @@ status: draft
 type: Technical
 category: Core
 created: 2023-09-26
+requires: FIP-0076
 spec-sections: 
   - 2.6.1.1 Sector Lifecycle
 
@@ -21,15 +22,15 @@ data updates in them activated simultaneously when the message is posted to the 
 ## Abstract
 
 This proposal adds a way for miners to post multiple `ProveReplicaUpdates`s at once, in the form of
-an aggregate Groth16 proof, using the `ProveReplicaUpdates2` method described in
+an aggregate Groth16 proof, using the `ProveReplicaUpdates3` method described in
 [FIP-0076](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md). The miner actor
-method `ProveReplicaUpdates2` currently provisions an interface for, but does not implement, aggregate
-sector update proof verification. This FIP proposes `ProveReplicaUpdates2` be modified to handle aggregate
+method `ProveReplicaUpdates3` currently provisions an interface for, but does not implement, aggregate
+sector update proof verification. This FIP proposes `ProveReplicaUpdates3` be modified to handle aggregate
 proof verification.
 
 ## Change Motivation
 
-Adding aggregate proof verification to the method `ProveReplicaUpdates2` amortizes some of the costs associated with
+Adding aggregate proof verification to the method `ProveReplicaUpdates3` amortizes some of the costs associated with
 multiple sector updates, in the same way that [FIP-0013](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0013.md)'s
 `ProveCommitAggregate` method has done for sealing proofs. While `ProveReplicaUpdate` is not one of the most frequent message
 on chain, it is believed to be too expensive to use in its current form.
@@ -43,20 +44,20 @@ with the number of proofs included in the aggregate proof.
 
 ### Actor changes
 
-This change reuses the miner actor method `ProveReplicaUpdates2` (method 34) introduced in
+This change reuses the miner actor method `ProveReplicaUpdates3` (method 35) introduced in
 [FIP-0076](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md) and the method's
-existing call parameters `ProveReplicaUpdates2Params`. The `ProveReplicaUpdates2` method and parameters already
+existing call parameters `ProveReplicaUpdates3Params`. The `ProveReplicaUpdates3` method and parameters already
 provision for aggregate proof handling, however the method currently
 [returns an error](https://github.com/filecoin-project/builtin-actors/blob/5b2e99b1bb355e73082d80ce5e25a86725d34363/actors/miner/src/lib.rs#L1116-L1122)
 when an aggregate replica update proof is provided for verification. This FIP proposes replacing the
 method's current aggregate proof handling (i.e. an error) with proper aggregate proof verification
 functionality.
 
-The following shows how the method's existing call parameters `ProveReplicaUpdates2Params`
+The following shows how the method's existing call parameters `ProveReplicaUpdates3Params`
 accommodate for aggregate proof verification.
 
 ```rust
-pub struct ProveReplicaUpdates2Params {
+pub struct ProveReplicaUpdates3Params {
     // A list of identifiers for the sector's updated in the aggregate proof.
     pub sector_updates: Vec<SectorUpdateManifest>,
     // An empty vector.


### PR DESCRIPTION
Note FIP-0076 as dependency, and update to reflect method renaming and renumbering in FIP-0076.

I don't believe this constitutes any substantive change or should interrupt Last Call.

FYI @cryptonemo 