### PR TITLE
Fix wrong conflict resolution in FIP-0083 update

### DIFF
--- a/FIPS/fip-0083.md
+++ b/FIPS/fip-0083.md
@@ -62,11 +62,16 @@ This event is emitted when the balance of a verifier is updated in the Verified 
 
 The event payload is defined as:
 
-| flags                | key             | value                               |
-| -------------------- | --------------- | ----------------------------------- |
-| Index Key + Value    | "$type"         | "verifier-balance" (string)         |
-| Index Key + Value    | "verifier"      | <VERIFIER_ACTOR_ID> (int)           |
-| Index Key            | "balance"       | <VERIFIER_DATACAP_BALANCE> (bigint) |
+| flags              | key        | value                               |
+|--------------------|------------| ----------------------------------- |
+| Index Key + Value  | "$type"    | "verifier-balance" (string)         |
+| Index Key + Value  | "verifier" | <VERIFIER_ACTOR_ID> (int)           |
+| Index Key + Value  | "client"   | <DATACAP_HOLDER_ACTOR_ID> (optional int) (only present when datacap allocated to a client) |
+| Index Key          | "balance"  | <VERIFIER_DATACAP_BALANCE> (bigint) |
+
+The "bigint" CBOR encoding format used for the "balance" field is the same as is used for encoding bigints on the Filecoin chain: a byte
+array representing a big-endian unsigned integer, compatible with the Golang big.Int byte representation, with a 0x00 (positive)
+or 0x01 (negative) prefix; with a zero-length array representing a value of 0.
 
 #### Datacap Allocated
 This event is emitted when a verified client allocates datacap to a specific data piece and storage provider.  


### PR DESCRIPTION
We accidentally resolved the conflict wrongly before merging https://github.com/filecoin-project/FIPs/pull/968.
This PR fixes that.