### PR TITLE
 [FIP-XXXX] Freeze stfil user’s transferred asset address

### DIFF
--- a/FIPS/fip-0091.md
+++ b/FIPS/fip-0091.md
@@ -1,0 +1,31 @@
+---
+fip: "0091"
+title: Freeze stfil user’s transferred asset address
+author: justin (@justinjuarez3518)
+discussions-to: https://github.com/filecoin-project/FIPs/discussions/989
+status: Draft
+type: Technical
+category: Core
+created: 2024-04-12
+---
+# FIP-0091: Freeze stfil user’s transferred asset address
+
+## Simple Summary
+
+Currently, more than 4.5 million FIL of Stfil user assets have been transferred to “unknown addresses” - https://filfox.info/en/address/f410falck3ysg7e2k4outtq2r24ytd66cuddydnoga6a,  which most likely belong to the police. 
+
+According to "customary practice" these assets will soon be sold off in the secondary market, and all investors and community members should pay attention and take action. 
+
+I propose that FF and PL should make freezing this account and formally consider how to implement it and take action!
+
+<img width="1270" alt="image" src="https://github.com/filecoin-project/FIPs/assets/152005035/0c603648-474e-4d0e-bb9a-1fda15410fc0">
+
+## Abstract
+
+Currently, more than 4.5 million FIL of Stfil user assets have been transferred to “unknown addresses” - https://filfox.info/en/address/f410falck3ysg7e2k4outtq2r24ytd66cuddydnoga6a,  which most likely belong to the police. 
+
+## Motivation
+
+## Implementations
+
+Implementation in progress (TODO).

--- a/FIPS/fip-0091.md
+++ b/FIPS/fip-0091.md
@@ -26,6 +26,8 @@ Currently, more than 4.5 million FIL of Stfil user assets have been transferred 
 
 ## Motivation
 
+stfil user assets are being stolen, freeze accounts to protect user assets!!!
+
 ## Implementations
 
 Implementation in progress (TODO).


### PR DESCRIPTION
Discussion: https://github.com/filecoin-project/FIPs/discussions/989

Currently, more than 4.5 million FIL of Stfil user assets have been transferred to “unknown addresses” - https://filfox.info/en/address/f410falck3ysg7e2k4outtq2r24ytd66cuddydnoga6a, which most likely belong to the police.

According to "customary practice" these assets will soon be sold off in the secondary market, and all investors and community members should pay attention and take action.

I propose that FF and PL should make freezing this account and formally consider how to implement it and take action!