### PR TITLE
Create CODEOWNERS for review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # Global owners
 # Ensure maintainers team is a requested reviewer for non-draft PRs
-*                       @filecoin-project/fips-editors
+*                       @momack2 @arajasek @jennijuju @kaitlin-beegle @anorth @raulk @jsoares

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @momack2 @arajasek @jennijuju @kaitlin-beegle @anorth @raulk @jsoares


### PR DESCRIPTION
I believe the goal/rule is to have 2 fip editors' review & approval for an FIP update to be merged into the repo. without this configuration, currently any 2 approvals from anyone has write access to this repo can approve and merge PR to the main branch.
<img width="764" alt="image" src="https://github.com/filecoin-project/FIPs/assets/42981373/c5dd0189-6116-4ddb-8bb2-6f54ed40598a">
