### PR TITLE
FIP-0086 Propagate some implementation decisions back to the spec.

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -225,16 +225,16 @@ GossiPBFT was designed with the Filecoin network in mind and presents a set of f
 
 #### Message format, signatures, and equivocation
 
-Messages include the following fields: $\langle Sender, Signature, MsgType, Value, Instance, [Round, Justification, Ticket] \rangle$. As $Round$, Justification, and $Ticket$ are fields that not all message types require, when not required by a message type, their default value is used (i.e. $0$, $nil$, and $[] byte \lbrace\rbrace$, respectively). We refer to a _field_ of message $m$, with $m.field$:
+Messages include the following fields: $\langle Sender, Signature, MsgType, Value, Instance, [Round, Evidence, Ticket] \rangle$. As $Round$, $Evidence$, and $Ticket$ are fields that not all message types require, when not required by a message type, their default value is used (i.e. $0$, $nil$, and $[] byte \lbrace\rbrace$, respectively). We refer to a _field_ of message $m$, with $m.field$:
 
 ```
-// A message in the Granite protocol.
+// A message in the GossiPBFT protocol.
 // The same message structure is used for all rounds and phases.
 // Note that the message is self-attesting so no separate envelope or signature is needed.
 // - The signature field fixes the included sender ID via the implied public key;
 // - The signature payload includes all fields a sender can freely choose;
 // - The ticket field is a signature of the same public key, so also self-attesting.
-type GMessage struct {
+type GossiPBFTMessage struct {
   // ID of the sender/signer of this message (a miner actor ID).
   Sender ActorID
   // Vote is the payload that is signed by the signature.
@@ -243,11 +243,11 @@ type GMessage struct {
   Signature []byte
   // VRF ticket for CONVERGE messages (otherwise empty byte array).
   Ticket Ticket
-  // Justification for this message, or nil.
-  Justification *Justification
+  // Evidence that justifies this message, or nil.
+  Evidence *Evidence
 }
 
-type Justification struct {
+type Evidence struct {
   // Vote is the payload that is signed by the signature.
   Vote Payload
   // RLE+ serialization of the indexes in the base power table of the signers.
@@ -340,14 +340,14 @@ GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
 \*participants is implicitly used to calculate quorums
 
 1:    round ← 0;
-2:    terminated ← False;
+2:    decideSent ← False;
 3:    proposal ← inputChain;  \* holds what the participant locally believes should be a decision
 4:    timeout ← 2*Δ
 5:    ECCompatibleChains ← all prefixes of proposal, not lighter than baseChain
 6:    value ← proposal \* used to communicate the voted value to others (proposal or 丄)
 7:    evidence ← nil   \* used to communicate optional evidence for the voted value
 
-8:    while (not terminated)  {
+8:    while (not decideSent)  {
 9:      if (round = 0)
 10:       BEBroadcast <QUALITY, value, instance>; trigger (timeout)
 11:       collect a clean set M of valid QUALITY messages
@@ -388,8 +388,7 @@ GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
 38:     if (HasStrongQuorumValue(M) AND StrongQuorumValue(M) ≠ 丄)    \* decide
 39:       evidence ← Aggregate(M)
 39:       BEBroadcast <DECIDE, StrongQuorumValue(M), evidence>
-40:       terminated ← True
-          return (StrongQuorumValue(M), Aggregate(M))
+40:       decideSent ← True \* break loop, wait for other DECIDE messages
 41:     if (∃ m ∈ M: m.value ≠ 丄) \* m.value was possibly decided by others
 42:       proposal ← m.value; \* sway local proposal to possibly decided value
 43:       evidence ← m.evidence \* strong PREPARE quorum is inherited evidence
@@ -400,11 +399,12 @@ GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
 48:   }  \*end while
 
 49:   collect a clean set M of valid DECIDE messages
-      until (HasStrongQuorumValue(M)) \* Collect a strong quorum of decide outside the round loop
-50:   terminated ← True
-      return (StrongQuorumValue(M), Aggregate(M))
+      until (HasStrongQuorumValue(M)) \* collect a strong quorum of decide outside the round loop
+50:   return (StrongQuorumValue(M), Aggregate(M)) \* terminate the algorithm with a decision
 ```
-Note that the selection of the heaviest prefix in line 16 need not read the tipsets' weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or viceversa (since the adversary controls < ⅓ of the QAP). As a result, selecting the heaviest prefix is as simple as selecting the highest blockheight, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
+Note that the selection of the heaviest prefix in line 16 does not need access to the tipsets' EC weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or viceversa (since the adversary controls < ⅓ of the QAP). As a result, selecting the heaviest prefix is as simple as selecting the highest blockheight, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
+
+Implementations may optimise this algorithm to treat the reception of an aggregated signature over some (MsgType, Instance, Round, Value) as evidence of a message as if it had received the same tuple of values directly from each participant in the aggregate. This may be used to effectively skip a partially-complete step. In the particular case of a DECIDE message, which carries evidence of a strong quorum of COMMITs for the same round and value, a participant may immediately send its own DECIDE for the same value (copying the evidence) and exit the loop at line 8.
 
 Also, concurrently, we expect that the participant feeds to GossiPBFT chains that are incentive-compatible with EC. To this end, GossiPBFT has a separate invocation called $\texttt{ECUpdate}()$, which is called by an external process at a participant once EC delivers a $chain$ such that $inputChain$ is a prefix of $chain$ (i.e., EC at a participant delivers an extension of $inputChain$). This part is critical to ensuring the progress property in conjunction with lines 24-25.
 
@@ -455,29 +455,28 @@ AND (∃ M: Power(M) > ⅔ AND m.evidence=Aggregate(M)      | evidence is a stro
   AND ((∀ m' ∈ M: m'.step = COMMIT AND m'.value = 丄)   | of COMMIT msgs for 丄
     OR (∀ m' ∈ M: m'.step = PREPARE AND                 | or PREPARE msgs for
       m'.value = m.value))                              | CONVERGE value
-  AND (∀ m' ∈ M: m'.round = m.round-1)                  | from previous round
-  AND (∀ m' ∈ M: m'.instance = m.instance)))            | from the same instance
+  AND (∀ m' ∈ M: m'.round = m.round-1)                  | from previous round to CONVERGE
+  AND (∀ m' ∈ M: m'.instance = m.instance)))            | from the same instance as CONVERGE
 
 
 OR (m = <COMMIT, value, round, evidence>                | valid COMMIT
   AND (∃ M: Power(M) > ⅔ AND m.evidence=Aggregate(M)    | evidence is a strong quorum
     AND ∀ m' ∈ M: m'.step = PREPARE                     | of PREPARE messages
-      AND ∀ m' ∈ M: m'.round = m.round                  | from the same round
-      AND ∀ m' ∈ M: m'.instance = m.instance            | from the same instance
-        AND ∀ m' ∈ M: m'.value = m.value)               | for the same value, or
-    OR (m.value = 丄))                                  | COMMIT is for 丄 with
-                                                        | no evidence
+      AND ∀ m' ∈ M: m'.round = m.round                  | from the same round as COMMIT
+      AND ∀ m' ∈ M: m'.instance = m.instance            | from the same instance as COMMIT
+        AND ∀ m' ∈ M: m'.value = m.value)               | for the same value as COMMIT, or
+  OR (m.value = 丄) AND m.evidence=nil)                 | COMMIT is for 丄 with no evidence
 
 OR (m = <DECIDE, value, round, evidence>                | valid DECIDE
   AND (∃ M: Power(M) > ⅔ AND m.evidence=Aggregate(M)    | evidence is a strong quorum
-    AND ∀ m' ∈ M: m'.step = COMMIT                      | of PREPARE messages
-      AND all the same round (!= m.round)               | from some (all the same) round
-      AND ∀ m' ∈ M: m'.instance = m.instance            | from the same instance
-        AND ∀ m' ∈ M: m'.value = m.value)               | for the same value
+    AND ∀ m' ∈ M: m'.step = COMMIT                      | of COMMIT messages
+      AND ∀ m', m'' ∈ M: m'.round = m''.round           | from some the same round as each other
+      AND ∀ m' ∈ M: m'.instance = m.instance            | from the same instance as DECIDE
+        AND ∀ m' ∈ M: m'.value = m.value)               | for the same value as DECIDE
 ```
 
 ### Evidence verification complexity
-Note that during the validation of each CONVERGE, COMMIT and DECIDE message, two signatures need to be verified: (1) the signature of the message contents, produced by the sender of the message (first check above) and (2) the aggregate signature in $m.evidence$ ($\texttt{ValidEvidence}(m)$ above). The former can be verified using the sender's public key (stored in the power table). The latter, being an aggregated signature, requires aggregating public keys of all the participants whose signatures it combines. Notice that the evidence of each message can be signed by a different set of participants, which requires aggregating a linear number of public BLS keys (in system size) per evidence verification.
+Note that during the validation of each CONVERGE, COMMIT, and DECIDE message, two signatures need to be verified: (1) the signature of the message contents, produced by the sender of the message (first check above) and (2) the aggregate signature in $m.evidence$ ($\texttt{ValidEvidence}(m)$ above). The former can be verified using the sender's public key (stored in the power table). The latter, being an aggregated signature, requires aggregating public keys of all the participants whose signatures it combines. Notice that the evidence of each message can be signed by a different set of participants, which requires aggregating a linear number of public BLS keys (in system size) per evidence verification.
 
 However, a participant only needs to verify the evidence once for each *unique* message (in terms of (step, round, value)) received. Moreover, verification can further be reduced to those messages a participant uses to make progress (such as advancing to the next step or deciding), ignoring the rest as they are not needed for progress. This reduces the number of evidence verifications in each step to at most one.
 
@@ -490,7 +489,7 @@ An instance of GossiPBFT requires a seed σ that must be common among all partic
 
 GossiPBFT ensures termination provided that (i) all participants start the instance at most $\Delta$ apart, and (ii) the estimate on Δ is large enough for $\Delta$-synchrony in some round (either because of the real network delay recovering from asynchrony or because of the estimate increasing).
 
-[Given prior tests performed on GossipSub](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf) (see also [here](https://gist.github.com/jsoares/9ce4c0ba6ebcfd2afa8f8993890e2d98)), we expect that almost all participants will reach sent messages within $Δ=3s$, with a huge majority receiving them even after $Δ=2s$. However, if several participants start the instance $Δ + ε$ after some other participants, termination is not guaranteed for the selected timeouts of $2*Δ$. Thus, we do not rely on an explicit synchrony bound for correctness. Instead, we increase the estimate of Δ locally within an instance as rounds progress without decision.
+[Given prior tests performed on GossipSub](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf) (see also [here](https://gist.github.com/jsoares/9ce4c0ba6ebcfd2afa8f8993890e2d98)), we expect that sent messages will reach almost all participants within $Δ=3s$, with a majority receiving them even after $Δ=2s$. However, if several participants start the instance $Δ + ε$ after some other participants, termination is not guaranteed for the selected timeouts of $2*Δ$. Thus, we do not rely on an explicit synchrony bound for correctness. Instead, we increase the estimate of Δ locally within an instance as rounds progress without decision.
 
 The synchronization of participants is performed in the call to $\texttt{updateTimeout(timeout, round)}$ (line 47), and works as follows:
 
@@ -749,6 +748,9 @@ We refer to the stand-alone implementation in a simulated environment in the [go
 
 - [x] Complete benchmarking around message complexity and computational/networking requirements.
 - [x] Decide between implicit and explicit evidence, taking into account benchmark results.
+- [ ] Specify power table delay mechanism, local message queue, bounds, etc
+- [ ] Re-specify timing of new instances after EC epochs
+- [ ] Specify power table commitment
 - [ ] Finalize and incorporate the WIP finality exchange protocol.
 - [ ] Update and move proofs of correctness and other supplemental documentation into `resources`
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -271,7 +271,7 @@ type Payload struct {
 
 type ECTipset struct {
   Epoch int
-  Tipset []byte // CBOR-serialized tipset key, a canonical array of the tipset's block header CIDs.
+  Tipset []CID // Tipset key, a canonical array of a tipset's block header CIDs.
   PowerTable CID // Commitment to resulting power table.
 }
 
@@ -470,7 +470,7 @@ OR (m = <COMMIT, value, round, evidence>                | valid COMMIT
 OR (m = <DECIDE, value, round, evidence>                | valid DECIDE
   AND (∃ M: Power(M) > ⅔ AND m.evidence=Aggregate(M)    | evidence is a strong quorum
     AND ∀ m' ∈ M: m'.step = COMMIT                      | of COMMIT messages
-      AND ∀ m', m'' ∈ M: m'.round = m''.round           | from some the same round as each other
+      AND ∀ m', m'' ∈ M: m'.round = m''.round           | from the same round as each other
       AND ∀ m' ∈ M: m'.instance = m.instance            | from the same instance as DECIDE
         AND ∀ m' ∈ M: m'.value = m.value)               | for the same value as DECIDE
 ```

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -179,7 +179,7 @@ The algorithm starts by initializing $finalizedTipsets[0]$ with the genesis tips
 3. Execute the instance $i$ of GossiPBFT consensus.
 4. Add the returned tipset from the consensus execution to the $finalizedTipsets$ list.
 
-To prevent useless instances of GossiPBFT deciding on the same $baseChain$ because of the lack of a new epoch that provides a new proposal, we make the $\texttt{ChainHead}()$ function blocking in that it does not return a proposal unless (i) the drand epoch value for the epoch immediately following the latest finalized tipset is received and (ii) the current chain head is different from the chain head of the finalized chain.
+To prevent useless instances of GossiPBFT deciding on the same $baseChain$ because of the lack of a new epoch that provides a new proposal, we make the $\texttt{ChainHead}()$ function blocking in that it does not return a proposal unless the current chain head is different from the chain head of the finalized chain.
 
 
 ### Changes to EC: Fork Choice Rule
@@ -225,39 +225,59 @@ GossiPBFT was designed with the Filecoin network in mind and presents a set of f
 
 #### Message format, signatures, and equivocation
 
-Messages include the following fields: $\langle Sender, Signature, MsgType, Value, Instance, [Round, Evidence, Ticket] \rangle$. As $Round$, $Evidence$, and $Ticket$ are fields that not all message types require, when not required by a message type, their default value is used (i.e. $0$, $\texttt{AggregatedEvidence}(0, [] ECTipset \lbrace\rbrace, 0, 0, [] byte \lbrace\rbrace, [] byte \lbrace\rbrace)$, and $[] byte \lbrace\rbrace$, respectively). We refer to a _field_ of message $m$, with $m.field$:
+Messages include the following fields: $\langle Sender, Signature, MsgType, Value, Instance, [Round, Justification, Ticket] \rangle$. As $Round$, Justification, and $Ticket$ are fields that not all message types require, when not required by a message type, their default value is used (i.e. $0$, $nil$, and $[] byte \lbrace\rbrace$, respectively). We refer to a _field_ of message $m$, with $m.field$:
 
 ```
-type GossiPBFTMessage struct {
-  // ID of the sender/signer of this message (a miner actor)
+// A message in the Granite protocol.
+// The same message structure is used for all rounds and phases.
+// Note that the message is self-attesting so no separate envelope or signature is needed.
+// - The signature field fixes the included sender ID via the implied public key;
+// - The signature payload includes all fields a sender can freely choose;
+// - The ticket field is a signature of the same public key, so also self-attesting.
+type GMessage struct {
+  // ID of the sender/signer of this message (a miner actor ID).
   Sender ActorID
-  // BLS Signature
-  Signature []bytes
-  // Enumeration of QUALITY, PREPARE, COMMIT, CONVERGE, DECIDE
-  MsgType int
-  // Chain of tipsets proposed/voted for finalization in this instance.
-  // Non-empty: the first entry is the base tipset finalized in instance-1
+  // Vote is the payload that is signed by the signature.
+  Vote Payload
+  // Signature by the sender's public key over serialized vote payload.
+  Signature []byte
+  // VRF ticket for CONVERGE messages (otherwise empty byte array).
+  Ticket Ticket
+  // Justification for this message, or nil.
+  Justification *Justification
+}
+
+type Justification struct {
+  // Vote is the payload that is signed by the signature.
+  Vote Payload
+  // RLE+ serialization of the indexes in the base power table of the signers.
+  Signers []byte
+  // BLS aggregate signature of signers over the vote.
+  Signature []byte
+}
+
+// Fields of the message that make up the signature payload.
+type Payload struct {
+  // GossiPBFT instance number.
+  Instance uint64
+  // GossiPBFT round number.
+  Round uint64
+  // GossiPBFT step number.
+  Step uint64
+  // Chain of tipsets proposed/voted for finalisation.
+  // Always non-empty; the first entry is the base tipset finalised in the previous instance.
   Value []ECTipset
-  // GossiPBFT instance number
-  Instance int
-  // GossiPBFT round for this message
-  Round int
-  // Aggregated GossiPBFTMessages that justify this message
-  Evidence AggregatedEvidence
-  // GossiPBFT ticket (only for CONVERGE)
-  Ticket []byte
 }
 
 type ECTipset struct {
   Epoch int
-  Tipset CID // Or TipsetKey (concat of block header CIDs)
-  Weight BigInt
-  PowerTable CID // CID of a PowerTable
+  Tipset []byte // CBOR-serialized tipset key, a canonical array of the tipset's block header CIDs.
+  PowerTable CID // Commitment to resulting power table.
 }
 
 // Table of nodes with power > 0 and their public keys.
 // This is expected to be calculated from the EC chain state and provided to GossiPBFT.
-// In descending order to provide unique representation.
+// Ordered by (power descending, participant ascending).
 type PowerTable {
   Entries []PowerTableEntry
 }
@@ -266,23 +286,6 @@ type PowerTableEntry struct {
   ParticipantID ActorID
   Power BigInt
   Key BLSPublicKey
-}
-
-// Aggregated list of GossiPBFT messages with the same instance, round and value. Used as evidence for justification of messages
-type AggregatedEvidence struct {
-  // Enumeration of QUALITY, PREPARE, COMMIT, CONVERGE, DECIDE
-  MsgType int
-  // Chain of tipsets proposed/voted for finalisation in this instance.
-  // Non-empty: the first entry is the base tipset finalised in instance-1
-  Value []ECTipset
-  // GossiPBFT instance number
-  Instance int
-  // GossiPBFT round
-  Round int
-  // Indexes in the base power table of the signers (bitset)
-  Signers []bytes
-  // BLS aggregate signature of signers
-  Signature []bytes
 }
 ```
 
@@ -345,14 +348,14 @@ GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
 \*participants is implicitly used to calculate quorums
 
 1:    round ← 0;
-2:    decideSent ← False;
+2:    terminated ← False;
 3:    proposal ← inputChain;  \* holds what the participant locally believes should be a decision
 4:    timeout ← 2*Δ
 5:    ECCompatibleChains ← all prefixes of proposal, not lighter than baseChain
 6:    value ← proposal \* used to communicate the voted value to others (proposal or 丄)
 7:    evidence ← nil   \* used to communicate optional evidence for the voted value
 
-8:    while (not decideSent)  {
+8:    while (not terminated)  {
 9:      if (round = 0)
 10:       BEBroadcast <QUALITY, value, instance>; trigger (timeout)
 11:       collect a clean set M of valid QUALITY messages
@@ -393,7 +396,8 @@ GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
 38:     if (HasStrongQuorumValue(M) AND StrongQuorumValue(M) ≠ 丄)    \* decide
 39:       evidence ← Aggregate(M)
 39:       BEBroadcast <DECIDE, StrongQuorumValue(M), evidence>
-40:       decideSent ← True
+40:       terminated ← True
+          return (StrongQuorumValue(M), Aggregate(M))
 41:     if (∃ m ∈ M: m.value ≠ 丄) \* m.value was possibly decided by others
 42:       proposal ← m.value; \* sway local proposal to possibly decided value
 43:       evidence ← m.evidence \* strong PREPARE quorum is inherited evidence
@@ -403,14 +407,10 @@ GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
 47:     timeout ← updateTimeout(timeout, round)
 48:   }  \*end while
 
-49:   collect a clean set M of DECIDE messages
+49:   collect a clean set M of valid DECIDE messages
       until (HasStrongQuorumValue(M)) \* Collect a strong quorum of decide outside the round loop
-50:   return (StrongQuorumValue(M), Aggregate(M))
-
-51:   upon reception of a valid <DECIDE, value, instance, evidence> message and not decideSent
-52:     decideSent ← True
-53:     BEBroadcast <DECIDE, value, instance, evidence>
-54:     go to line 49
+50:   terminated ← True
+      return (StrongQuorumValue(M), Aggregate(M))
 ```
 Note that the selection of the heaviest prefix in line 16 need not read the tipsets' weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or viceversa (since the adversary controls < ⅓ of the QAP). As a result, selecting the heaviest prefix is as simple as selecting the highest blockheight, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
 
@@ -425,7 +425,7 @@ ECupdate(chain):
 
 #### Valid messages and evidence
 
-The $\texttt{Valid}()$ predicate (referred to in lines 11, 22, 29, 37, and 51) is defined below.
+The $\texttt{Valid}()$ predicate (referred to in lines 11, 22, 29, and 37) is defined below.
 
 ```
 Valid(m):                                   | For a message m to be valid,
@@ -434,15 +434,21 @@ If m is not properly signed:                | m must be properly signed.
   return False
 if m.instance != instance                   | m must match the instance ID
   return False
-If m.step = QUALITY AND                     | A QUALITY message must
-  NOT IsPrefix(baseChain, m.proposal)       | contain a proposal prefixed
-    return False                            | with baseChain.
+If not (IsPrefix(baseChain, m.value)        | A value must be bottom 
+    or m.value = 丄)                        | or start with baseChain.
+  return False                              
+If m.step = QUALITY AND                     | A QUALITY message
+  m.round != 0                              | must be for round 0
+    return false
+If m.step = DECIDE AND                      | A DECIDE message
+  m.round != 0                              | must specify round = 0
+    return false
 If m.step = CONVERGE AND                    | A CONVERGE message
   (m.ticket does not pass VRF validation    | must have a valid VRF ticket
     OR m.round = 0)                         | and round > 0.
       return False
-If m.step ∈ {CONVERGE, COMMIT} AND          | CONVERGE, COMMIT
-  NOT ValidEvidence(m)                      | must contain valid evidence.
+If m.step ∈ {CONVERGE, COMMIT, DECIDE} AND  | CONVERGE, COMMIT, DECIDE
+  not ValidEvidence(m)                      | must contain valid evidence.
     return False
 return True
 ```
@@ -469,10 +475,17 @@ OR (m = <COMMIT, value, round, evidence>                | valid COMMIT
         AND ∀ m' ∈ M: m'.value = m.value)               | for the same value, or
     OR (m.value = 丄))                                  | COMMIT is for 丄 with
                                                         | no evidence
+
+OR (m = <DECIDE, value, round, evidence>                | valid DECIDE
+  AND (∃ M: Power(M) > ⅔ AND m.evidence=Aggregate(M)    | evidence is a strong quorum
+    AND ∀ m' ∈ M: m'.step = COMMIT                      | of PREPARE messages
+      AND all the same round (!= m.round)               | from some (all the same) round
+      AND ∀ m' ∈ M: m'.instance = m.instance            | from the same instance
+        AND ∀ m' ∈ M: m'.value = m.value)               | for the same value
 ```
 
 ### Evidence verification complexity
-Note that during the validation of each CONVERGE and COMMIT message, two signatures need to be verified: (1) the signature of the message contents, produced by the sender of the message (first check above) and (2) the aggregate signature in $m.evidence$ ($\texttt{ValidEvidence}(m)$ above). The former can be verified using the sender's public key (stored in the power table). The latter, being an aggregated signature, requires aggregating public keys of all the participants whose signatures it combines. Notice that the evidence of each message can be signed by a different set of participants, which requires aggregating a linear number of public BLS keys (in system size) per evidence verification.
+Note that during the validation of each CONVERGE, COMMIT and DECIDE message, two signatures need to be verified: (1) the signature of the message contents, produced by the sender of the message (first check above) and (2) the aggregate signature in $m.evidence$ ($\texttt{ValidEvidence}(m)$ above). The former can be verified using the sender's public key (stored in the power table). The latter, being an aggregated signature, requires aggregating public keys of all the participants whose signatures it combines. Notice that the evidence of each message can be signed by a different set of participants, which requires aggregating a linear number of public BLS keys (in system size) per evidence verification.
 
 However, a participant only needs to verify the evidence once for each *unique* message (in terms of (step, round, value)) received. Moreover, verification can further be reduced to those messages a participant uses to make progress (such as advancing to the next step or deciding), ignoring the rest as they are not needed for progress. This reduces the number of evidence verifications in each step to at most one.
 
@@ -485,14 +498,14 @@ An instance of GossiPBFT requires a seed σ that must be common among all partic
 
 GossiPBFT ensures termination provided that (i) all participants start the instance at most $\Delta$ apart, and (ii) the estimate on Δ is large enough for $\Delta$-synchrony in some round (either because of the real network delay recovering from asynchrony or because of the estimate increasing).
 
-[Given prior tests performed on GossipSub](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf) (see also [here](https://gist.github.com/jsoares/9ce4c0ba6ebcfd2afa8f8993890e2d98)), we expect that almost all participants will reach sent messages within $Δ=3s$, with a huge majority receiving them even after $Δ=2s$. However, if several participants start the instance $Δ + ε$ after some other participants, termination is not guaranteed for the selected timeouts of $2*Δ$. Thus, we do not rely on an explicit synchrony bound for correctness. Instead, we (i) use drand as a beacon to synchronize participants within an instance and (ii) increase the estimate of Δ locally within an instance as rounds progress without decision.
+[Given prior tests performed on GossipSub](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf) (see also [here](https://gist.github.com/jsoares/9ce4c0ba6ebcfd2afa8f8993890e2d98)), we expect that almost all participants will reach sent messages within $Δ=3s$, with a huge majority receiving them even after $Δ=2s$. However, if several participants start the instance $Δ + ε$ after some other participants, termination is not guaranteed for the selected timeouts of $2*Δ$. Thus, we do not rely on an explicit synchrony bound for correctness. Instead, we increase the estimate of Δ locally within an instance as rounds progress without decision.
 
 The synchronization of participants is performed in the call to $\texttt{updateTimeout(timeout, round)}$ (line 47), and works as follows:
 
 * Participants start an instance with $Δ=2s$.
 * Participants set their timeout for the current round to $Δ*1.3^{r}$ where $r$ is the round number ($r=0$ for the first round).
 
-Additionally, as an optimization, participants could continue to the subsequent step once the execution of the current step has been determined, without waiting for the timeout. For example, if a participant receives QUALITY messages from all participants, it can proceed to the next step without waiting for the timeout. More generally, if the remaining valid messages to be received cannot change the execution of the step, regardless of the values contained in the messages, then a participant should continue to the next step.
+Additionally, as an optimization, participants may continue to the subsequent step once the execution of the current step has been determined, without waiting for the timeout. For example, if a participant receives QUALITY messages from all participants, it can proceed to the next step without waiting for the timeout. More generally, if the remaining valid messages to be received cannot change the execution of the step, regardless of the values contained in the messages, then a participant may continue to the next step.
 
 
 ### Synchronization of Participants across Instances

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -319,14 +319,6 @@ A set of messages $M$ that does not contain equivocating messages is called _cle
       ```
 * `StrongQuorumValue(M)`
     * Returns $v$ if $\texttt{HasStrongQuorumValue}(M)$ holds, $nil$ otherwise.
-* `HasWeakQuorumValue(M)`
-    * Where $M$ is a clean set of messages of the same type and the same round
-    * The predicate returns True iff there is a value $v$, such that there is a set $P$ of participants who are senders of messages in $M$ such that their message value is exactly $v$ and $\texttt{Power}(P)>1/3$. More precisely:
-      ```
-      HasWeakQuorumValue(M) = ∃ v: Power({p : ∃ m∈ M: m.sender=p AND m.value=v})>1/3
-      ```
-* `WeakQuorumValue(M)`
-    * Returns $v$ if $\texttt{HasWeakQuorumValue}(M)$ holds, $nil$ otherwise.
 * `LowestTicketProposal(M)`
     * Let $M$ be a clean set of CONVERGE messages for the same round.
     * If $M = ∅$, the predicate returns $baseChain$.
@@ -453,7 +445,7 @@ If m.step ∈ {CONVERGE, COMMIT, DECIDE} AND  | CONVERGE, COMMIT, DECIDE
 return True
 ```
 
-The $\texttt{ValidEvidence}()$ predicate is defined below. Note that QUALITY, PREPARE and DECIDE messages do not need evidence. In fact, DECIDE does not need any protocol-specific validation, since a weak quorum of DECIDE with the same value is required to trigger any  execution of the protocol.
+The $\texttt{ValidEvidence}()$ predicate is defined below. Note that QUALITY and PREPARE messages do not need evidence.
 
 ```
 ValidEvidence(m):


### PR DESCRIPTION
- Update the message schemas to match implementation
- Remove tipset weight
- Removed definition of weak quorum
- Added justification of DECIDE
- Replace short-circuit DECIDE pseudocode with description of optimisation
- Some (partial) fixes to message validation and justification
- Remove drand from timing
- Added some TODOs

@ranchalp please review.