### PR TITLE
Update FIP-0083 based on feedback from review of implementation

### DIFF
--- a/FIPS/fip-0083.md
+++ b/FIPS/fip-0083.md
@@ -205,13 +205,13 @@ This event is emitted for each pre-committed sector that is successfully activat
 
 The event payload is defined as:
 
-| flags             | key            | value                       |
-|-------------------|----------------|-----------------------------|
-| Index Key + Value | “$type"        | "sector-activated" (string) |
-| Index Key + Value | “sector”       | <SECTOR_NUMER> (int)        |
-| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (cid)        |
-| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)           |
-| Index Key         | "piece-size"   | <PIECE_SIZE> (bigint)       |
+| flags             | key            | value                                                        |
+|-------------------|----------------|--------------------------------------------------------------|
+| Index Key + Value | “$type"        | "sector-activated" (string)                                  |
+| Index Key + Value | “sector”       | <SECTOR_NUMER> (int)                                         |
+| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (Nillable cid) (Nil means sector has no data) |
+| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                            |
+| Index Key         | "piece-size"   | <PIECE_SIZE> (u64)                                           |
 
 - Note that `piece-cid` and `piece-size` is included for each piece in the sector.
 
@@ -220,13 +220,13 @@ This event is emitted for each CC sector that is updated to contained actual sea
 
 The event payload is defined as:
 
-| flags             | key            | value                       |
-|-------------------|----------------|-----------------------------|
-| Index Key + Value | “$type"        | "sector-updated" (string)   |
-| Index Key + Value | “sector”       | <SECTOR_NUMER> (int)        |
-| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (cid)        |
-| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)           |
-| Index Key         | "piece-size"   | <PIECE_SIZE> (bigint)       |
+| flags             | key            | value                                                        |
+|-------------------|----------------|--------------------------------------------------------------|
+| Index Key + Value | “$type"        | "sector-updated" (string)                                    |
+| Index Key + Value | “sector”       | <SECTOR_NUMER> (int)                                         |
+| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (Nillable cid) (Nil means sector has no data) |
+| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                            |
+| Index Key         | "piece-size"   | <PIECE_SIZE> (u64)                                           | 
 
 - Note that `piece-cid` and `piece-size` is included for each piece in the updated sector.
 
@@ -240,6 +240,43 @@ The event payload is defined as:
 | Index Key + Value | “$type" | "sector-terminated" (string) |
 | Index Key + Value | “sector” | <SECTOR_NUMER> (int)         |
 
+### Changing the Market Actor `BatchActivateDealsResult` type
+The legacy (pre [FIP-0076](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md)) sector activation and 
+sector update methods and flows in the Miner Actor need access to the piece manifests for the sector data to build the 
+sector activation and sector update event payloads described above. This information is currently persisted in the 
+Market Actor.
+
+Since these legacy flows already call the Market Actor `BatchActivateDeals`(method 6) method to activate the deals in the sectors,
+the return type of this method has been changed to include the piece manifests for the sector data. 
+
+The updated `BatchActivateDealsResult` type is defined as:
+
+```
+type BatchActivateDealsResult {
+    /// Status of each sector grouping of deals.
+    activation_results: BatchReturn,
+    /// Activation information for the sector groups that were activated.
+    activations: Vec<SectorDealActivation>,
+}
+
+type SectorDealActivation {
+    /// Information about each deal activated.
+    activated: Vec<ActivatedDeal>,
+    /// Unsealed CID computed from the deals specified for the sector.
+    /// A None indicates no deals were specified, or the computation was not requested.
+    unsealed_cid: Option<Cid>
+}
+
+pub struct ActivatedDeal {
+    pub client: ActorID,
+    pub allocation_id: AllocationID, // NO_ALLOCATION_ID for unverified deals.
+    pub data: Cid, // "piece-cid" 
+    pub size: PaddedPieceSize // "piece-size" 
+}
+```
+
+This is not a problem for the sector activation and sector update methods and flows introduced in FIP-0076 as those methods
+already have access to the piece manifests for the sector data in their input params.
 
 ## Design Rationale
 Richer and more detailed payloads for the events were initially considered. However, a large event payload 

--- a/FIPS/fip-0083.md
+++ b/FIPS/fip-0083.md
@@ -211,7 +211,7 @@ The event payload is defined as:
 | Index Key + Value | “sector”       | <SECTOR_NUMER> (int)                                         |
 | Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
 | Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                            |
-| Index Key         | "piece-size"   | <PIECE_SIZE> (u64)                                           |
+| Index Key         | "piece-size"   | <PIECE_SIZE> (int)                                           |
 
 - Note that `piece-cid` and `piece-size` is included for each piece in the sector.
 
@@ -226,7 +226,7 @@ The event payload is defined as:
 | Index Key + Value | “sector”       | <SECTOR_NUMER> (int)                                         |
 | Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
 | Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                            |
-| Index Key         | "piece-size"   | <PIECE_SIZE> (u64)                                           | 
+| Index Key         | "piece-size"   | <PIECE_SIZE> (int)                                           | 
 
 - Note that `piece-cid` and `piece-size` is included for each piece in the updated sector.
 

--- a/FIPS/fip-0083.md
+++ b/FIPS/fip-0083.md
@@ -209,7 +209,7 @@ The event payload is defined as:
 |-------------------|----------------|--------------------------------------------------------------|
 | Index Key + Value | “$type"        | "sector-activated" (string)                                  |
 | Index Key + Value | “sector”       | <SECTOR_NUMER> (int)                                         |
-| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (Nillable cid) (Nil means sector has no data) |
+| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
 | Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                            |
 | Index Key         | "piece-size"   | <PIECE_SIZE> (u64)                                           |
 
@@ -224,7 +224,7 @@ The event payload is defined as:
 |-------------------|----------------|--------------------------------------------------------------|
 | Index Key + Value | “$type"        | "sector-updated" (string)                                    |
 | Index Key + Value | “sector”       | <SECTOR_NUMER> (int)                                         |
-| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (Nillable cid) (Nil means sector has no data) |
+| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
 | Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                            |
 | Index Key         | "piece-size"   | <PIECE_SIZE> (u64)                                           | 
 

--- a/FIPS/fip-0083.md
+++ b/FIPS/fip-0083.md
@@ -267,11 +267,11 @@ type SectorDealActivation {
     unsealed_cid: Option<Cid>
 }
 
-pub struct ActivatedDeal {
-    pub client: ActorID,
-    pub allocation_id: AllocationID, // NO_ALLOCATION_ID for unverified deals.
-    pub data: Cid, // "piece-cid" 
-    pub size: PaddedPieceSize // "piece-size" 
+type ActivatedDeal {
+    client: ActorID,
+    allocation_id: AllocationID, // NO_ALLOCATION_ID for unverified deals.
+    data: Cid, // "piece-cid" 
+    size: PaddedPieceSize // "piece-size" 
 }
 ```
 


### PR DESCRIPTION
This PR updates [FIP-0083](https://github.com/filecoin-project/FIPs/blob/7eb8da9f5d50f2664e059bd56c930272d6189a57/FIPS/fip-0083.md) based on the feedback receieved on it's implementation at https://github.com/filecoin-project/builtin-actors/pull/1491.

The changes it proposes are:

- Updates the types for `unsealed_cid` and `piece-size` values in the sector activation and sector update paylods
- Documents the change we've made to the `BatchActivateDealsResult` type in the Market Actor so that legacy sector activation and sector update flows can access the piece manifest for the sector data to be able to build the expected sector update and sector activation paylods.