### PR TITLE
Update FIPs table to reflect recent statuses

### DIFF
--- a/FIPS/fip-0084.md
+++ b/FIPS/fip-0084.md
@@ -4,7 +4,7 @@ fip: "0084"
 title:  Remove Storage Miner Actor Method `ProveCommitSectors`  
 author: Jennifer Wang (@jennijuju)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/899
-status: Last Call
+status: Accepted
 type: Technical 
 category: Core
 created: 2023-09-03

--- a/FIPS/fip-0085.md
+++ b/FIPS/fip-0085.md
@@ -3,7 +3,7 @@ fip: "0085"
 title: Convert f090 Mining Reserve actor to a keyless account actor
 author: Jennifer Wang (@jennijuju), Jon Victor (@jnthnvctr)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/901
-status: Draft
+status: Last Call
 type: Technical
 category: Core
 created: 2024-01-04

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ This improvement protocol helps achieve that objective for all members of the Fi
 |[0081](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0081.md)  | Introduce lower bound for sector initial pledge | FIP | @anorth, @vkalghatgi | Draft |
 |[0082](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0082.md)  | Add support for aggregated replica update proofs | FIP | nemo (@cryptonemo), Jake (@drpetervannostrand), @anorth | Accepted |
 |[0083](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0083.md) | Add built-in Actor events in the Verified Registry, Miner and Market Actors | FIP | Aarsh (@aarshkshah1992)| Accepted |
-|[0084](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0084.md) | Remove Storage Miner Actor Method `ProveCommitSectors`   | FIP | Jennifer Wang (@jennijuju)| Last Call |
-|[0085](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0085.md) | Convert f090 Mining Reserve actor to a keyless account actor   | FIP | Jennifer Wang (@jennijuju), Jon Victor (@jnthnvctr)| Draft |
+|[0084](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0084.md) | Remove Storage Miner Actor Method `ProveCommitSectors`   | FIP | Jennifer Wang (@jennijuju)| Accepted |
+|[0085](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0085.md) | Convert f090 Mining Reserve actor to a keyless account actor   | FIP | Jennifer Wang (@jennijuju), Jon Victor (@jnthnvctr)| Last Call |
 |[0086](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md) | Fast Finality in Filecoin (F3) | FIP | @stebalien, @mb1896, @hmoniz, @anorth, @matejpavlovic, @arajasek, @ranchalp, @jsoares, @Kubuxu, @vukolic | Draft |
 |[0087](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0087.md) | FVM-Enabled Deal Aggregation | FRC | @aashidham, @honghao, @raulk, @nonsense | Draft |
 


### PR DESCRIPTION
FIP0084 has since passed out of Last Call and the new status needs to be updated. FIP0085 has recently entered into Last Call and is no longer in Draft status.

