### PR TITLE
FIP-0086: Allow jumping rounds from QUALITY phase, but recommend processing locally available messages first.

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -504,7 +504,7 @@ The conditions for skipping rounds and buffering messages are shown below (below
 112:      go to line 21  \* start new round>0 by jumping forward
 
 113:  shouldJump(round, step): 
-114:    if step = QUALITY OR step = DECIDE: \* never jump on DECIDE or QUALITY
+114:    if step = DECIDE: \* never jump once up to DECIDE step
 115:      return nil
 116:    if (∃ msg' st. msg'.step = CONVERGE \* there must be a CONVERGE for the new round
             AND msg'.round > round          \* round must be greater
@@ -519,6 +519,7 @@ Implementations may optimise this algorithm to treat the reception of an aggrega
 
 Also, we restrict the set C of candidate values that the participant contributes to deciding to only values that either (i) pass the QUALITY step or (ii) may have been decided by other participants (hence the function `mayHaveStrongQuorum`).
 
+When a participant is in receipt of multiple messages at once (such as when starting an instance with queued messages), a decision to jump ahead rounds should be taken only after processing all available messages. This will enable the participant to contribute to a decision other than the base chain.
 
 #### Valid messages and evidence
 


### PR DESCRIPTION
As [discussed in Slack](https://filecoinproject.slack.com/archives/C0556MSR945/p1716507174528439). @ranchalp @vukolic @masih 