### PR TITLE
Fix method number for ProveReplicaUpdate3 in FIP-0076

### DIFF
--- a/FIPS/fip-0076.md
+++ b/FIPS/fip-0076.md
@@ -20,7 +20,7 @@ sector metadata in the miner actor.
 Removes the legacy `PreCommitSector` (method 6) and `PreCommitSectorBatch` (method 25)
 in favour of the existing `PreCommitSectorBatch2` (method 28) which requires
 the sector unsealed CID to be specified while pre-committing.
-Removes the legacy and unused `ProveReplicaUpdates3` (method 29) (giving that name to the new method 34).
+Removes the legacy and unused `ProveReplicaUpdates2` (method 29).
 
 Existing onboarding flows that use the built-in market actor remain fully supported, but optional.
 


### PR DESCRIPTION
This PR corrects the method name from `ProveReplicaUpdates3` to `ProveReplicaUpdates2` for the unused/deprecated method in FIP-0076.