### PR TITLE
Sender address must be a f4 address for ETH transactions

### DIFF
--- a/FIPS/fip-0091.md
+++ b/FIPS/fip-0091.md
@@ -126,6 +126,9 @@ Based on the above, the revised steps for processing and validating a Filecoin m
 4. Validate the transaction parameters and signature (after ignoring the first marker byte `0x02` for EIP-155 transactions as that is not part of the signature created by the user).
 5. Ensure that the `ChainID` signed by the user in the transaction digest is the same as the `ChainID` of the network
 
+Note that the sender address on the Filecoin message for both Homestead and EIP-155 transactions 
+must be an `f4` address or an ID address that can be resolved to a `f4` address.
+
 **Note that this FIP does not need any changes to the EVM/FVM runtime and to built-in Actors**.
 
 ### Handling the `GasPrice` parameter of the legacy transaction

--- a/FIPS/fip-0091.md
+++ b/FIPS/fip-0091.md
@@ -127,7 +127,7 @@ Based on the above, the revised steps for processing and validating a Filecoin m
 5. Ensure that the `ChainID` signed by the user in the transaction digest is the same as the `ChainID` of the network
 
 Note that the sender address on the Filecoin message for both Homestead and EIP-155 transactions 
-must be an `f4` address or an ID address that can be resolved to a `f4` address.
+must be an `f4` address or an ID address that can be resolved to a `f4` address. This behaviour is the same for existing EIP-1559 transactions.
 
 **Note that this FIP does not need any changes to the EVM/FVM runtime and to built-in Actors**.
 

--- a/FIPS/fip-0091.md
+++ b/FIPS/fip-0091.md
@@ -127,7 +127,7 @@ Based on the above, the revised steps for processing and validating a Filecoin m
 5. Ensure that the `ChainID` signed by the user in the transaction digest is the same as the `ChainID` of the network
 
 Note that the sender address on the Filecoin message for both Homestead and EIP-155 transactions 
-must be an `f4` address or an ID address that can be resolved to a `f4` address. This behaviour is the same for existing EIP-1559 transactions.
+must be an `f4` address or an ID address that can be resolved to an `f4` address. This behaviour is the same for existing EIP-1559 transactions.
 
 **Note that this FIP does not need any changes to the EVM/FVM runtime and to built-in Actors**.
 


### PR DESCRIPTION
Small update to the FIP to note that sender address must be an f4 address.