### PR TITLE
Add ReplicaInfo to fip-0090

### DIFF
--- a/FIPS/fip-0090.md
+++ b/FIPS/fip-0090.md
@@ -110,7 +110,7 @@ Note that, same as with interactive PoRep, each sector has a `SealRandEpoch` tha
   struct ReplicaInfo {
 	  // Sector number used to generate replica id 
 	  // Must be set to SectorID 
-      SectorNumber: SectorNumber,
+	  SectorNumber: SectorNumber,
 	  // Sector number used as unique id in actor state
 	  SectorID: SectorNumber,
 	  // Must be set to ProviderID 

--- a/FIPS/fip-0090.md
+++ b/FIPS/fip-0090.md
@@ -97,12 +97,24 @@ Note that, same as with interactive PoRep, each sector has a `SealRandEpoch` tha
 - Introduce a new method `ProveCommitSectorsNI` (method 36), which performs a non-interactive proof for CC sectors, without a preceding PreCommitSector message (ie, this method rejects sectors that were already pre-committed. Such sectors must be activated with one of the existing ProveCommit methods). The method can be used with seal proofs or aggregate proof (but only one option can be chosen per call); the return type is the same  as `ProveCommitAggregate`.
   
   ```go
-  // Note no UnsealedCID because it must be "zero" data.
+    // Note no UnsealedCID because it must be "zero" data.
   struct SectorNIActivationInfo {
-      SectorNumber: SectorNumber,
+	  ReplicaInfo: ReplicaInfo
       SealedCID: Cid, // CommR
       SealRandEpoch: ChainEpoch,
       Expiration: ChainEpoch,
+  }
+  
+  // Organize information used in replica id
+  // Included to avoid breaking change for future SealerActor FIP 
+  struct ReplicaInfo {
+	  // Sector number used to generate replica id 
+	  // Must be set to SectorID 
+      SectorNumber: SectorNumber,
+	  // Sector number used as unique id in actor state
+	  SectorID: SectorNumber,
+	  // Must be set to ProviderID 
+	  SealerID: ActorID
   }
 
   struct ProveCommitSectorsNIParams {

--- a/FIPS/fip-0090.md
+++ b/FIPS/fip-0090.md
@@ -97,9 +97,9 @@ Note that, same as with interactive PoRep, each sector has a `SealRandEpoch` tha
 - Introduce a new method `ProveCommitSectorsNI` (method 36), which performs a non-interactive proof for CC sectors, without a preceding PreCommitSector message (ie, this method rejects sectors that were already pre-committed. Such sectors must be activated with one of the existing ProveCommit methods). The method can be used with seal proofs or aggregate proof (but only one option can be chosen per call); the return type is the same  as `ProveCommitAggregate`.
   
   ```go
-    // Note no UnsealedCID because it must be "zero" data.
+  // Note no UnsealedCID because it must be "zero" data.
   struct SectorNIActivationInfo {
-	  ReplicaInfo: ReplicaInfo
+      ReplicaInfo: ReplicaInfo
       SealedCID: Cid, // CommR
       SealRandEpoch: ChainEpoch,
       Expiration: ChainEpoch,
@@ -110,7 +110,7 @@ Note that, same as with interactive PoRep, each sector has a `SealRandEpoch` tha
   struct ReplicaInfo {
 	  // Sector number used to generate replica id 
 	  // Must be set to SectorID 
-	  SectorNumber: SectorNumber,
+	  SealingNumber: SectorNumber,
 	  // Sector number used as unique id in actor state
 	  SectorID: SectorNumber,
 	  // Must be set to ProviderID 

--- a/FIPS/fip-0090.md
+++ b/FIPS/fip-0090.md
@@ -99,22 +99,12 @@ Note that, same as with interactive PoRep, each sector has a `SealRandEpoch` tha
   ```go
   // Note no UnsealedCID because it must be "zero" data.
   struct SectorNIActivationInfo {
-      ReplicaInfo: ReplicaInfo
+      SealingNumber: SectorNumber, // Sector number used to generate replica id
+      SealerID: ActorID, // Must be set to ID of receiving actor for now
       SealedCID: Cid, // CommR
+      SectorNumber: SectorNumber, // unique id of sector in actor state
       SealRandEpoch: ChainEpoch,
       Expiration: ChainEpoch,
-  }
-  
-  // Organize information used in replica id
-  // Included to avoid breaking change for future SealerActor FIP 
-  struct ReplicaInfo {
-	  // Sector number used to generate replica id 
-	  // Must be set to SectorID 
-	  SealingNumber: SectorNumber,
-	  // Sector number used as unique id in actor state
-	  SectorID: SectorNumber,
-	  // Must be set to ProviderID 
-	  SealerID: ActorID
   }
 
   struct ProveCommitSectorsNIParams {


### PR DESCRIPTION
Proposed SealerActor FIP #993 is needed to fully unlock SaaS functionality after landing FIP 0090.

To avoid an annoying method deprecation we're predicting the needs of the SealerActor in the NI porep params.  This PR adds fields for specifying sealer actor id and sealer actor specified sector number to the NI porep method.  The protocol should enforce that these values are constrained until the sealer actor fip arrives.