### PR TITLE
FIP-0086: Merklize The Tipset List

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -784,9 +784,9 @@ First, the decision payloads are designed to be easy to work with in the EVM (32
 | **00-31** | G | P | B | F | T | : | f | i | l | e | c  | o  | i  | n  | :  | .  | .  | .  | .  | .  | .  | .  | .  | .  | x  | x  | x  | x  | x  | x  | x  | x  |
 | **32-63** | y | y | y | y | y | y | y | y | y | y | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  |
 
-Where `.` is a zero byte, `xxx` is the instance (64bit BigEndian integer) and `yyy` is the root hash of the tipset merkle-tree.
+Where `.` is a zero byte, `xxx` is the instance (64bit BigEndian integer) and `yyy` is the root hash of the tipset merkle tree.
 
-Importantly, the instance and merkle-tree root are 32-byte aligned and bytes 0-24 are constant.
+Importantly, the instance and merkle tree root are 32-byte aligned and bytes 0-24 are constant.
 
 Unfortunately, we're still missing two pieces:
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -717,10 +717,10 @@ On the other hand, when signing, we tend to sign hashes and merkle-trees so we c
 Decision payloads are designed to be easy to work with in the EVM (32-byte alignment) and within zkSNARKs (small with fixed-length fields). Instead of naively signing a CBOR-encoded value, we sign `Payload` objects such that decisions are encoded as follows:
 
 
-|           | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 |
-|-----------|---|---|---|---|---|---|---|---|---|---|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|
-| **00-31** | G | P | B | F | T | : | f | i | l | e | c  | o  | i  | n  | :  | .  | .  | .  | .  | .  | .  | .  | .  | .  | x  | x  | x  | x  | x  | x  | x  | x  |
-| **32-63** | y | y | y | y | y | y | y | y | y | y | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  |
+|           | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15  | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 |
+|-----------|---|---|---|---|---|---|---|---|---|---|----|----|----|----|----|-----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|
+| **00-31** | G | P | B | F | T | : | f | i | l | e | c  | o  | i  | n  | :  | 0x5 | .  | .  | .  | .  | .  | .  | .  | .  | x  | x  | x  | x  | x  | x  | x  | x  |
+| **32-63** | y | y | y | y | y | y | y | y | y | y | y  | y  | y  | y  | y  | y   | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  |
 
 Where `.` is a zero byte, `xxx` is the instance (64bit BigEndian integer) and `yyy` is the root hash of the tipset merkle tree.
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -754,13 +754,6 @@ func buildTree(depth int, values [][]byte) (Digest, [][]Digest) {
 }
 ```
 
-We considered using the merkle tree from CometBFT, but that one:
-
-1. Uses sha256 (not EVM friendly).
-2. Requires more complex math on validation. This lets it avoid a few hash operations in some cases, but that likely isn't worth the complexity.
-
-Most other well-known merkle tree formats (verkle trees, etc.) optimize for sparse trees and where we have _full_ trees, so the complexity isn't worth it.
-
 ## Design Rationale
 
 Many possibilities were considered for faster finality. We justify the architecture of F3 as the best candidate to achieve fast finality in Filecoin by comparing it with other options:
@@ -793,9 +786,19 @@ Unfortunately, we're still missing two pieces:
 1. The BLS curve we're using in this signature is not zkSNARK friendly.
 2. The hash function we're using to map the payload onto the BLS curve point uses sha2-256 (also not snark friendly).
 
-#### Merkle Tree
+#### Merkle Trees
 
-....
+We put both the tipsets and the commitments inside tipsets into merkle trees to keep proof-sizes (for bridges) small, even if we have a large instance with many tipsets.
+
+Our merkle tree is heavily based on the [merkle tree from CometBFT][comet-merkle], but that one:
+
+1. Uses sha256 (not EVM friendly).
+2. Requires more complex math on validation. This lets it avoid a few hash operations in some cases, but that likely isn't worth the complexity.
+3. Needs additional out-of-band information to be a _true_ vector commitment. Optimization 2 in the CometBFT merkle tree means that a proof for item 7/7 can be treated as a proof of an item 6/6.
+
+Most other well-known merkle tree formats (verkle trees, etc.) optimize for sparse trees and where we have _full_ trees, so the complexity isn't worth it.
+
+[comet-merkle]: https://github.com/cometbft/cometbft/blob/main/spec/core/encoding.md#merkle-trees
 
 ## Backwards Compatibility
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -778,8 +778,11 @@ Several design choices were made to reduce the cost of smart-contract validation
 
 First, the decision payloads are designed to be easy to work with in the EVM (32-byte alignment) and within zkSNARKs (small with fixed-length fields). Instead of naively signing a CBOR-encoded value, we sign `Payload` objects such that decisions are encoded as follows:
 
-|**00-31**|G|P|B|F|T|:|f|i|l|e|c|o|i|n|:|.|.|.|.|.|.|.|.|.|x|x|x|x|x|x|x|x|
-|**32-63**|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|
+
+|           | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 |
+|-----------|---|---|---|---|---|---|---|---|---|---|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|
+| **00-31** | G | P | B | F | T | : | f | i | l | e | c  | o  | i  | n  | :  | .  | .  | .  | .  | .  | .  | .  | .  | .  | x  | x  | x  | x  | x  | x  | x  | x  |
+| **32-63** | y | y | y | y | y | y | y | y | y | y | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  |
 
 Where `.` is a zero byte, `xxx` is the instance (64bit BigEndian integer) and `yyy` is the root hash of the tipset merkle-tree.
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -654,105 +654,7 @@ Specifically, we use a balanced binary merkle tree where:
 3. Each leaf is prefixed with a single `0x1` byte before hashing (`keccak256([1] + value)`).
 4. Missing values and empty sub-trees hash to `[32]byte{}` (32 `0x0` bytes).
 
-In our tree, we prove that some value `v` is committed to at index `i` in the merkle tree rooted at `r` by providing the "uncles" (the branches not taken) of the merkle path from `v` to `r`. This algorithm is best described in code:
-
-```go
-package main
-
-import (
-	"math/bits"
-
-	"golang.org/x/crypto/sha3"
-)
-
-// Digest is a 32-byte hash digest.
-type Digest = [32]byte
-
-// VerifyProof verifies that the given value maps to the given index in the
-// merkle tree with the given root. It returns "more" if the value is not the
-// last value in the merkle tree.
-func VerifyProof(root Digest, index int, value []byte, proof []Digest) (valid bool, more bool) {
-	digest := leafHash(value) // this is the "leaf" hash.
-
-	// If the index is greater than 2^len(proof) - 1, it can't possibly be
-	// part of this tree.
-	if index > 1<<len(proof) - 1 {
-		return false, false
-	}
-
-	// Walk from the leaf to the root, hashing with each uncle.
-	for i, uncle := range proof {
-		// We read the bits of the index LSB to MSB. We're walking from the
-		// _bottom_ of the tree to the top.
-		if index&(1<<i) == 0 {
-			// If we hit a left branch and the uncle (right-branch) is non-zero,
-			// there are more values in the tree beyond the current index.
-			more = more || uncle != (Digest{})
-			digest = internalHash(digest, uncle)
-		} else {
-			digest = internalHash(uncle, digest)
-		}
-	}
-	return root == digest, more
-}
-
-// MerkleRoot returns a the root of the merkle tree of the given values.
-func MerkleRoot(values [][]byte) Digest {
-	root, _ := MerkleRootWithProofs(values)
-    return root
-}
-
-// MerkleRootWithProofs returns a the root of the merkle tree of the
-// given values, along with merkle proofs for each leaf.
-func MerkleRootWithProofs(values [][]byte) (Digest, [][]Digest) {
-	return buildTree(bits.Len(uint(len(values))-1), values)
-}
-
-var internalMarker = []byte{0}
-var leafMarker = []byte{1}
-
-func internalHash(left Digest, right Digest) (out Digest) {
-	hash := sha3.NewLegacyKeccak256()
-	_, _ = hash.Write(internalMarker)
-	_, _ = hash.Write(left[:])
-	_, _ = hash.Write(right[:])
-	copy(out[:], hash.Sum(out[:0]))
-	return out
-}
-
-func leafHash(value []byte) (out Digest) {
-	hash := sha3.NewLegacyKeccak256()
-	_, _ = hash.Write(leafMarker)
-	_, _ = hash.Write(value)
-	copy(out[:], hash.Sum(out[:0]))
-	return out
-}
-
-func appendPath(paths [][]Digest, element Digest) [][]Digest {
-	for i := range paths {
-		paths[i] = append(paths[i], element)
-	}
-	return paths
-}
-
-func buildTree(depth int, values [][]byte) (Digest, [][]Digest) {
-	if len(values) == 0 {
-		return Digest{}, nil
-	} else if depth == 0 {
-		if len(values) != 1 {
-			panic("expected one value at the leaf")
-		}
-		return leafHash(values[0]), [][]Digest{nil}
-	}
-
-	split := min(1<<(depth-1), len(values))
-	leftHash, leftPaths := buildTree(depth-1, values[:split])
-	rightHash, rightPaths := buildTree(depth-1, values[split:])
-	paths := append(appendPath(leftPaths, rightHash), appendPath(rightPaths, leftHash)...)
-
-	return internalHash(leftHash, rightHash), paths
-}
-```
+In our tree, we prove that some value `v` is committed to at index `i` in the merkle tree rooted at `r` by providing the "uncles" (the branches not taken) of the merkle path from `v` to `r` (bottom to top). This algorithm is best described in [code](../resources/fip-0086/merkletree.go).
 
 ## Design Rationale
 
@@ -781,7 +683,7 @@ Where `.` is a zero byte, `xxx` is the instance (64bit BigEndian integer) and `y
 
 Importantly, the instance and merkle tree root are 32-byte aligned and bytes 0-24 are constant.
 
-Unfortunately, we're still missing two pieces:
+However, note that:
 
 1. The BLS curve we're using in this signature is not zkSNARK friendly.
 2. The hash function we're using to map the payload onto the BLS curve point uses sha2-256 (also not snark friendly).

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -288,7 +288,7 @@ type PowerTableEntry struct {
 }
 ```
 
-All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over $(Instance || MsgType || MerkleRoot(Value) || Round)$. The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
+All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over `"GPBFT:filecoin:":15 || Step:1 || Round:8 || Instance:8 || MerkleRoot(Value):32` (where `Round` and `Instance` are big-endian encoded). The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
 
 The receiver of a message only considers messages with valid signatures and discards all other messages as invalid. We sometimes omit the sender IDs and signatures in further descriptions for better readability.
 
@@ -770,6 +770,29 @@ Many possibilities were considered for faster finality. We justify the architect
 * _Sub-sample voting_: Avalanche's sub-sample voting copes with arbitrarily large groups of participants by repeatedly sub-sampling constant-size subsets. Unfortunately, Avalanche's strong network assumptions make the protocol vulnerable to an adversary exploiting network delays. Moreover, Avalanche ensures correctness against an adversary controlling at most ⅕ of participants, versus ⅓ targeted by GossiPBFT. Even when GossiPBFT becomes amenable to committees, for reasonable committees of 600 participants, GossiPBFT already tolerates Avalanche's ⅕ of total participants with significantly weaker network assumptions.
 * _Replacing EC with BFT_: Replacing EC with a BFT protocol (like GossiPBFT) would imply a huge code refactoring, leading to more bugs and significantly more time to develop and productionize the Filecoin upgrade. Furthermore, the combination of EC and F3 is more redundant, ensuring that the system continues operating in the unlikely case that F3 halts.
 
+### Smart Contract Validation
+
+Several design choices were made to reduce the cost of smart-contract validation, although further improvements are required before it's practical.
+
+#### Certificate/Decision Signature
+
+First, the decision payloads are designed to be easy to work with in the EVM (32-byte alignment) and within zkSNARKs (small with fixed-length fields). Instead of naively signing a CBOR-encoded value, we sign `Payload` objects such that decisions are encoded as follows:
+
+|**00-31**|G|P|B|F|T|:|f|i|l|e|c|o|i|n|:|.|.|.|.|.|.|.|.|.|x|x|x|x|x|x|x|x|
+|**32-63**|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|y|
+
+Where `.` is a zero byte, `xxx` is the instance (64bit BigEndian integer) and `yyy` is the root hash of the tipset merkle-tree.
+
+Importantly, the instance and merkle-tree root are 32-byte aligned and bytes 0-24 are constant.
+
+Unfortunately, we're still missing two pieces:
+
+1. The BLS curve we're using in this signature is not zkSNARK friendly.
+2. The hash function we're using to map the payload onto the BLS curve point uses sha2-256 (also not snark friendly).
+
+#### Merkle Tree
+
+....
 
 ## Backwards Compatibility
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -227,7 +227,7 @@ GossiPBFT was designed with the Filecoin network in mind and presents a set of f
 
 Messages include the following fields: $\langle Sender, Signature, MsgType, Value, Instance, [Round, Evidence, Ticket] \rangle$. As $Round$, $Evidence$, and $Ticket$ are fields that not all message types require, when not required by a message type, their default value is used (i.e. $0$, $nil$, and $[] byte \lbrace\rbrace$, respectively). We refer to a _field_ of message $m$, with $m.field$:
 
-```
+```go
 // A message in the GossiPBFT protocol.
 // The same message structure is used for all rounds and phases.
 // Note that the message is self-attesting so no separate envelope or signature is needed.
@@ -264,16 +264,16 @@ type Payload struct {
   Round uint64
   // GossiPBFT step number.
   Step uint8
-  // Chain of cbor-serialized tipsets proposed/voted for finalisation.
+  // Chain of ECTipset objects proposed/voted for finalisation.
   // Always non-empty; the first entry is the base tipset finalised in the previous instance.
-  Value [][]byte // cbor-serialized ECTipset instances
+  Value []ECTipset
 }
 
 type ECTipset struct {
-  Epoch uint64
-  Tipset []CID // Tipset key, a canonical array of a tipset's block header CIDs.
-  PowerTable CID // Commitment to resulting power table.
-  Commitments [32]byte // Root of a Merkle tree containing additional commitments, defaults to 0.
+  Epoch       uint64   // The Filecoin epoch
+  TipsetKey   []byte   // A canonical concatination of the block-header CIDs in a tipset.
+  PowerTable  CID      // A blake2b-256 CID of the cbor-encoded power-table.
+  Commitments [32]byte // Root of a Merkle tree containing additional commitments.
 }
 
 // Table of nodes with power > 0 and their public keys.
@@ -288,7 +288,7 @@ type PowerTableEntry struct {
 }
 ```
 
-All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over `"GPBFT:filecoin:":15 || Step:1 || Round:8 || Instance:8 || MerkleRoot(Value):32` (where `Round` and `Instance` are big-endian encoded). The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
+All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over `"GPBFT:filecoin:":15 || Step:1 || Round:8 || Instance:8 || MerkelizeValue(Value):32` (where `Round` and `Instance` are big-endian encoded). The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
 
 The receiver of a message only considers messages with valid signatures and discards all other messages as invalid. We sometimes omit the sender IDs and signatures in further descriptions for better readability.
 
@@ -296,6 +296,18 @@ Two (or more) messages $m1$ and $m2$ are called _equivocating messages_ if $m1.S
 
 A set of messages $M$ that does not contain equivocating messages is called _clean_. Participants discard all equivocating messages when forming clean sets. In fact, in the proposed version of GossiPBFT in this document, only one of the equivocating messages needs to be stored (thanks to evidences explicitly validating a message).
 
+##### `MerkelizeValue`
+
+Instead of encoding `Payload.Value` as CBOR and signing the result, we convert it into a merkle-tree and format the individual `ECTipset` objects in a way that's easy to parse within both snarks and EVM-based blockchains.
+
+Specifically, we encode each `ECTipset` by concatenating:
+
+1. The `Epoch`, encoded as a big-endian 64bit value (8 bytes).
+2. The `Commitements` hash as-is (32 bytes).
+3. The tipset _CID_, a blake2b CID of the `TipsetKey` encoded as a CBOR byte array (38 bytes). The resulting CID is the "tipset CID". Importantly, it's hash digest is the digest returned by the `BLOCKHASH` instruction in Filecoin's EVM implementation.
+4. The `PowerTable` CID .
+
+Then, we build a [merkle tree](#merkle-tree-format) from these encoded `ECTipset` values. Only the final merkle tree root gets signed.
 
 #### Predicates and functions used in the protocol
 
@@ -669,9 +681,40 @@ Many possibilities were considered for faster finality. We justify the architect
 
 Several design choices were made to reduce the cost of smart-contract validation, although further improvements are required before it's practical.
 
-#### Certificate/Decision Signature
+#### `ECTipset` Contents
 
-First, the decision payloads are designed to be easy to work with in the EVM (32-byte alignment) and within zkSNARKs (small with fixed-length fields). Instead of naively signing a CBOR-encoded value, we sign `Payload` objects such that decisions are encoded as follows:
+The `ECTipset` contains 4 values:
+
+1. The epoch.
+2. The tipset key itself.
+3. A CID of the power table.
+4. The root of the commitements merkle tree.
+
+We included the epoch directly in the `ECTipset` object itself because we expect proofs of the form "event X happened before/after/at epoch Y" to be common in cross-chain interactions.
+
+The tipset key is required as this is the main value F3 is finalizing. While off-chain light-clients will use the tipset key, cross-chain bridges likely won't which is why we _hash_ the tipset key before signing (so we won't have to send the full tipset key to bridge contracts, saving gas).
+
+We include a blake2b hash of the power table to aid in syncing the F3 chain. In theory we could have added it to the commitment merkle tree and left it out of the root `ECTipset` object, but being able to validate a chain of finality certificates without any additional merkle-proofs is convenient and the an extra 32 bytes is not an unreasonable cost (512 gas on Ethereum) .
+
+Finally, we include the root hash of the commitments merkle-tree. This tree is _empty_ at the moment but will eventually include:
+
+1. Commitements to snark-friendly representations of the power table.
+2. Events, likely indexed by emitter (useful for cross-chain messaging).
+
+And probably more. Importantly, the network can easily commit to additional values here without altering the `ECTipset` structure (and potentially breaking bridges).
+
+#### Wire Format v. Signing Format
+
+For both the `Payload` and the `ECTIpset`s themselves, we encode them one way for signing and another when sending them over the network.
+
+1. Even though we end up signing a root of a merkle-tree of the tipsets, we have to send the full list of tipsets over the network as the protocol needs a way to find common prefixes.
+2. Even though we end up signing a CID of the tipset key, we have to send the full tipset key over the wire because the Filecoin chainsync protocol names tipsets by tipset key, not tipset CID/hash. By sending the full key, a client can learn about _new_ tipsets from F3 if it doesn't hear about them from its peers.
+
+On the other hand, when signing, we tend to sign hashes and merkle-trees so we can easily omit unnecessary data from proofs sent across bridges.
+
+##### Certificate/Decision Signing Format
+
+Decision payloads are designed to be easy to work with in the EVM (32-byte alignment) and within zkSNARKs (small with fixed-length fields). Instead of naively signing a CBOR-encoded value, we sign `Payload` objects such that decisions are encoded as follows:
 
 
 |           | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 |
@@ -687,6 +730,15 @@ However, note that:
 
 1. The BLS curve we're using in this signature is not zkSNARK friendly.
 2. The hash function we're using to map the payload onto the BLS curve point uses sha2-256 (also not snark friendly).
+
+##### ECTipset Signing Format
+
+ECTipsets are encoded (for signing) as:
+
+1. Two fixed-sized values first: epoch (8 bytes) and the commitements root (32 bytes). That way, EVM smart contracts can extract these values at fixed offsets without any parsing.
+2. Two "variable length" (although they'll be fixed-sized in practice) values: the tipset CID and the power table CID. Cross-chain bridges should generally ignore these values.
+
+Additionally, the epoch comes _before_ the commitments as it lets the bridge arrange for padding such that both the epoch and the commitments root hash are 32-byte aligned.
 
 #### Merkle Trees
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -264,9 +264,9 @@ type Payload struct {
   Round uint64
   // GossiPBFT step number.
   Step uint64
-  // Chain of tipsets proposed/voted for finalisation.
+  // Chain of cbor-serialized tipsets proposed/voted for finalisation.
   // Always non-empty; the first entry is the base tipset finalised in the previous instance.
-  Value []ECTipset
+  Value [][]byte // cbor-serialized ECTipset instances
 }
 
 type ECTipset struct {
@@ -288,7 +288,7 @@ type PowerTableEntry struct {
 }
 ```
 
-All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over $(Instance || MsgType || Value || Round)$. The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
+All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over $(Instance || MsgType || MerkleRoot(Value) || Round)$. The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
 
 The receiver of a message only considers messages with valid signatures and discards all other messages as invalid. We sometimes omit the sender IDs and signatures in further descriptions for better readability.
 
@@ -630,7 +630,6 @@ At the same time, the node can sync the headers (and only the headers) of the EC
 
 This produces a fully trusted chain sync without revalidating the EC chain (which takes days) or fetching the message history. Today, many nodes simply trust that the snapshot they obtain is on the “right” chain; **this fast catch-up is, therefore, both faster and more secure (no eclipse) than revalidating the EC chain.**
 
-
 #### Verification by light client
 
 A light client can also verify the most recent finalized tipset without validating the EC chain execution. They can fetch just one epoch of block headers and a subset of the state tree to verify some specific state or produce a valid transaction against that state.
@@ -644,6 +643,123 @@ A smart contract will never accept a finality certificate earlier than those it 
 
 Only one such smart contract is needed on a single blockchain execution environment, which can provide the resulting final tipset information to others.
 
+### Merkle Tree Format
+
+This protocol uses merkle trees as vector commitments to commit to both (a) the tipsets in an instance and (b) the values committed to in each tipset. We use a single binary merkle tree format in both cases.
+
+Specifically, we use a balanced binary merkle tree where:
+
+1. The hash function is `keccak256` (same as Ethereum) for maximum EVM compatibility.
+2. Each internal node is prefixed with a single `0x0` byte before hashing (`keccak256([0] + left + right)`).
+3. Each leaf is prefixed with a single `0x1` byte before hashing (`keccak256([1] + value)`).
+4. Missing values and empty sub-trees hash to `[32]byte{}` (32 `0x0` bytes).
+
+In our tree, we prove that some value `v` is committed to at index `i` in the merkle tree rooted at `r` by providing the "uncles" (the branches not taken) of the merkle path from `v` to `r`. This algorithm is best described in code:
+
+```go
+package main
+
+import (
+	"math/bits"
+
+	"golang.org/x/crypto/sha3"
+)
+
+// Digest is a 32-byte hash digest.
+type Digest = [32]byte
+
+// VerifyProof verifies that the given value maps to the given index in the
+// merkle tree with the given root. It returns "more" if the value is not the
+// last value in the merkle tree.
+func VerifyProof(root Digest, index int, value []byte, proof []Digest) (valid bool, more bool) {
+	digest := leafHash(value) // this is the "leaf" hash.
+
+	// If the index is greater than 2^len(proof) - 1, it can't possibly be
+	// part of this tree.
+	if index > 1<<len(proof) - 1 {
+		return false, false
+	}
+
+	// Walk from the leaf to the root, hashing with each uncle.
+	for i, uncle := range proof {
+		// We read the bits of the index LSB to MSB. We're walking from the
+		// _bottom_ of the tree to the top.
+		if index&(1<<i) == 0 {
+			// If we hit a left branch and the uncle (right-branch) is non-zero,
+			// there are more values in the tree beyond the current index.
+			more = more || uncle != (Digest{})
+			digest = internalHash(digest, uncle)
+		} else {
+			digest = internalHash(uncle, digest)
+		}
+	}
+	return root == digest, more
+}
+
+// MerkleRoot returns a the root of the merkle tree of the given values.
+func MerkleRoot(values [][]byte) Digest {
+	root, _ := MerkleRootWithProofs(values)
+    return root
+}
+
+// MerkleRootWithProofs returns a the root of the merkle tree of the
+// given values, along with merkle proofs for each leaf.
+func MerkleRootWithProofs(values [][]byte) (Digest, [][]Digest) {
+	return buildTree(bits.Len(uint(len(values))-1), values)
+}
+
+var internalMarker = []byte{0}
+var leafMarker = []byte{1}
+
+func internalHash(left Digest, right Digest) (out Digest) {
+	hash := sha3.NewLegacyKeccak256()
+	_, _ = hash.Write(internalMarker)
+	_, _ = hash.Write(left[:])
+	_, _ = hash.Write(right[:])
+	copy(out[:], hash.Sum(out[:0]))
+	return out
+}
+
+func leafHash(value []byte) (out Digest) {
+	hash := sha3.NewLegacyKeccak256()
+	_, _ = hash.Write(leafMarker)
+	_, _ = hash.Write(value)
+	copy(out[:], hash.Sum(out[:0]))
+	return out
+}
+
+func appendPath(paths [][]Digest, element Digest) [][]Digest {
+	for i := range paths {
+		paths[i] = append(paths[i], element)
+	}
+	return paths
+}
+
+func buildTree(depth int, values [][]byte) (Digest, [][]Digest) {
+	if len(values) == 0 {
+		return Digest{}, nil
+	} else if depth == 0 {
+		if len(values) != 1 {
+			panic("expected one value at the leaf")
+		}
+		return leafHash(values[0]), [][]Digest{nil}
+	}
+
+	split := min(1<<(depth-1), len(values))
+	leftHash, leftPaths := buildTree(depth-1, values[:split])
+	rightHash, rightPaths := buildTree(depth-1, values[split:])
+	paths := append(appendPath(leftPaths, rightHash), appendPath(rightPaths, leftHash)...)
+
+	return internalHash(leftHash, rightHash), paths
+}
+```
+
+We considered using the merkle tree from CometBFT, but that one:
+
+1. Uses sha256 (not EVM friendly).
+2. Requires more complex math on validation. This lets it avoid a few hash operations in some cases, but that likely isn't worth the complexity.
+
+Most other well-known merkle tree formats (verkle trees, etc.) optimize for sparse trees and where we have _full_ trees, so the complexity isn't worth it.
 
 ## Design Rationale
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -729,7 +729,7 @@ Importantly, the instance and merkle tree root are 32-byte aligned and bytes 0-2
 However, note that:
 
 1. The BLS curve we're using in this signature is not zkSNARK friendly.
-2. The hash function we're using to map the payload onto the BLS curve point uses sha2-256 (also not snark friendly).
+2. The hash function we're using to map the payload onto the BLS curve point uses blake2s (also not snark friendly).
 
 ##### ECTipset Signing Format
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -263,7 +263,7 @@ type Payload struct {
   // GossiPBFT round number.
   Round uint64
   // GossiPBFT step number.
-  Step uint64
+  Step uint8
   // Chain of cbor-serialized tipsets proposed/voted for finalisation.
   // Always non-empty; the first entry is the base tipset finalised in the previous instance.
   Value [][]byte // cbor-serialized ECTipset instances

--- a/resources/fip-0086/merkletree.go
+++ b/resources/fip-0086/merkletree.go
@@ -1,0 +1,95 @@
+package merkletree
+
+import (
+	"math/bits"
+
+	"golang.org/x/crypto/sha3"
+)
+
+// Digest is a 32-byte hash digest.
+type Digest = [32]byte
+
+// VerifyProof verifies that the given value maps to the given index in the
+// merkle tree with the given root. It returns "more" if the value is not the
+// last value in the merkle tree.
+func VerifyProof(root Digest, index int, value []byte, proof []Digest) (valid bool, more bool) {
+	digest := leafHash(value) // this is the "leaf" hash.
+
+	// If the index is greater than 2^len(proof) - 1, it can't possibly be
+	// part of this tree.
+	if index > 1<<len(proof)-1 {
+		return false, false
+	}
+
+	// Walk from the leaf to the root, hashing with each uncle.
+	for i, uncle := range proof {
+		// We read the bits of the index LSB to MSB. We're walking from the
+		// _bottom_ of the tree to the top.
+		if index&(1<<i) == 0 {
+			// If we hit a left branch and the uncle (right-branch) is non-zero,
+			// there are more values in the tree beyond the current index.
+			more = more || uncle != (Digest{})
+			digest = internalHash(digest, uncle)
+		} else {
+			digest = internalHash(uncle, digest)
+		}
+	}
+	return root == digest, more
+}
+
+// MerkleRoot returns a the root of the merkle tree of the given values.
+func MerkleRoot(values [][]byte) Digest {
+	root, _ := MerkleRootWithProofs(values)
+	return root
+}
+
+// MerkleRootWithProofs returns a the root of the merkle tree of the
+// given values, along with merkle proofs for each leaf.
+func MerkleRootWithProofs(values [][]byte) (Digest, [][]Digest) {
+	return buildTree(bits.Len(uint(len(values))-1), values)
+}
+
+var internalMarker = []byte{0}
+var leafMarker = []byte{1}
+
+func internalHash(left Digest, right Digest) (out Digest) {
+	hash := sha3.NewLegacyKeccak256()
+	_, _ = hash.Write(internalMarker)
+	_, _ = hash.Write(left[:])
+	_, _ = hash.Write(right[:])
+	copy(out[:], hash.Sum(out[:0]))
+	return out
+}
+
+func leafHash(value []byte) (out Digest) {
+	hash := sha3.NewLegacyKeccak256()
+	_, _ = hash.Write(leafMarker)
+	_, _ = hash.Write(value)
+	copy(out[:], hash.Sum(out[:0]))
+	return out
+}
+
+func appendPath(paths [][]Digest, element Digest) [][]Digest {
+	for i := range paths {
+		paths[i] = append(paths[i], element)
+	}
+	return paths
+}
+
+func buildTree(depth int, values [][]byte) (Digest, [][]Digest) {
+	if len(values) == 0 {
+		return Digest{}, nil
+	} else if depth == 0 {
+		if len(values) != 1 {
+			panic("expected one value at the leaf")
+		}
+		return leafHash(values[0]), [][]Digest{nil}
+	}
+
+	split := min(1<<(depth-1), len(values))
+	leftHash, leftPaths := buildTree(depth-1, values[:split])
+	rightHash, rightPaths := buildTree(depth-1, values[split:])
+	paths := append(appendPath(leftPaths, rightHash), appendPath(rightPaths, leftHash)...)
+
+	return internalHash(leftHash, rightHash), paths
+}


### PR DESCRIPTION
This PR turns the tipset list into a merkle-tree to shrink the size of the root "decision" message to something more friendly to zkSNARKs and bandwidth-limited blockchains. I've also re-arranged the signature format a bit to align the fields on 32-byte word boundaries to make it a little more EVM friendly.

Second, this PR reformats the `ECTipset` structs themselves to be more EVM friendly. Specifically:

1. We sign the CID of the tipset key, not the tipset key itself, so we can omit the full tipset keys from bridge messages.
2. We encode the `ECTIpset` by concatenating the four fields (epoch, commitments, tipset cid, powertable cid) instead of CBOR-encoding.
3. We put the fixed-sized fields (epoch and commitments) _first_ when encoding the `ECTipset` for signing, so we can avoid parsing. We likely don't care about the tipset CID and/or the power table CID in bridge smart contracts anyways.

See the rational for details.