### PR TITLE
FIP-0086: Fix minor typos and inconsistent styling

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -286,7 +286,7 @@ type AggregatedEvidence struct {
 }
 ```
 
-All messages broadcasted by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over $(Instance || MsgType || Value || Round)$. The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
+All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over $(Instance || MsgType || Value || Round)$. The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
 
 The receiver of a message only considers messages with valid signatures and discards all other messages as invalid. We sometimes omit the sender IDs and signatures in further descriptions for better readability.
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -255,21 +255,21 @@ type ECTipset struct {
   PowerTable CID // CID of a PowerTable
 }
 
-// Table of nodes with power >0 and their public keys.
+// Table of nodes with power > 0 and their public keys.
 // This is expected to be calculated from the EC chain state and provided to GossiPBFT.
 // In descending order to provide unique representation.
 type PowerTable {
   Entries []PowerTableEntry
 }
 
-type PowerTableEntry {
+type PowerTableEntry struct {
   ParticipantID ActorID
   Power BigInt
   Key BLSPublicKey
 }
 
 // Aggregated list of GossiPBFT messages with the same instance, round and value. Used as evidence for justification of messages
-type AggregatedEvidence {
+type AggregatedEvidence struct {
   // Enumeration of QUALITY, PREPARE, COMMIT, CONVERGE, DECIDE
   MsgType int
   // Chain of tipsets proposed/voted for finalisation in this instance.
@@ -284,10 +284,9 @@ type AggregatedEvidence {
   // BLS aggregate signature of signers
   Signature []bytes
 }
-
 ```
 
-All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over $(Instance || MsgType || Value || Round)$. The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
+All messages broadcasted by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over $(Instance || MsgType || Value || Round)$. The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
 
 The receiver of a message only considers messages with valid signatures and discards all other messages as invalid. We sometimes omit the sender IDs and signatures in further descriptions for better readability.
 
@@ -301,17 +300,17 @@ A set of messages $M$ that does not contain equivocating messages is called _cle
 * `Power(p | P) ∈ [0, 1]`
     * Returns the relative QAP of participant $p$ (or set of participants $p$) in EC, defined by the power table corresponding to $baseChain$. The returned value is a fraction of the total QAP of all participants in the power table.
 * `isPrefix(a,b)`
-    * Returns $True$ if $a$ is a prefix of $b$. (Each chain is also a prefix of itself.)
-* `StrongQuorum(prefix,M)`
+    * Returns $True$ if chain $a$ is a prefix of chain $b$. (Each chain is also a prefix of itself.)
+* `HasStrongQuorum(prefix,M)`
     * Where $M$ is a clean set of messages of the same type and the same round.
-    * Let $p$ be the set of participants who are senders of messages in $M$ such that their message contains a value with $prefix$ as a prefix. More precisely:
+    * Let $P$ be the set of participants who are senders of messages in $M$ such that their message contains a value with $prefix$ as a prefix. More precisely:
       ```
       Let P={p : ∃ m∈ M: m.sender=p AND isPrefix(prefix,m.value)}
       ```
       then the predicate returns $True$ iff $\texttt{Power}(P)>2/3$
 * `HasStrongQuorumValue(M)`
     * Where $M$ is a clean set of messages of the same type and the same round
-    * The predicate returns $True$ iff there is a value $v$, such that there is a set $p$ of participants who are senders of messages in $M$ such that their message value is exactly $v$ and $\texttt{Power}(P)>2/3$. More precisely:
+    * The predicate returns $True$ iff there is a value $v$, such that there is a set $P$ of participants who are senders of messages in $M$ such that their message value is exactly $v$ and $\texttt{Power}(P)>2/3$. More precisely:
       ```
       HasStrongQuorumValue(M) = ∃ v: Power({p : ∃ m∈ M: m.sender=p AND m.value=v})>2/3
       ```
@@ -319,7 +318,7 @@ A set of messages $M$ that does not contain equivocating messages is called _cle
     * Returns $v$ if $\texttt{HasStrongQuorumValue}(M)$ holds, $nil$ otherwise.
 * `HasWeakQuorumValue(M)`
     * Where $M$ is a clean set of messages of the same type and the same round
-    * The predicate returns True iff there is a value $v$, such that there is a set $p$ of participants who are senders of messages in $M$ such that their message value is exactly $v$ and $\texttt{Power}(P)>1/3$. More precisely:
+    * The predicate returns True iff there is a value $v$, such that there is a set $P$ of participants who are senders of messages in $M$ such that their message value is exactly $v$ and $\texttt{Power}(P)>1/3$. More precisely:
       ```
       HasWeakQuorumValue(M) = ∃ v: Power({p : ∃ m∈ M: m.sender=p AND m.value=v})>1/3
       ```
@@ -357,8 +356,8 @@ GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
 9:      if (round = 0)
 10:       BEBroadcast <QUALITY, value, instance>; trigger (timeout)
 11:       collect a clean set M of valid QUALITY messages
-          until StrongQuorum(proposal, M) OR timeout expires
-12:       let C={prefix : IsPrefix(prefix,proposal) and StrongQuorum(prefix,M)}
+          until HasStrongQuorum(proposal, M) OR timeout expires
+12:       let C={prefix : IsPrefix(prefix,proposal) and HasStrongQuorum(prefix,M)}
 13:       if (C = ∅)
 14:         proposal ← baseChain \* no proposals of high-enough quality
 15:       else
@@ -366,7 +365,7 @@ GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
 17:       value ← proposal
 
 18:     if (round > 0)     \* CONVERGE
-19:       ticket ← VRF(Randomness(baseChain) || instance || round )
+19:       ticket ← VRF(Randomness(baseChain) || instance || round)
 20:       value ← proposal \* set local proposal as value in CONVERGE message
 21:       BEBroadcast <CONVERGE, value, instance, round, evidence, ticket>; trigger(timeout)
 22:       collect a clean set M of valid CONVERGE msgs from this round
@@ -380,7 +379,7 @@ GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
 28:     BEBroadcast <PREPARE, value, instance, round>; trigger(timeout)
 29:     collect a clean set M of valid <PREPARE, proposal, instance, round> msgs \* match PREPARE value against local proposal
         until Power(M) > ⅔ OR timeout expires
-30:     if (Power(M)>⅔)  \* strong quorum of PREPAREs for local proposal
+30:     if (Power(M) > ⅔)  \* strong quorum of PREPAREs for local proposal
 31:       value ← proposal \* vote for deciding proposal (COMMIT)
 32:       evidence ← Aggregate(M) \* strong quorum of PREPAREs is evidence
 33:     else
@@ -413,7 +412,7 @@ GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
 53:     BEBroadcast <DECIDE, value, instance, evidence>
 54:     go to line 49
 ```
-Note that the selection of the heaviest prefix in line 16 need not read the tipsets' weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or viceversa (since the adversary controls <⅓ of the QAP). As a result, selecting the heaviest prefix is as simple as selecting the highest blockheight, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
+Note that the selection of the heaviest prefix in line 16 need not read the tipsets' weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or viceversa (since the adversary controls < ⅓ of the QAP). As a result, selecting the heaviest prefix is as simple as selecting the highest blockheight, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
 
 Also, concurrently, we expect that the participant feeds to GossiPBFT chains that are incentive-compatible with EC. To this end, GossiPBFT has a separate invocation called $\texttt{ECUpdate}()$, which is called by an external process at a participant once EC delivers a $chain$ such that $inputChain$ is a prefix of $chain$ (i.e., EC at a participant delivers an extension of $inputChain$). This part is critical to ensuring the progress property in conjunction with lines 24-25.
 
@@ -426,7 +425,7 @@ ECupdate(chain):
 
 #### Valid messages and evidence
 
-The $\texttt{Valid}()$ predicate (referred to in lines 11, 22, 29, 37, and 49) is defined below.
+The $\texttt{Valid}()$ predicate (referred to in lines 11, 22, 29, 37, and 51) is defined below.
 
 ```
 Valid(m):                                   | For a message m to be valid,
@@ -454,7 +453,7 @@ The $\texttt{ValidEvidence}()$ predicate is defined below. Note that QUALITY, PR
 ValidEvidence(m):
 
 (m = <CONVERGE, value, round, evidence, ticket>         | valid CONVERGE
-AND (∃ M: Power(M)>⅔ AND m.evidence=Aggregate(M)        | evidence is a strong quorum
+AND (∃ M: Power(M) > ⅔ AND m.evidence=Aggregate(M)      | evidence is a strong quorum
   AND ((∀ m' ∈ M: m'.step = COMMIT AND m'.value = 丄)   | of COMMIT msgs for 丄
     OR (∀ m' ∈ M: m'.step = PREPARE AND                 | or PREPARE msgs for
       m'.value = m.value))                              | CONVERGE value
@@ -463,7 +462,7 @@ AND (∃ M: Power(M)>⅔ AND m.evidence=Aggregate(M)        | evidence is a stro
 
 
 OR (m = <COMMIT, value, round, evidence>                | valid COMMIT
-  AND (∃ M: Power(M)>⅔ AND m.evidence=Aggregate(M)      | evidence is a strong quorum
+  AND (∃ M: Power(M) > ⅔ AND m.evidence=Aggregate(M)    | evidence is a strong quorum
     AND ∀ m' ∈ M: m'.step = PREPARE                     | of PREPARE messages
       AND ∀ m' ∈ M: m'.round = m.round                  | from the same round
       AND ∀ m' ∈ M: m'.instance = m.instance            | from the same instance
@@ -488,7 +487,7 @@ GossiPBFT ensures termination provided that (i) all participants start the insta
 
 [Given prior tests performed on GossipSub](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf) (see also [here](https://gist.github.com/jsoares/9ce4c0ba6ebcfd2afa8f8993890e2d98)), we expect that almost all participants will reach sent messages within $Δ=3s$, with a huge majority receiving them even after $Δ=2s$. However, if several participants start the instance $Δ + ε$ after some other participants, termination is not guaranteed for the selected timeouts of $2*Δ$. Thus, we do not rely on an explicit synchrony bound for correctness. Instead, we (i) use drand as a beacon to synchronize participants within an instance and (ii) increase the estimate of Δ locally within an instance as rounds progress without decision.
 
-The synchronization of participants is performed in the call to updateTimeout(timeout, round) (line 47), and works as follows:
+The synchronization of participants is performed in the call to $\texttt{updateTimeout(timeout, round)}$ (line 47), and works as follows:
 
 * Participants start an instance with $Δ=2s$.
 * Participants set their timeout for the current round to $Δ*1.3^{r}$ where $r$ is the round number ($r=0$ for the first round).


### PR DESCRIPTION
* Fix incorrect reference to line number.
* Use consistent `struct` type definition
* Use consistent casing for symbols donated to a set of participants
* Use consistent spacing for better snippet readability.
* Rename `StrongQuorum` to `HasStrongQuorum` to be consistent with other predicate namings.