### PR TITLE
FIP-0083: Add additional event properties to ease DDO transition

### DIFF
--- a/FIPS/fip-0083.md
+++ b/FIPS/fip-0083.md
@@ -104,6 +104,8 @@ The event payload is defined as:
 | Index Key + Value | “id” | <CLAIM_ID> (int)      |
 | Index Key + Value | “client” | <CLIENT_ACTOR_ID> (int) |
 | Index Key + Value | “provider” | <SP_ACTOR_ID> (int)   |
+| Index Key + Value | "piece-cid" | <PIECE_CID> (cid) |
+| Index Key         | "piece-size" | <PIECE_SIZE> (int) |
 
 #### Claim Updated
 This event is emitted when the term of an existing allocation is extended by the client.

--- a/FIPS/fip-0083.md
+++ b/FIPS/fip-0083.md
@@ -12,7 +12,7 @@ created: 2023-11-27
 # FIP-0083: Add built-in Actor events in the Verified Registry, Miner and Market Actors
 
 ## Simple Summary
-This FIP defines and proposes the implementation of a meaningful subset of fire-and-forget externally observable events that will be emitted by the built-in Verified Registry, Storage Market and Storage Miner Actors. These enable external agents (henceforth referred to as *“clients”*) to observe and track a specific subset of on-chain datacap allocation/claims, deal lifecycle and sector lifecycle state transitions.
+This FIP defines and proposes the implementation of a meaningful subset of fire-and-forget externally observable events that will be emitted by the built-in Verified Registry, Storage Market and Storage Miner Actors. These enable external agents (henceforth referred to as *"clients"*) to observe and track a specific subset of on-chain datacap allocation/claims, deal lifecycle and sector lifecycle state transitions.
 
 While this FIP explicitly delineates the implementation of events tied to specific transitions, it does not encompass the full spectrum of potential built-in actor events. The introduction and integration of additional built-in actor events will be addressed in subsequent FIPs.
 
@@ -38,9 +38,9 @@ Filecoin network observability tools, block explorers, SP monitoring dashboards,
  _Please see [FIP-0049](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0049.md) for a detailed explanation of the FVM event schema and the possible values each field_ 
  in the event schema can take. The interpretation of the flags field in each event entry is as follows:
 
- 1. {"flags": "0x03”} ⇒ Index both key and value of the event entry
- 2. {"flags": "0x02”} ⇒ Index only the value of the event entry
- 3. {"flags": "0x01”} ⇒ Index only the key of the event entry
+ 1. {"flags": "0x03"} ⇒ Index both key and value of the event entry
+ 2. {"flags": "0x02"} ⇒ Index only the value of the event entry
+ 3. {"flags": "0x01"} ⇒ Index only the key of the event entry
 
 
 
@@ -59,11 +59,11 @@ This event is emitted when the balance of a verifier is updated in the Verified 
 
 The event payload is defined as:
 
-| flags                | key | value                                |
-|----------------------| --- |--------------------------------------|
-| Index Key + Value    | “$type” | “verifier-balance” (string)          |
-| Index Key + Value    | “verifier” | <VERIFIER_ACTOR_ID> (int)            |
-| Index Key            | “balance” | <VERIFIER_DATACAP_BALANCE> (bigint) |
+| flags                | key        | value                               |
+| -------------------- | ---------- | ----------------------------------- |
+| Index Key + Value    | "$type"    | "verifier-balance" (string)         |
+| Index Key + Value    | "verifier" | <VERIFIER_ACTOR_ID> (int)           |
+| Index Key            | "balance"  | <VERIFIER_DATACAP_BALANCE> (bigint) |
 
 _The "bigint" CBOR encoding format used for the "balance" field is the same as is used for encoding bigints on the Filecoin chain: a byte array representing a big-endian unsigned integer, compatible with the Golang `big.Int` byte representation, with a `0x00` (positive) or `0x01` (negative) prefix; with a zero-length array representing a value of `0`._
 
@@ -72,25 +72,24 @@ This event is emitted when a verified client allocates datacap to a specific dat
 
 The event payload is defined as:
 
-| flags | key | value                   |
-| --- | --- |-------------------------|
-| Index Key + Value | “$type” | “allocation” (string)   |
-| Index Key + Value | “id” | <ALLOCATION_ID> (int)   |
-| Index Key + Value | “client” | <CLIENT_ACTOR_ID> (int) |
-| Index Key + Value | “provider” | <SP_ACTOR_ID> (int)     |
+| flags             | key        | value                   |
+| ----------------- | ---------- | ----------------------- |
+| Index Key + Value | "$type"    | "allocation" (string)   |
+| Index Key + Value | "id"       | <ALLOCATION_ID> (int)   |
+| Index Key + Value | "client"   | <CLIENT_ACTOR_ID> (int) |
+| Index Key + Value | "provider" | <SP_ACTOR_ID> (int)     |
 
 #### Datacap Allocation Removed
 This event is emitted when a datacap allocation that is past its expiration epoch is removed.
 
 The event payload is defined as:
 
-| flags | key | value                         |
-| --- | --- |-------------------------------|
-| Index Key + Value | “$type” | “allocation-removed” (string) |
-| Index Key + Value | “id” | <ALLOCATION_ID> (int)         |
-| Index Key + Value | “client” | <CLIENT_ACTOR_ID> (int)       |
-| Index Key + Value | “provider” | <SP_ACTOR_ID> (int)           |
-
+| flags             | key        | value                         |
+| ----------------- | ---------- | ----------------------------- |
+| Index Key + Value | "$type"    | "allocation-removed" (string) |
+| Index Key + Value | "id"       | <ALLOCATION_ID> (int)         |
+| Index Key + Value | "client"   | <CLIENT_ACTOR_ID> (int)       |
+| Index Key + Value | "provider" | <SP_ACTOR_ID> (int)           |
 
 
 #### Allocation Claimed
@@ -98,38 +97,36 @@ This event is emitted when a client allocation is claimed by a storage provider 
 
 The event payload is defined as:
 
-| flags | key | value                 |
-| --- | --- |-----------------------|
-| Index Key + Value | “$type” | “claim” (string)      |
-| Index Key + Value | “id” | <CLAIM_ID> (int)      |
-| Index Key + Value | “client” | <CLIENT_ACTOR_ID> (int) |
-| Index Key + Value | “provider” | <SP_ACTOR_ID> (int)   |
-| Index Key + Value | "piece-cid" | <PIECE_CID> (cid) |
-| Index Key         | "piece-size" | <PIECE_SIZE> (int) |
+| flags             | key        | value                   |
+| ----------------- | ---------- | ----------------------- |
+| Index Key + Value | "$type"    | "claim" (string)        |
+| Index Key + Value | "id"       | <CLAIM_ID> (int)        |
+| Index Key + Value | "client"   | <CLIENT_ACTOR_ID> (int) |
+| Index Key + Value | "provider" | <SP_ACTOR_ID> (int)     |
 
 #### Claim Updated
 This event is emitted when the term of an existing allocation is extended by the client.
 
 The event payload is defined as:
 
-| flags | key | value                    |
-| --- | --- |--------------------------|
-| Index Key + Value | “$type” | “claim-updated” (string) |
-| Index Key + Value | “id” | <CLAIM_ID> (int)         |
-| Index Key + Value | “client” | <CLIENT_ACTOR_ID> (int)  |
-| Index Key + Value | “provider” | <SP_ACTOR_ID> (int)      |
+| flags             | key        | value                    |
+| ----------------- | ---------- | ------------------------ |
+| Index Key + Value | "$type"    | "claim-updated" (string) |
+| Index Key + Value | "id"       | <CLAIM_ID> (int)         |
+| Index Key + Value | "client"   | <CLIENT_ACTOR_ID> (int)  |
+| Index Key + Value | "provider" | <SP_ACTOR_ID> (int)      |
 
 ####  Claim Removed
 This event is emitted when an expired claim is removed by the Verified Registry Actor.
 
 The event payload is defined as:
 
-| flags | key | value                    |
-| --- | --- |--------------------------|
-| Index Key + Value | “$type” | “claim-removed” (string) |
-| Index Key + Value | “id” | <CLAIM_ID> (int)         |
-| Index Key + Value | “client” | <CLIENT_ACTOR_ID> (int)  |
-| Index Key + Value | “provider” | <SP_ACTOR_ID> (int)      |
+| flags             | key        | value                    |
+| ----------------- | ---------- | ------------------------ |
+| Index Key + Value | "$type"    | "claim-removed" (string) |
+| Index Key + Value | "id"       | <CLAIM_ID> (int)         |
+| Index Key + Value | "client"   | <CLIENT_ACTOR_ID> (int)  |
+| Index Key + Value | "provider" | <SP_ACTOR_ID> (int)      |
 
 ### Market Actor Events
 The Market Actor emits the following deal lifecycle events:
@@ -139,11 +136,11 @@ This event is emitted for each new deal that is successfully published by a stor
 
 The event payload is defined as:
 
-| flags | key | value                             |
-| --- | --- |-----------------------------------|
-| Index Key + Value | “$type” | "deal-published" (string)         |
-| Index Key + Value | "id" | <DEAL_ID> (int)                   |
-| Index Key + Value | "client" | <STORAGE_CLIENT_ACTOR_ID> (int)   |
+| flags             | key        | value                             |
+| ----------------- | ---------- | --------------------------------- |
+| Index Key + Value | "$type"    | "deal-published" (string)         |
+| Index Key + Value | "id"       | <DEAL_ID> (int)                   |
+| Index Key + Value | "client"   | <STORAGE_CLIENT_ACTOR_ID> (int)   |
 | Index Key + Value | "provider" | <STORAGE_PROVIDER_ACTOR_ID> (int) |
 
 #### Deal Activated
@@ -151,11 +148,11 @@ The deal activation event is emitted for each deal that is successfully activate
 
 The event payload is defined as:
 
-| flags | key | value                     |
-| --- | --- |---------------------------|
-| Index Key + Value | “$type” | "deal-activated" (string) |
-| Index Key + Value | “id” | <DEAL_ID> (int)           |
-| Index Key + Value | "client" | <STORAGE_CLIENT_ACTOR_ID> (int)   |
+| flags             | key        | value                             |
+| ----------------- | ---------- | --------------------------------- |
+| Index Key + Value | "$type"    | "deal-activated" (string)         |
+| Index Key + Value | "id"       | <DEAL_ID> (int)                   |
+| Index Key + Value | "client"   | <STORAGE_CLIENT_ACTOR_ID> (int)   |
 | Index Key + Value | "provider" | <STORAGE_PROVIDER_ACTOR_ID> (int) |
 
 #### Deal Terminated
@@ -169,11 +166,11 @@ as terminated by the `OnMinerSectorsTerminate` method.
 
 The event payload is defined as:
 
-| flags | key | value                      |
-| --- | --- |----------------------------|
-| Index Key + Value | “$type” | "deal-terminated" (string) |
-| Index Key + Value | “id” | <DEAL_ID> (int)            |
-| Index Key + Value | "client" | <STORAGE_CLIENT_ACTOR_ID> (int)   |
+| flags             | key        | value                             |
+| ----------------- | ---------- | --------------------------------- |
+| Index Key + Value | "$type"    | "deal-terminated" (string)        |
+| Index Key + Value | "id"       | <DEAL_ID> (int)                   |
+| Index Key + Value | "client"   | <STORAGE_CLIENT_ACTOR_ID> (int)   |
 | Index Key + Value | "provider" | <STORAGE_PROVIDER_ACTOR_ID> (int) |
 
 #### Deal Completed Successfully 
@@ -186,11 +183,11 @@ This applies to new deals made post landing FIP-0074. For deals made before FIP-
 
 The event payload is defined as:
 
-| flags | key | value                     |
-| --- | --- |---------------------------|
-| Index Key + Value | “$type” | "deal-completed" (string) |
-| Index Key + Value | “id” | <DEAL_ID> (int)           |
-| Index Key + Value | "client" | <STORAGE_CLIENT_ACTOR_ID> (int)   |
+| flags             | key        | value                             |
+| ----------------- | ---------- | --------------------------------- |
+| Index Key + Value | "$type"    | "deal-completed" (string)         |
+| Index Key + Value | "id"       | <DEAL_ID> (int)                   |
+| Index Key + Value | "client"   | <STORAGE_CLIENT_ACTOR_ID> (int)   |
 | Index Key + Value | "provider" | <STORAGE_PROVIDER_ACTOR_ID> (int) |
 
 ### Miner Actor Events
@@ -201,23 +198,23 @@ The sector pre-committed event is emitted for each new sector that is successful
 
 The event payload is defined as:
 
-| flags | key | value                          |
-| --- | --- |--------------------------------|
-| Index Key + Value | “$type" | "sector-precommitted" (string) |
-| Index Key + Value | “sector” | <SECTOR_NUMER> (int)           |
+| flags             | key      | value                          |
+| ----------------- | -------- | ------------------------------ |
+| Index Key + Value | "$type"  | "sector-precommitted" (string) |
+| Index Key + Value | "sector" | <SECTOR_NUMER> (int)           |
 
 #### Sector Activated
 This event is emitted for each pre-committed sector that is successfully activated by a storage provider. For now, sector activation corresponds 1:1 with prove-committing a sector but this can change in the future.
 
 The event payload is defined as:
 
-| flags             | key            | value                                                        |
-|-------------------|----------------|--------------------------------------------------------------|
-| Index Key + Value | “$type"        | "sector-activated" (string)                                  |
-| Index Key + Value | “sector”       | <SECTOR_NUMER> (int)                                         |
-| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
-| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                            |
-| Index Key         | "piece-size"   | <PIECE_SIZE> (int)                                           |
+| flags             | key            | value                                                         |
+| ----------------- | -------------- | ------------------------------------------------------------- |
+| Index Key + Value | "$type"        | "sector-activated" (string)                                   |
+| Index Key + Value | "sector"       | <SECTOR_NUMER> (int)                                          |
+| Index Key + Value | "unsealed-cid" | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
+| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                             |
+| Index Key         | "piece-size"   | <PIECE_SIZE> (int)                                            |
 
 - Note that `piece-cid` and `piece-size` is included for each piece in the sector.
 
@@ -226,13 +223,13 @@ This event is emitted for each CC sector that is updated to contained actual sea
 
 The event payload is defined as:
 
-| flags             | key            | value                                                        |
-|-------------------|----------------|--------------------------------------------------------------|
-| Index Key + Value | “$type"        | "sector-updated" (string)                                    |
-| Index Key + Value | “sector”       | <SECTOR_NUMER> (int)                                         |
-| Index Key + Value | “unsealed-cid” | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
-| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                            |
-| Index Key         | "piece-size"   | <PIECE_SIZE> (int)                                           | 
+| flags             | key            | value                                                         |
+| ----------------- | -------------- | ------------------------------------------------------------- |
+| Index Key + Value | "$type"        | "sector-updated" (string)                                     |
+| Index Key + Value | "sector"       | <SECTOR_NUMER> (int)                                          |
+| Index Key + Value | "unsealed-cid" | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
+| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                             |
+| Index Key         | "piece-size"   | <PIECE_SIZE> (int)                                            | 
 
 - Note that `piece-cid` and `piece-size` is included for each piece in the updated sector.
 
@@ -241,10 +238,10 @@ The sector termination event is emitted for each sector that is marked as termin
 
 The event payload is defined as:
 
-| flags | key | value                        |
-| --- | --- |------------------------------|
-| Index Key + Value | “$type" | "sector-terminated" (string) |
-| Index Key + Value | “sector” | <SECTOR_NUMER> (int)         |
+| flags             | key      | value                        |
+| ----------------- | -------- | ---------------------------- |
+| Index Key + Value | "$type"  | "sector-terminated" (string) |
+| Index Key + Value | "sector" | <SECTOR_NUMER> (int)         |
 
 ### Changing the Market Actor `BatchActivateDealsResult` type
 The legacy (pre [FIP-0076](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md)) sector activation and 
@@ -298,7 +295,7 @@ in and then query the chain state with the corresponding allocation/claim ID to 
 
 ### Market Actor Events
 Once a deal is published, clients have access to the `dealId` of the deal. All Market Actor events except 
-for the “deal published” event have the `dealId` in their payload, which clients can use to filter for events
+for the "deal published" event have the `dealId` in their payload, which clients can use to filter for events
 they are interested in and then query the chain state for more information.
 
 All Market Actor events have the client and provider Actor IDs in the event payload. This enables users

--- a/FIPS/fip-0083.md
+++ b/FIPS/fip-0083.md
@@ -42,8 +42,6 @@ Filecoin network observability tools, block explorers, SP monitoring dashboards,
  2. {"flags": "0x02"} ⇒ Index only the value of the event entry
  3. {"flags": "0x01"} ⇒ Index only the key of the event entry
 
-
-
  _All values in the event payloads defined below are encoded with CBOR and so the codec field for each event_ 
  entry will be set to 0x51.  The codec field is left empty in the payloads defined below only for the 
  sake of brevity.
@@ -52,6 +50,11 @@ Filecoin network observability tools, block explorers, SP monitoring dashboards,
 The FVM currently only supports event values encoded with the `raw` encoding. This FIP adds
 support for CBOR encoding (0x51), and built-in actor event values will be encoded with CBOR.
 
+_Note that the "bigint" CBOR encoding format used below for token amount fields is the same as is
+used for encoding bigints on the Filecoin chain: a byte array representing a big-endian unsigned
+integer, compatible with the Golang `big.Int` byte representation, with a `0x00` (positive) or
+`0x01` (negative) prefix; with a zero-length array representing a value of `0`._
+
 ### Verified Registry Actor Events
 
 #### Verifier Balance Updated
@@ -59,74 +62,106 @@ This event is emitted when the balance of a verifier is updated in the Verified 
 
 The event payload is defined as:
 
-| flags                | key        | value                               |
-| -------------------- | ---------- | ----------------------------------- |
-| Index Key + Value    | "$type"    | "verifier-balance" (string)         |
-| Index Key + Value    | "verifier" | <VERIFIER_ACTOR_ID> (int)           |
-| Index Key            | "balance"  | <VERIFIER_DATACAP_BALANCE> (bigint) |
+| flags                | key             | value                                        |
+| -------------------- | --------------- | -------------------------------------------- |
+| Index Key + Value    | "$type"         | "verifier-balance" (string)                  |
+| Index Key + Value    | "verifier"      | <VERIFIER_ACTOR_ID> (int)                    |
+| Index Key + Value    | "client"        | <DATACAP_HOLDER_ACTOR_ID> (int)              |
+| Index Key            | "prev-balance"  | <PREVIOUS_VERIFIER_DATACAP_BALANCE> (bigint) |
+| Index Key            | "balance"       | <VERIFIER_DATACAP_BALANCE> (bigint)          |
 
-_The "bigint" CBOR encoding format used for the "balance" field is the same as is used for encoding bigints on the Filecoin chain: a byte array representing a big-endian unsigned integer, compatible with the Golang `big.Int` byte representation, with a `0x00` (positive) or `0x01` (negative) prefix; with a zero-length array representing a value of `0`._
+* `client` will not be present for `AddVerifier` and `RemoveVerifier` methods but will be for the `AddVerifiedClient` method and indicates the actor ID of the receiver of the datacap.
+* `prev-balance` will be zero for the `AddVerifier` method.
+* `balance` will be zero for the `RemoveVerifier` method.
 
 #### Datacap Allocated
 This event is emitted when a verified client allocates datacap to a specific data piece and storage provider.  
 
 The event payload is defined as:
 
-| flags             | key        | value                   |
-| ----------------- | ---------- | ----------------------- |
-| Index Key + Value | "$type"    | "allocation" (string)   |
-| Index Key + Value | "id"       | <ALLOCATION_ID> (int)   |
-| Index Key + Value | "client"   | <CLIENT_ACTOR_ID> (int) |
-| Index Key + Value | "provider" | <SP_ACTOR_ID> (int)     |
+| flags             | key          | value                    |
+| ----------------- | ------------ | ------------------------ |
+| Index Key + Value | "$type"      | "allocation" (string)    |
+| Index Key + Value | "id"         | <ALLOCATION_ID> (int)    |
+| Index Key + Value | "client"     | <CLIENT_ACTOR_ID> (int)  |
+| Index Key + Value | "provider"   | <SP_ACTOR_ID> (int)      |
+| Index Key + Value | "piece-cid"  | <PIECE_CID> (cid)        |
+| Index Key         | "piece-size" | <PIECE_SIZE> (int)       |
+| Index Key         | "term-min"   | <TERM_MINIMUM> (int)     |
+| Index Key         | "term-max"   | <TERM_MAXIMUM> (int)     |
+| Index Key + Value | "expiration" | <EXPIRATION_EPOCH> (int) |
 
 #### Datacap Allocation Removed
 This event is emitted when a datacap allocation that is past its expiration epoch is removed.
 
 The event payload is defined as:
 
-| flags             | key        | value                         |
-| ----------------- | ---------- | ----------------------------- |
-| Index Key + Value | "$type"    | "allocation-removed" (string) |
-| Index Key + Value | "id"       | <ALLOCATION_ID> (int)         |
-| Index Key + Value | "client"   | <CLIENT_ACTOR_ID> (int)       |
-| Index Key + Value | "provider" | <SP_ACTOR_ID> (int)           |
+| flags             | key          | value                         |
+| ----------------- | ------------ | ----------------------------- |
+| Index Key + Value | "$type"      | "allocation-removed" (string) |
+| Index Key + Value | "id"         | <ALLOCATION_ID> (int)         |
+| Index Key + Value | "client"     | <CLIENT_ACTOR_ID> (int)       |
+| Index Key + Value | "provider"   | <SP_ACTOR_ID> (int)           |
+| Index Key + Value | "piece-cid"  | <PIECE_CID> (cid)             |
+| Index Key         | "piece-size" | <PIECE_SIZE> (int)            |
+| Index Key         | "term-min"   | <TERM_MINIMUM> (int)          |
+| Index Key         | "term-max"   | <TERM_MAXIMUM> (int)          |
+| Index Key + Value | "expiration" | <EXPIRATION_EPOCH> (int)      |
 
-
-#### Allocation Claimed
+#### Datacap Allocation Claimed
 This event is emitted when a client allocation is claimed by a storage provider after the corresponding verified data is provably committed to the chain.
 
 The event payload is defined as:
 
-| flags             | key        | value                   |
-| ----------------- | ---------- | ----------------------- |
-| Index Key + Value | "$type"    | "claim" (string)        |
-| Index Key + Value | "id"       | <CLAIM_ID> (int)        |
-| Index Key + Value | "client"   | <CLIENT_ACTOR_ID> (int) |
-| Index Key + Value | "provider" | <SP_ACTOR_ID> (int)     |
+| flags             | key          | value                    |
+| ----------------- | ------------ | ------------------------ |
+| Index Key + Value | "$type"      | "claim" (string)         |
+| Index Key + Value | "id"         | <CLAIM_ID> (int)         |
+| Index Key + Value | "client"     | <CLIENT_ACTOR_ID> (int)  |
+| Index Key + Value | "provider"   | <SP_ACTOR_ID> (int)      |
+| Index Key + Value | "piece-cid"  | <PIECE_CID> (cid)        |
+| Index Key         | "piece-size" | <PIECE_SIZE> (int)       |
+| Index Key + Value | "sector"     | <SECTOR_ID> (int)        |
+| Index Key         | "term-min"   | <TERM_MINIMUM> (int)     |
+| Index Key         | "term-max"   | <TERM_MAXIMUM> (int)     |
+| Index Key + Value | "expiration" | <EXPIRATION_EPOCH> (int) |
 
-#### Claim Updated
+#### Datacap Claim Updated
 This event is emitted when the term of an existing allocation is extended by the client.
 
 The event payload is defined as:
 
-| flags             | key        | value                    |
-| ----------------- | ---------- | ------------------------ |
-| Index Key + Value | "$type"    | "claim-updated" (string) |
-| Index Key + Value | "id"       | <CLAIM_ID> (int)         |
-| Index Key + Value | "client"   | <CLIENT_ACTOR_ID> (int)  |
-| Index Key + Value | "provider" | <SP_ACTOR_ID> (int)      |
+| flags             | key             | value                         |
+| ----------------- | --------------- | ----------------------------- |
+| Index Key + Value | "$type"         | "claim-updated" (string)      |
+| Index Key + Value | "id"            | <CLAIM_ID> (int)              |
+| Index Key + Value | "client"        | <CLIENT_ACTOR_ID> (int)       |
+| Index Key + Value | "provider"      | <SP_ACTOR_ID> (int)           |
+| Index Key + Value | "piece-cid"     | <PIECE_CID> (cid)             |
+| Index Key         | "piece-size"    | <PIECE_SIZE> (int)            |
+| Index Key + Value | "sector"        | <SECTOR_ID> (int)             |
+| Index Key         | "term-min"      | <TERM_MINIMUM> (int)          |
+| Index Key         | "term-max"      | <TERM_MAXIMUM> (int)          |
+| Index Key         | "prev-term-max" | <PREVIOUS_TERM_MAXIMUM> (int) |
+| Index Key + Value | "expiration"    | <EXPIRATION_EPOCH> (int)      |
 
-####  Claim Removed
+#### Datacap Claim Removed
 This event is emitted when an expired claim is removed by the Verified Registry Actor.
 
 The event payload is defined as:
 
-| flags             | key        | value                    |
-| ----------------- | ---------- | ------------------------ |
-| Index Key + Value | "$type"    | "claim-removed" (string) |
-| Index Key + Value | "id"       | <CLAIM_ID> (int)         |
-| Index Key + Value | "client"   | <CLIENT_ACTOR_ID> (int)  |
-| Index Key + Value | "provider" | <SP_ACTOR_ID> (int)      |
+| flags             | key          | value                    |
+| ----------------- | ------------ | ------------------------ |
+| Index Key + Value | "$type"      | "claim-removed" (string) |
+| Index Key + Value | "id"         | <CLAIM_ID> (int)         |
+| Index Key + Value | "client"     | <CLIENT_ACTOR_ID> (int)  |
+| Index Key + Value | "provider"   | <SP_ACTOR_ID> (int)      |
+| Index Key + Value | "piece-cid"  | <PIECE_CID> (cid)        |
+| Index Key         | "piece-size" | <PIECE_SIZE> (int)       |
+| Index Key + Value | "sector"     | <SECTOR_ID> (int)        |
+| Index Key         | "term-min"   | <TERM_MINIMUM> (int)     |
+| Index Key         | "term-max"   | <TERM_MAXIMUM> (int)     |
+| Index Key + Value | "expiration" | <EXPIRATION_EPOCH> (int) |
 
 ### Market Actor Events
 The Market Actor emits the following deal lifecycle events:
@@ -136,42 +171,43 @@ This event is emitted for each new deal that is successfully published by a stor
 
 The event payload is defined as:
 
-| flags             | key        | value                             |
-| ----------------- | ---------- | --------------------------------- |
-| Index Key + Value | "$type"    | "deal-published" (string)         |
-| Index Key + Value | "id"       | <DEAL_ID> (int)                   |
-| Index Key + Value | "client"   | <STORAGE_CLIENT_ACTOR_ID> (int)   |
-| Index Key + Value | "provider" | <STORAGE_PROVIDER_ACTOR_ID> (int) |
+| flags             | key                   | value                              |
+| ----------------- | --------------------- | ---------------------------------- |
+| Index Key + Value | "$type"               | "deal-published" (string)          |
+| Index Key + Value | "id"                  | <DEAL_ID> (int)                    |
+| Index Key + Value | "client"              | <STORAGE_CLIENT_ACTOR_ID> (int)    |
+| Index Key + Value | "provider"            | <STORAGE_PROVIDER_ACTOR_ID> (int)  |
 
 #### Deal Activated
 The deal activation event is emitted for each deal that is successfully activated. 
 
 The event payload is defined as:
 
-| flags             | key        | value                             |
-| ----------------- | ---------- | --------------------------------- |
-| Index Key + Value | "$type"    | "deal-activated" (string)         |
-| Index Key + Value | "id"       | <DEAL_ID> (int)                   |
-| Index Key + Value | "client"   | <STORAGE_CLIENT_ACTOR_ID> (int)   |
-| Index Key + Value | "provider" | <STORAGE_PROVIDER_ACTOR_ID> (int) |
+| flags             | key                   | value                              |
+| ----------------- | --------------------- | ---------------------------------- |
+| Index Key + Value | "$type"               | "deal-activated" (string)          |
+| Index Key + Value | "id"                  | <DEAL_ID> (int)                    |
+| Index Key + Value | "client"              | <STORAGE_CLIENT_ACTOR_ID> (int)    |
+| Index Key + Value | "provider"            | <STORAGE_PROVIDER_ACTOR_ID> (int)  |
 
 #### Deal Terminated
 [FIP-0074](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0074.md) ensures that terminated deals are processed immediately in the `OnMinerSectorsTerminate` method
 rather than being submitted for deferred processing to the market actor cron job. That change will make 
 this event available to clients.
 
-
 The deal termination event is emitted by the market actor cron job when it processes deals that were marked
 as terminated by the `OnMinerSectorsTerminate` method. 
 
 The event payload is defined as:
 
-| flags             | key        | value                             |
-| ----------------- | ---------- | --------------------------------- |
-| Index Key + Value | "$type"    | "deal-terminated" (string)        |
-| Index Key + Value | "id"       | <DEAL_ID> (int)                   |
-| Index Key + Value | "client"   | <STORAGE_CLIENT_ACTOR_ID> (int)   |
-| Index Key + Value | "provider" | <STORAGE_PROVIDER_ACTOR_ID> (int) |
+| flags             | key                   | value                             |
+| ----------------- | --------------------- | --------------------------------- |
+| Index Key + Value | "$type"               | "deal-terminated" (string)        |
+| Index Key + Value | "id"                  | <DEAL_ID> (int)                   |
+| Index Key + Value | "client"              | <STORAGE_CLIENT_ACTOR_ID> (int)   |
+| Index Key + Value | "provider"            | <STORAGE_PROVIDER_ACTOR_ID> (int) |
+
+* `end-epoch` is the nominal end epoch of the deal per the deal proposal, not the termination epoch.
 
 #### Deal Completed Successfully 
 This event is emitted when a deal is marked as successfully complete by the Market Actor cron job. 
@@ -183,12 +219,12 @@ This applies to new deals made post landing FIP-0074. For deals made before FIP-
 
 The event payload is defined as:
 
-| flags             | key        | value                             |
-| ----------------- | ---------- | --------------------------------- |
-| Index Key + Value | "$type"    | "deal-completed" (string)         |
-| Index Key + Value | "id"       | <DEAL_ID> (int)                   |
-| Index Key + Value | "client"   | <STORAGE_CLIENT_ACTOR_ID> (int)   |
-| Index Key + Value | "provider" | <STORAGE_PROVIDER_ACTOR_ID> (int) |
+| flags             | key                   | value                             |
+| ----------------- | --------------------- | --------------------------------- |
+| Index Key + Value | "$type"               | "deal-completed" (string)         |
+| Index Key + Value | "id"                  | <DEAL_ID> (int)                   |
+| Index Key + Value | "client"              | <STORAGE_CLIENT_ACTOR_ID> (int)   |
+| Index Key + Value | "provider"            | <STORAGE_PROVIDER_ACTOR_ID> (int) |
 
 ### Miner Actor Events
 The Miner Actor emits the following sector lifecycle events:
@@ -198,50 +234,58 @@ The sector pre-committed event is emitted for each new sector that is successful
 
 The event payload is defined as:
 
-| flags             | key      | value                          |
-| ----------------- | -------- | ------------------------------ |
-| Index Key + Value | "$type"  | "sector-precommitted" (string) |
-| Index Key + Value | "sector" | <SECTOR_NUMER> (int)           |
+| flags             | key                | value                                                         |
+| ----------------- | ------------------ | ------------------------------------------------------------- |
+| Index Key + Value | "$type"            | "sector-precommitted" (string)                                |
+| Index Key + Value | "sector"           | <SECTOR_NUMER> (int)                                          |
+
+* `deal` is included for each deal in the sector, i.e. it may appear zero or more times in the event payload.
 
 #### Sector Activated
 This event is emitted for each pre-committed sector that is successfully activated by a storage provider. For now, sector activation corresponds 1:1 with prove-committing a sector but this can change in the future.
 
 The event payload is defined as:
 
-| flags             | key            | value                                                         |
-| ----------------- | -------------- | ------------------------------------------------------------- |
-| Index Key + Value | "$type"        | "sector-activated" (string)                                   |
-| Index Key + Value | "sector"       | <SECTOR_NUMER> (int)                                          |
-| Index Key + Value | "unsealed-cid" | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
-| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                             |
-| Index Key         | "piece-size"   | <PIECE_SIZE> (int)                                            |
+| flags             | key                | value                                                         |
+| ----------------- | ------------------ | ------------------------------------------------------------- |
+| Index Key + Value | "$type"            | "sector-activated" (string)                                   |
+| Index Key + Value | "sector"           | <SECTOR_NUMER> (int)                                          |
+| Index Key + Value | "unsealed-cid"     | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
+| Index Key + Value | "expiration-epoch" | <END_EPOCH> (int)                                             |
+| Index Key + Value | "piece-cid"        | <PIECE_CID> (cid)                                             |
+| Index Key         | "piece-size"       | <PIECE_SIZE> (int)                                            |
+| Index Key + Value | "claim"            | <CLAIM_ID> (cid)                                              |
 
-- Note that `piece-cid` and `piece-size` is included for each piece in the sector.
+* `piece-cid` and `piece-size` is included for each piece in the sector, i.e. they may appear zero or more times in the event payload but always as a pair.
+* `claim` will accompany the `piece-cid` and `piece-size` pair for each piece in the sector where datacap is allocated to the piece via the verified registry actor. A matching `claim` event will be emitted by the verified registry actor for each `claim` in the `sector-activated` event payload.
 
 #### Sector Updated
 This event is emitted for each CC sector that is updated to contained actual sealed data.
 
 The event payload is defined as:
 
-| flags             | key            | value                                                         |
-| ----------------- | -------------- | ------------------------------------------------------------- |
-| Index Key + Value | "$type"        | "sector-updated" (string)                                     |
-| Index Key + Value | "sector"       | <SECTOR_NUMER> (int)                                          |
-| Index Key + Value | "unsealed-cid" | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
-| Index Key + Value | "piece-cid"    | <PIECE_CID> (cid)                                             |
-| Index Key         | "piece-size"   | <PIECE_SIZE> (int)                                            | 
+| flags             | key                | value                                                         |
+| ----------------- | ------------------ | ------------------------------------------------------------- |
+| Index Key + Value | "$type"            | "sector-updated" (string)                                     |
+| Index Key + Value | "sector"           | <SECTOR_NUMER> (int)                                          |
+| Index Key + Value | "unsealed-cid"     | <SECTOR_COMMD> (nullable cid) (null means sector has no data) |
+| Index Key + Value | "expiration-epoch" | <END_EPOCH> (int)                                             |
+| Index Key + Value | "piece-cid"        | <PIECE_CID> (cid)                                             |
+| Index Key         | "piece-size"       | <PIECE_SIZE> (int)                                            |
+| Index Key + Value | "claim"            | <CLAIM_ID> (cid)                                              |
 
-- Note that `piece-cid` and `piece-size` is included for each piece in the updated sector.
+* `piece-cid` and `piece-size` is included for each piece in the sector, i.e. they may appear zero or more times in the event payload but always as a pair.
+* `claim` will accompany the `piece-cid` and `piece-size` pair for each piece in the sector where datacap is allocated to the piece via the verified registry actor. A matching `claim` event will be emitted by the verified registry actor for each `claim` in the `sector-updated` event payload.
 
 #### Sector Terminated
 The sector termination event is emitted for each sector that is marked as terminated by a storage provider. 
 
 The event payload is defined as:
 
-| flags             | key      | value                        |
-| ----------------- | -------- | ---------------------------- |
-| Index Key + Value | "$type"  | "sector-terminated" (string) |
-| Index Key + Value | "sector" | <SECTOR_NUMER> (int)         |
+| flags             | key       | value                        |
+| ----------------- | --------- | ---------------------------- |
+| Index Key + Value | "$type"   | "sector-terminated" (string) |
+| Index Key + Value | "sector"  | <SECTOR_NUMER> (int)         |
 
 ### Changing the Market Actor `BatchActivateDealsResult` type
 The legacy (pre [FIP-0076](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md)) sector activation and 


### PR DESCRIPTION
This is a revisit of #955, a proposal to add additional information to built-in actor events, but adds more information across more events than #955 did. That PR was discussed further in this thread: https://github.com/filecoin-project/FIPs/discussions/754#discussioncomment-8698293, where it was pointed out regarding the costs of these events:

> On thing that is new since the beginning of this discussion is that we have quantified the gas cost. Built-in actor methods tend to be doing a lot, so the cost of events is very small as a proportion. Perhaps the minimalist approach isn't right here, and we should just include all the near-to-hand information with all events?

After receiving additional feedback on the information currently available in events, including from a raised awareness of the implications of DDO in network version 22 on observability concerns, we're coming back with **this new proposal that we're hoping to get approved and shipped _with_ network version 22**.

Given the tight time constraints and concerns about stability, we've attempted to craft a line between "near-to-hand" information (i.e. low-risk, minimal code changes) and "maximally useful" when considering the requirements we are hearing from parties concerned about a DDO world.

A lot of the feedback we have received is related to the verified registry and the difficulties in tracking claims, pieces, SPs and clients and their relationships. The events, as they are currently structured, require reactive state inspection to provide enough context to make sense of them, such as the example of claims outlined #955.

The diff here also includes some formatting changes, so it's a bit noisier than just the pure event changes, sorry. The changes proposed here are summarised as follows:

**Verified registry events**

* `verifier-balance`
  * Add `"prev-balance"` (zero for `AddVerifier`, whereas `"balance"` is zero for `RemoveVerifier`)
  * Add `"client"` (ID) as optional (only used for `AddVerifiedClient`)
* `allocation`
  * Add `"piece-cid"` and `"piece-size"`
  * Add `"term-max"` and `"term-min"`
  * Add `"expiration"`
* `allocation-removed`
  * Add `"piece-cid"` and `"piece-size"`
  * Add `"term-max"` and `"term-min"`
  * Add `"expiration"`
* `claim`
  * Add `"piece-cid"` and `"piece-size"`
  * Add `"sector"` (ID)
  * Add `"term-max"` and `"term-min"`
  * Add `"expiration"`
* `claim-updated`
  * Add `"piece-cid"` and `"piece-size"`
  * Add `"sector"` (ID)
  * Add `"term-max"` and `"term-min"`
  * Add `"prev-term-max"`
  * Add `"expiration"`
* `claim-removed`
  * Add `"piece-cid"` and `"piece-size"`
  * Add `"sector"` (ID)
  * Add `"term-max"` and `"term-min"`
  * Add `"expiration"`

**Market actor events**

No changes, these are complicated because there's so much information possible to include (e.g. all `DealProposal` could be included on all of these events) and can be revisited in a future FIP according to feedback. Hopefully many existing workflows will be sufficient where the market actor is involved.

**Miner actor events**

* `sector-activated`
  * Add `"expiration-epoch"`
  * Add `"claim"` (ID) to couple with each `"piece-cid"` & `"piece-size"` pair where a claim is made
* `sector-updated`
  * Add `"expiration-epoch"`
  * Add `"claim"` (ID) to couple with each `"piece-cid"` & `"piece-size"` pair where a claim is made
