### PR TITLE
FIP-0063: Tweak protocol change details

### DIFF
--- a/FIPS/fip-0063.md
+++ b/FIPS/fip-0063.md
@@ -80,8 +80,10 @@ corresponding to a filecoin epoch at time `T` is calculated as `(T - 30 - 169280
 
 ### Block Headers
 
-Blocks should only ever include one beacon entry in their header, for the round corresponding to the Filecoin epoch as described above.
-This is a change from existing behaviour, where block headers sometimes include multiple beacon entries (specifically when built on "null" tipsets). Storing multiple beacons is no longer necessary as the unchained nature of Quicknet does not require us to keep and validate the full history of consecutive rounds.
+As today, blocks should include beacon entries for the epoch corresponding to their own height, as well as those corresponding to any parent epochs that were null.
+This guarantees that a unique beacon entry can be found for any Filecoin epoch to serve as a source of external randomness to the protocol (currently used for WindowPoSt and ProveCommit verification).
+
+Note that this does NOT mean that every beacon entry is included in the blockchain as it is today. Instead, only every 10th entry will be included.
 
 ### Upgrade
 


### PR DESCRIPTION
This makes a minor change to the protocol changes described in #914. This change corrects an oversight in that PR, and continues to guarantee that beacon randomness can be sourced for every epoch, even if the epoch is null. 