### PR TITLE
FIP-0083: Clarify bigint CBOR encoding scheme

### DIFF
--- a/FIPS/fip-0083.md
+++ b/FIPS/fip-0083.md
@@ -63,6 +63,8 @@ The event payload is defined as:
 | Index Key + Value    | “verifier” | <VERIFIER_ACTOR_ID> (int)            |
 | Index Key            | “balance” | <VERIFIER_DATACAP_BALANCE> (bigint) |
 
+_The "bigint" CBOR encoding format used for the "balance" field is the same as is used for encoding bigints on the Filecoin chain: a byte array representing a big-endian unsigned integer, compatible with the Golang `big.Int` byte representation, with a `0x00` (positive) or `0x01` (negative) prefix; with a zero-length array representing a value of `0`._
+
 #### Datacap Allocated
 This event is emitted when a verified client allocates datacap to a specific data piece and storage provider.  
 


### PR DESCRIPTION
Came up in https://github.com/filecoin-project/builtin-actors/pull/1516 because it's not obvious when doing serialisation that we have a bespoke bigint form that fits within the IPLD data model and is based off the Go representation. Letting a "bigint" pass through a system without special casing leads to surprise so I feel the call-out is warranted and hopefully a reminder for future events where we're going to be using these more.
