### PR TITLE
FIP-0076 fix: s/SectorDeals/SectorDealIDs in market state to disambiguate naming

### DIFF
--- a/FIPS/fip-0076.md
+++ b/FIPS/fip-0076.md
@@ -465,7 +465,7 @@ The unused verified claim ID field is removed from the deal state structure.
 
 ```
 // New structure storing per-sector deal information.
-struct SectorDeals {
+struct SectorDealIDs {
     Deals: []DealID
 }
 
@@ -492,7 +492,7 @@ struct State {
 	States: Cid 
 
     // New mapping of sector IDs to deal IDs, grouped by storage provider.
-    // HAMT[Address]HAMT[SectorNumber]SectorDeals
+    // HAMT[Address]HAMT[SectorNumber]SectorDealIDs
     ProviderSectors: Cid 
 }
 ```


### PR DESCRIPTION
`SectorDeals` is also used in `BatchActivateDeals` but has a different form there. This change simply renames the struct to disambiguate it. This also reflects how it's implemented in builtin-actors.

---

While I'm in here, can I ask for clarity on why this is a struct in the first place? It's introduced new complexity now that it's adopted "transparent" encoding in builtin-actors which has required new cbor-gen adjustments to make it work with go-state-types too. Why are we containing it in a struct in the first place and not just doing `SectorDealIDs []DealID` or omitting `SectorDealIDs` entirely and saying `HAMT[Address]HAMT[SectorNumber][]DealID`, which would both result in the same forms as they are currently implemented in both of the proposed builtin-actors and go-state-types but may afford a little bit of simplification in the code by removing an intermediary?

_(Edit: here's what such simplification could look like: https://github.com/filecoin-project/builtin-actors/pull/1510)_