### PR TITLE
FIP-0076: Edit migration details to make it feasible to run

### DIFF
--- a/FIPS/fip-0076.md
+++ b/FIPS/fip-0076.md
@@ -580,12 +580,12 @@ and miner actor state per-sector deal IDs.
 
 - For each deal state object in the market actor state that has a terminated epoch set to `-1`:
   - find the corresponding deal proposal object;
-    - if the deal has expired, skip processing this deal
+    - if the deal has expired, set the sector number to `0`.
   - extract the provider's actor ID, look up the provider's miner state, find the ID of the sector with the corresponding deal ID in sector metadata;
   - set the new deal state object's sector number to the sector ID found;
 - For each deal state object in the market actor state that has a terminated epoch set to any other value:
   - set the deal state object's sector number to `0`. 
-- For each miner, for each unexpired sector:
+- For each miner, for each unexpired sector (even if the sector has been terminated):
   - add the deal IDs in the sector to the `ProviderSectors` mapping for the provider's actor ID and sector number.
 
 The result includes a value in the `ProviderSectors` mapping for each activated and not yet terminated or expired deal.

--- a/FIPS/fip-0076.md
+++ b/FIPS/fip-0076.md
@@ -579,17 +579,14 @@ The built-in market actor's `ProviderSectors` mapping is initialised from the ex
 and miner actor state per-sector deal IDs. 
 
 - For each deal state object in the market actor state that has a terminated epoch set to `-1`:
-  - find the corresponding deal proposal object and extract the provider's actor ID;
-  - in the provider's miner state, find the ID of the sector with the corresponding deal ID in sector metadata;
-    - if such a sector cannot be found, assert that the deal's end epoch has passed and use sector ID `0` [1];
+  - find the corresponding deal proposal object;
+    - if the deal has expired, skip processing this deal
+  - extract the provider's actor ID, look up the provider's miner state, find the ID of the sector with the corresponding deal ID in sector metadata;
   - set the new deal state object's sector number to the sector ID found;
-  - add the deal ID to the `ProviderSectors` mapping for the provider's actor ID and sector number.
 - For each deal state object in the market actor state that has a terminated epoch set to any other value:
   - set the deal state object's sector number to `0`. 
-
-[1] It may be impossible to find the sector for a deal that has completed successfully 
-but not yet been cleaned up in market actor state, 
-if the corresponding sector has since expired and been compacted out of state.
+- For each miner, for each unexpired sector:
+  - add the deal IDs in the sector to the `ProviderSectors` mapping for the provider's actor ID and sector number.
 
 The result includes a value in the `ProviderSectors` mapping for each activated and not yet terminated or expired deal.
 The built-in market actor's implementation of deal expiration clean-up must be robust to the provider sector mapping

--- a/FIPS/fip-0076.md
+++ b/FIPS/fip-0076.md
@@ -583,7 +583,7 @@ and miner actor state per-sector deal IDs.
     - if the deal has expired, set the sector number to `0`.
   - extract the provider's actor ID, look up the provider's miner state, find the ID of the sector with the corresponding deal ID in sector metadata;
   - set the new deal state object's sector number to the sector ID found;
-- For each deal state object in the market actor state that has a terminated epoch set to any other value:
+- For each deal state object in the market actor state that has a slashed epoch set to any other value:
   - set the deal state object's sector number to `0`. 
 - For each miner, for each unexpired sector (even if the sector has been terminated):
   - add the deal IDs in the sector to the `ProviderSectors` mapping for the provider's actor ID and sector number.

--- a/FIPS/fip-0076.md
+++ b/FIPS/fip-0076.md
@@ -578,7 +578,7 @@ struct GetDealSectorReturn {
 The built-in market actor's `ProviderSectors` mapping is initialised from the existing deal state
 and miner actor state per-sector deal IDs. 
 
-- For each deal state object in the market actor state that has a terminated epoch set to `-1`:
+- For each deal state object in the market actor state that has a slashed epoch set to `-1`:
   - find the corresponding deal proposal object;
     - if the deal has expired, set the sector number to `0`.
   - extract the provider's actor ID, look up the provider's miner state, find the ID of the sector with the corresponding deal ID in sector metadata;


### PR DESCRIPTION
The Lotus team cannot implement the migration, as currently specified, cannot be safely implemented in what we currently consider satisfactory time (<=2 epochs). This change, which primarily decouples some of the conditions between the market state and miner(s) state, simplifies the migration to the point where it can be run faster.

The impact is to have more state than strictly necessary in the new `ProviderSectors` field of the market actor.

NOTE: The Core Devs should discuss what acceptable network downtime is. We currently require state migrations to run in ~1 epoch, which avoids null rounds, and is overall healthy for the network, but significantly slows down protocol development & adds risk to these operations. It is possible that we decide that we actually don't have a problem with 5-10 minutes of network downtime in order to accelerate the pace of development and de-risk state migrations by cutting out tricky optimizations.