### PR TITLE
FIP-0086 updates from implementation

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -54,9 +54,9 @@ The participants in F3 are the storage providers (SPs) of the Filecoin network. 
 In short, each participant $p$ in the Filecoin network (i.e., a storage provider with power) runs F3 in a loop and feeds its input from EC. F3 returns a finalized prefix chain to EC, which updates the canonical chain to extend this F3-finalized prefix. More precisely, in each loop iteration $i$ (corresponding to the i-th instance of F3):
 
 - **EC/F3 interface:** Participant $p$ feeds its current canonical chain $canonical$ and its previously F3-finalized chain, called the $baseChain$, to F3. The $baseChain$ (with some lookback parameter) fixes the power table used by F3 and randomness seed used to configure the F3 instance, while $p$'s current canonical chain is the chain $p$ proposes to be finalized.
-- **F3 consensus:** F3 establishes network-wide consensus on finalized tipsets and produces a _Proof of Finality (PoF)_ for a tipset finalized in instance $i$, $t_i$. Every _PoF_ output by F3 is signed by ≥ ⅔ of the total QAP, i.e., a super-majority of the power table. This vouches that honest participants with more than ⅓ QAP consider tipset $t_i$ final (assuming up to ⅓ QAP may be dishonest).
+- **F3 consensus:** F3 establishes network-wide consensus on finalized tipsets and produces a _Certificate of Finality_ for a tipset finalized in instance $i$, $t_i$. Every certificate output by F3 is signed by ≥ ⅔ of the total QAP, i.e., a super-majority of the power table. This vouches that honest participants with more than ⅓ QAP consider tipset $t_i$ final (assuming up to ⅓ QAP may be dishonest).
 - **EC:** Participant $p$ updates its local EC chain and commits not to reorganize the finalized tipset $t_i$, i.e., the tipset must stay in $p$'s EC canonical chain for good. Apart from this change, EC continues operating as it currently does. In particular, EC still does a 900-epoch lookback for its power table (which can therefore differ from the one used by F3) and continues operating “normally” if F3 assumptions are violated and F3 halts, with the combined EC/F3 protocol favoring availability over consistency (in CAP theorem parlance).
-- **F3 synchronization:** Participants disseminate information about finalized tipset $t_i$ and its proof $PoF_i$ to all other participants, light clients, and smart contracts. The main goal of F3 synchronization is to allow an external party (or a lagging F3 participant) to fetch a sequence of messages that prove the finality of some recent final tipset. The sequence demonstrates a chain of eligible participants deciding on a final tipset and, thus, the eligible power table for the next round. Verifying the finality of a tipset from genesis does not require access to the EC chain.
+- **F3 synchronization:** Participants disseminate information about each finalized tipset and associated certificate to all other participants, light clients, and smart contracts. The main goal of F3 synchronization is to allow an external party (or a lagging F3 participant) to fetch a sequence of messages that prove the finality of some recent final tipset. The sequence demonstrates a chain of eligible participants deciding on a final tipset and, thus, the eligible power table for the next round. Verifying the finality of a tipset from genesis does not require access to the EC chain.
 
 ![](../resources/fip-0086/flow.png)
 
@@ -91,6 +91,25 @@ In practice, if GossipSub is used for _BEBroadcast_, $\Delta$ is an assumed uppe
 
 For termination, a classical partially synchronous model is assumed, with an unknown bound on communication delays among non-Byzantine participants.
 
+### Power Table and Consensus Committee
+
+The EC chain state maintains a table of the quality-adjusted power of each SP, as well as their signing key. Each tipset $t$ in the chain commits to a particular state that results from executing all messages in the chain from genesis to $t$. The committee of participants for an instance of GossiPBFT is determined by the chain state resulting from the tipset finalized by a previous instance: the input parameter $committee$ of instance $i$ is defined by the tipset output by instance $i-PowerTableLookback$. If $i$ is less than $PowerTableLookback$, $committee$ is drawn from the chain state committed by the genesis.
+
+Given an EC chain state at some epoch, the corresponding F3 committee comprises all miner actors with:
+- at least 10TiB of quality-adjusted power;
+- zero fee debt; and
+- no active consensus fault.
+
+The F3 consensus power of each eligible F3 participant is the corresponding miner actor's EC quality-adjusted power, scaled such that the total power of all participants fits in a 16-bit unsigned integer.
+
+```
+ParticipantPower ← truncate(0xffff * MinerQAP / TotalQAP)
+```
+
+The total F3 consensus weight is the sum of all eligible participants' consensus weight (note this differs from EC leader election). An F3 participant's signing key is the associated miner actor's worker key (always a BLS key).
+
+The parameter $PowerTableLookback$ takes the value 10.
+
 ### Properties of F3
 
 F3 is not identical to classical consensus, however similar to it. In a nutshell, the reasons why EC and Filecoin should not rely on classical consensus properties (implemented by existing off-the-shelf BFT consensus protocol) for fast finality are twofold: EC-compatibility and resilience to Filecoin power leakage attacks in case of a strong adversary. 
@@ -99,7 +118,7 @@ With this in mind, the F3 component interface and properties are given below.
 
 > **Interface and properties of F3 at participant p:**
 >
-> `F3.invoke (int i, chain canonical, chain baseChain)` **returns** ("finalizes") `(int i, chain h, proof_of_finality PoF)`
+> `F3.invoke (int i, chain canonical, chain baseChain)` **returns** ("finalizes") `(int i, chain h, proof_of_finality certificate)`
 >
 > **Properties:**
 >
@@ -107,7 +126,7 @@ With this in mind, the F3 component interface and properties are given below.
 >
 > **Validity.** If an honest participant finalizes $(i,h,\ast)$, then $h$ is a prefix of the canonical input chain of some honest participant $p'$ in instance $i$.
 >
-> **Proof of Finality.** If an honest participant finalizes $(i,h,PoF)$, then $PoF$ is signed by ⅔ QAP majority corresponding to the $\texttt{PowerTable}(baseChain)'$ input in instance $i$ of some honest participant $p'$.
+> **Proof of Finality.** If an honest participant finalizes $(i,h,certificate)$, then certificate is signed by ⅔ QAP majority corresponding to the committee input to instance $i$ of some honest participant $p'$.
 >
 > **Progress.** If the system is $\Delta$-synchronous, i.e.,
 > * All honest participants can communicate within a known time bound $\Delta$, and
@@ -129,73 +148,64 @@ The GossiPBFT consensus protocol is detailed [below](#GossiPBFT-Consensus). It i
 Invocation of a consensus instance from a participant is denoted:
 
 ```
-GossiPBFT(i, proposal, baseChain, participants) → decision, PoF
+GossiPBFT(i, proposal, baseChain, committee) → decision, certificate
 ```
 
-A participant that invokes the $\texttt{GossiPBFT()}$ function starts a consensus instance identified by the sequence number $i$ and with an input value $proposal$. The $baseChain$ parameter represents the default value (agreement on not finalizing any new tipset). The $participants$ parameter is composed of the SPs that participate in this instance along with their respective individual weights (i.e., quality-adjusted power). The next section explains how the $participants$ are obtained from the power table. The invocation eventually returns a $decision$ value and a proof of finality $PoF$ that proves $decision$ is indeed the output of this consensus instance. In any invocation from F3, $decision$ is a finalized chain prefix in the form of a tipset. $PoF$ can be verified by using the $\texttt{Verify}()$ function:
+A participant that invokes the $\texttt{GossiPBFT()}$ function starts a consensus instance identified by the sequence number $i$ and with an input value $proposal$. The $baseChain$ parameter represents the default value (agreement on not finalizing any new tipset). The $committee$ parameter is composed of the SPs that participate in this instance along with their respective individual weights (i.e., quality-adjusted power) and signing keys. The invocation eventually returns a $decision$ value and a certificate that proves $decision$ is indeed the output of this consensus instance. In any invocation from F3, $decision$ is a finalized chain prefix in the form of a tipset. Certificates can be verified by using the $\texttt{Verify}()$ function:
 
 ```
-Verify(PoF, decision, participants) → boolean
+Verify(certificate, decision, committee) → boolean
 ```
 
-This function uses the $PoF$ to verify that $decision$ was the output of some instance of consensus executed among the $participants$.
+This function uses the certificate to verify that $decision$ was the output of some instance of consensus executed among the $committee$.
 
-
-### Power Table and Consensus Participants
-
-The _power table_ in the existing power actor maintains, among other things, the quality-adjusted power of each SP. Each tipset $t$ in the chain commits to a particular power table denoted $\texttt{PowerTable}(t)$ that results from executing all messages in the chain from genesis to $t$. The participants of an instance of GossiPBFT are determined by the power table resulting from the tipset finalized by a previous instance. More rigorously, the input parameter $participants$ of an instance $i$ is obtained from $\texttt{PowerTable}(decision_{i-PowerTableLookback})$, where $decision_{i-PowerTableLookback}$ is the tipset output by instance $i-PowerTableLookback$. If $i$ is less than $PowerTableLookback$, $participants$ is the power table committed by genesis tipset.
-
-The parameter $PowerTableLookback$ takes the value 10.
 
 ### F3 Pseudocode
 
 The F3 algorithm is specified by pseudo-code:
 
 ```
-// finalizedTipsets is a list of records with tipset and PoF fields representing
-// all finalized tipsets with their respective proof of finality.
+// A list of all finalized tipsets with their respective certificates.
+// One entry per consensus instance.
+// Initialized with a genesis which needs no proof.
+finalizedTipsets[0] ← {tipset: genesis, certificate: nil}
 
-// It is initialized with the genesis tipset by definition, which needs no proof.
-finalizedTipsets[0].tipset ← genesis
-finalizedTipsets[0].PoF ← nil
-
+// The first instance number after genesis is 1.
 i ← 1
 while True:
-  wait until EC.CurrentEpoch() >= finalizedTipsets[i-1].Head().epoch + 2: // do not start until 2 epochs ahead
-  proposal ← EC.HeaviestUnfinalizedChain() // get heaviest chain from EC
+   // Delay start until EC is 2 epochs ahead of last finalised chain.
+  wait until EC.CurrentEpoch() >= finalizedTipsets[i-1].Head().epoch + 2
+  // Fetch tipsets from locally-observed EC chain from (inclusive) the last finalised tipset.
+  proposal ← EC.HeaviestUnfinalizedChain()
   if proposal.Head().epoch = EC.CurrentEpoch()
-	proposal = proposal[-1] // remove head from current epoch, as pre-agreement is unlikely
-  if i > PowerTableLookback:
-  	participants ← PowerTable(finalizedTipsets[i-PowerTableLookback].tipset)
-  else:
-	participants ← PowerTable(finalizedTipsets[0].tipset) // use genesis table the first 10 instances.
-  finalizedTipset, PoF ← GossiPBFT(i, proposal, finalizedTipsets[i-1], participants)
-  finalizedTipsets[i].tipset ← finalizedTipset
-  finalizedTipsets[i].PoF ← PoF
+    // Remove current epoch tipset, as pre-agreement is unlikely
+    proposal ← proposal[:-1]
+  // Get the power table from previously-finalised tipset from lookback instances ago.
+  // Use genesis power for initial instances.
+  lookback ← min(i, PowerTableLookback)
+  committee ← MakeCommittee(finalizedTipsets[i-lookback].tipset)
+  // Execute GPBFT instance i.
+  finalizedTipset, certificate ← GossiPBFT(i, proposal, finalizedTipsets[i-1], committee)
+  // Record decision and prepare for next instance.
+  finalizedTipsets[i] ← {tipset: finalizedTipset, certificate: certificate}
   i ← i + 1
 ```
 
-Each participant keeps track of the finalized tipsets and respective proofs of finality in a data structure named $finalizedTipsets$. It contains one $finalizedTipsets[i]$ entry per consensus instance where $finalizedTipsets[i].tipset$ and $finalizedTipsets[i].PoF$ denote, respectively, the tipset and PoF output by consensus instance $i$. A participant considers a tipset finalized if it is included in $finalizedTipsets$ or is an ancestor of some tipset included in $finalizedTipsets$.
-
-The algorithm starts by initializing $finalizedTipsets[0]$ with the genesis tipset. This tipset is pre-defined as finalized and does not require a PoF. Then, in each iteration $i$ of the loop, it takes the following steps:
-
-1. Wait until the current epoch is at least two epochs from that of the latest finalized head.
-2. Obtain the set of participants of instance $i$ from the power table determined by the finalized tipset $PowerTableLookback$ instances ago.
-3. Call the $\texttt{HeaviestUnfinalizedChain}()$ function that returns the tipsets of the locally observed chain constructed by EC from finalizedTipset[i-1].Head (including the head of the finalized chain) and sets the $proposal$ variable to the returned value. Note that the proposal is pruned so that its head is at most a tipset from the previous epoch, not the current epoch.
-4. Execute the instance $i$ of GossiPBFT consensus.
-5. Add the returned tipset from the consensus execution to the $finalizedTipsets$ list.
+A participant considers a tipset _final_ if it is included in, or is an ancestor of, any finalized tipset.
 
 Note that if EC produces empty tipsets, EC epochs progress regardless. F3 will then repeatedly propose and finalize the same base chain until a non-empty tipset is produced. 
 
 ### Changes to EC: Fork Choice Rule
 
-EC is modified to accommodate the finalization of tipsets by F3. **This is the only change to EC this FIP introduces.**
+The current EC fork-choice rule selects, from all the known tipsets, the tipset backed by the most weight.
+This fork choice rule is modified to accommodate the finalization of tipsets by F3. **This is the only change to EC this FIP introduces.**
 
-The current EC fork-choice rule selects, from all the known tipsets, the tipset backed by the most weight. As the F3 component finalizes tipsets, the fork-choice rule must ensure that the heaviest finalized chain is always a prefix of the heaviest chain, preventing reorganizations of the already finalized chain.
+The fork choice rule is modified in the presence of a finalized prefix:
+* the fork choice rule selects the heaviest chain out of all chains with a prefix that **includes all tipsets finalized by F3**.
 
-The fork choice rule is adjusted in the presence of a finalized prefix: the fork choice rule selects the heaviest chain out of all chians with a prefix that **matches exactly all tipsets finalized by F3**, in that a tipset $t'$ that is a superset of finalized tipset $t$ in the same epoch is not heavier than $t$ itself, despite it being backed by more EC power.
+A competing tipset $t'$ that is a superset of finalized tipset $t$ at the same epoch is not heavier than $t$ itself, despite it being backed by more EC power.
 
-This redefinition of the fork choice rule is consistent with the abstract notion of the heaviest chain being backed by the most power because a finalized tipset has been backed by a super-majority of participants in GossiPBFT. In contrast, any non-finalized block in the same epoch is only backed in that epoch by the EC proposer.
+This redefinition of the fork choice rule is consistent with the abstract notion of the heaviest chain being backed by the most power because a finalized tipset has been backed by a super-majority of the committee in GossiPBFT. In contrast, any non-finalized block in the same epoch is only backed in that epoch by it's proposer.
 
 The updated rule is illustrated in the following figure, where blocks in blue are finalized blocks, and all blocks are assumed to be proposed by a proposer holding only one EC ticket (the weight of a chain is the number of blocks):
 
@@ -213,9 +223,9 @@ Integrating F3 into Filecoin follows the usual path for Filecoin upgrades. One e
 
 ### GossiPBFT Consensus
 
-This section provides the specification of GossiPBFT, the consensus protocol that is iteratively instantiated by the F3 loop and returns a decision (in the form of an F3-finalized chain) and a PoF per instance.
+This section provides the specification of GossiPBFT, the consensus protocol that is iteratively instantiated by the F3 loop and returns a decision (in the form of an F3-finalized chain) and a certificate per instance.
 
-GossiPBFT is a Byzantine fault-tolerant consensus protocol that is resilient optimal, i.e., it tolerates up to less than ⅓ QAP being controlled by a Byzantine adversary. Each instance of the protocol has a known set of participants. Each participant inputs a proposal value, and the protocol outputs one of the input values as the final decision value. Unlike a longest-chain protocol, the output of GossiPBFT is permanent.
+GossiPBFT is a Byzantine fault-tolerant consensus protocol that is resilient optimal, i.e., it tolerates up to less than ⅓ QAP being controlled by a Byzantine adversary. The committee for each instance of the protocol is known. Each participant inputs a proposal value, and the protocol outputs one of the input values as the final decision value. Unlike a longest-chain protocol, the output of GossiPBFT is permanent.
 
 GossiPBFT was designed with the Filecoin network in mind and presents a set of features that make it desirable in that context:
 
@@ -230,24 +240,24 @@ GossiPBFT was designed with the Filecoin network in mind and presents a set of f
 
 #### Message format, signatures, and equivocation
 
-Messages include the following fields: $\langle Sender, Signature, MsgType, Value, Instance, [Round, Evidence, Ticket] \rangle$. As $Round$, $Evidence$, and $Ticket$ are fields that not all message types require, when not required by a message type, their default value is used (i.e. $0$, $nil$, and $[] byte \lbrace\rbrace$, respectively). We refer to a _field_ of message $m$, with $m.field$:
+The schema for messages exchanged in the GPBFT protocol is defined below.
+The same message structure is used for all rounds and phases.
+
+Note that the message is self-attesting so no separate envelope or signature is needed:
+- The signature field fixes the included sender ID via the implied public key;
+- The signature payload includes all fields a sender can freely choose;
+- The ticket field is a signature of the same public key, so also self-attesting.
 
 ```go
-// A message in the GossiPBFT protocol.
-// The same message structure is used for all rounds and phases.
-// Note that the message is self-attesting so no separate envelope or signature is needed.
-// - The signature field fixes the included sender ID via the implied public key;
-// - The signature payload includes all fields a sender can freely choose;
-// - The ticket field is a signature of the same public key, so also self-attesting.
 type GossiPBFTMessage struct {
   // ID of the sender/signer of this message (a miner actor ID).
   Sender ActorID
-  // Vote is the payload that is signed by the signature.
+  // The payload that is signed by the signature.
   Vote Payload
   // Signature by the sender's public key over serialized vote payload.
   Signature []byte
   // VRF ticket for CONVERGE messages (otherwise empty byte array).
-  Ticket Ticket
+  Ticket []byte
   // Evidence that justifies this message, or nil.
   Evidence *Evidence
 }
@@ -267,7 +277,7 @@ type SupplementalData struct {
   // Merkle-tree of instance-specific commitments. Currently empty (0) but this will
   // eventually include things like snark-friendly power-table commitments.
   Commitments [32]byte
-  // The DagCBOR-blake2b256 CID of the power table used to validate the next
+  // The DagCBOR-blake2b256 CID of the power table / committee to be used to validate the *next*
   // instance, taking lookback into account.
   PowerTable CID
 }
@@ -288,13 +298,13 @@ type Payload struct {
 }
 
 type ECTipset struct {
-  Epoch       uint64   // The Filecoin epoch
-  TipsetKey   []byte   // A canonical concatination of the block-header CIDs in a tipset.
-  PowerTable  CID      // A blake2b-256 CID of the cbor-encoded power-table.
+  Epoch uint64         // The Filecoin epoch
+  TipsetKey []byte     // A canonical concatination of the block-header CIDs in a tipset.
+  PowerTable CID       // A blake2b-256 CID of the cbor-encoded power-table.
   Commitments [32]byte // Root of a Merkle tree containing additional commitments.
 }
 
-// Table of nodes with power > 0 and their public keys.
+// Table of nodes eligible for the committee, with their weights public keys.
 // This is expected to be calculated from the EC chain state and provided to GossiPBFT.
 // Ordered by (power descending, participant ascending).
 type PowerTable = []PowerTableEntry
@@ -306,43 +316,53 @@ type PowerTableEntry struct {
 }
 ```
 
+Values for step numbers are:
+
+| Step name | Value |
+|-----------|-------|
+| QUALITY   | 1     |
+| CONVERGE  | 2     |
+| PREPARE   | 3     |
+| COMMIT    | 4     |
+| DECIDE    | 5     |
+
 All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over `"GPBFT:filecoin:":15 || Step:1 || Round:8 || Instance:8 || SupplementalData.Commitments:32 || MerkelizeValue(Value):32 || SUpplementalData.PowerTable` (where `Round` and `Instance` are big-endian encoded). The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
 
-The receiver of a message only considers messages with matching supplemental data and valid signatures, discarding all other messages as invalid. We sometimes omit the sender IDs and signatures in further descriptions for better readability.
+The receiver of a message only considers messages with matching supplemental data and valid signatures, and discards all other messages as invalid. The sender ID and signatures are omitted in further descriptions for better readability.
 
-Two (or more) messages $m1$ and $m2$ are called _equivocating messages_ if $m1.Sender=m2.Sender \land m1.Instance=m2.Instance \land m1.Value ≠ m2.Value \land m1.MsgType=m2.MsgType \land \texttt(if applicable)\ m1.Round=m2.Round$. We call $m1.Sender$ an _equivocating sender_.
+Two (or more) messages $m1$ and $m2$ are called _equivocating messages_ if $m1.Sender=m2.Sender \land m1.Instance=m2.Instance \land m1.Value ≠ m2.Value \land m1.MsgType=m2.MsgType \land \texttt(if applicable)\ m1.Round=m2.Round$. $m1.Sender$ is called an _equivocating sender_.
 
-A set of messages $M$ that does not contain equivocating messages is called _clean_. Participants discard all equivocating messages when forming clean sets. In fact, in the proposed version of GossiPBFT in this document, only one of the equivocating messages needs to be stored (thanks to evidences explicitly validating a message).
+A set of messages $M$ that does not contain equivocating messages is called _clean_. Participants discard all equivocating messages when forming clean sets.
 
 ##### `MerkelizeValue`
 
-Instead of encoding `Payload.Value` as CBOR and signing the result, we convert it into a merkle-tree and format the individual `ECTipset` objects in a way that's easy to parse within both snarks and EVM-based blockchains.
+Instead of encoding `Payload.Value` as CBOR and signing the result, it is converted into a merkle-tree and format the individual `ECTipset` objects in a way that's easy to parse within both snarks and EVM-based blockchains.
 
-Specifically, we encode each `ECTipset` by concatenating:
+Specifically, each `ECTipset` is encoded by concatenating:
 
 1. The `Epoch`, encoded as a big-endian 64bit value (8 bytes).
 2. The `Commitements` hash as-is (32 bytes).
 3. The tipset _CID_, a blake2b CID of the `TipsetKey` encoded as a CBOR byte array (38 bytes). The resulting CID is the "tipset CID". Importantly, it's hash digest is the digest returned by the `BLOCKHASH` instruction in Filecoin's EVM implementation.
 4. The `PowerTable` CID .
 
-Then, we build a [merkle tree](#merkle-tree-format) from these encoded `ECTipset` values. Only the final merkle tree root gets signed.
+A [merkle tree](#merkle-tree-format) is built from these encoded `ECTipset` values. Only the final merkle tree root gets signed.
 
 #### Predicates and functions used in the protocol
 
 * `Power(p | P) ∈ [0x0000, 0xffff]`
-    * Returns the relative QAP of participant $p$ in EC as an integer in the range `[0x0000, 0xffff]`, defined by the power table corresponding to $baseChain$.
+    * Returns the relative QAP of participant $p$ in EC as an integer in the range `[0x0000, 0xffff]`, defined by the power table for $committee$.
     * If $p$ is a set of participants, the returned value is $\sum_{p\prime \in p} \texttt{Power}(p\prime | P)$. That is, the sum of the $\texttt{Power}$ of the participants in the set.
     * Otherwise, the returned value is a fraction of the total QAP of all participants in the power table scaled to an integer in the range $[0, 2^{16})$, rounded down ($\lfloor (2^{16}-1) \times \texttt{QAP}(p) / \texttt{QAP}(P) \rfloor$).
 * `IsStrongQuorum(p | P)`
    * Returns $True$ if $\texttt{Power}(p) \ge \lceil ⅔\texttt{Power}(P) \rceil$ where $p$ is a subset of the participants and $P$ is the set of all members in the power table.
    * $\texttt{Power}(P)$ will likely be less than $\mathrm{0xffff}$ due to compounded rounding errors.
-* `isPrefix(a,b)`
+* `IsPrefix(a,b)`
     * Returns $True$ if chain $a$ is a prefix of chain $b$. (Each chain is also a prefix of itself.)
 * `HasStrongQuorum(prefix,M)`
     * Where $M$ is a clean set of messages of the same type and the same round.
     * Let $P$ be the set of participants who are senders of messages in $M$ such that their message contains a value with $prefix$ as a prefix. More precisely:
       ```
-      Let P={p : ∃ m∈ M: m.sender=p AND isPrefix(prefix,m.value)}
+      Let P={p : ∃ m∈ M: m.sender=p AND IsPrefix(prefix,m.value)}
       ```
       then the predicate returns $True$ iff $\texttt{IsStrongQuorum}(P)$.
 * `HasStrongQuorumValue(M)`
@@ -368,170 +388,181 @@ Then, we build a [merkle tree](#merkle-tree-format) from these encoded `ECTipset
 
 #### GossiPBFT pseudocode (main algorithm)
 
-We illustrate the pseudocode for GossiPBFT below, consisting of 3 steps per round (QUALITY/CONVERGE, PREPARE, COMMIT) and an additional step outside the round loop (DECIDE). The $Sender$, $Signature$, and $Instance$ fields are omitted from messages for better readability. See also the simplified [PlusCal/TLA+ specification](https://github.com/filecoin-project/tla-f3).
+The GossiPBFT algorithm is specified by pseudo-code below. It consists of 3 steps per round (QUALITY/CONVERGE, PREPARE, COMMIT) and an additional step outside the round loop (DECIDE). Message fields that are constant for the instance are omitted for readability. 
+
+Messages are delivered to the participant in some order, whereupon a predicate over the set of received messages is evaluated, depending on the algorithm's current round and step.
+
+See also the simplified [PlusCal/TLA+ specification](https://github.com/filecoin-project/tla-f3).
 
 ```
-GossiPBFT(instance, inputChain, baseChain, participants) → decision, PoF:
-\*participants is implicitly used to calculate quorums
+GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
+// Committee is implicitly used to calculate quora.
 
 01:  round ← 0
-02:  decideSent ← False
-03:  proposal ← inputChain  \* holds what the participant locally believes should be a decision
+03:  proposal ← inputChain  // CHain that the participant locally believes should be decided.
 04:  timeout ← 2*Δ
-05:  timeout_rebroadcast  ← timeout + 1 
-     \* timeout_rebroadcast is at least >timeout, how much greater is up to the participant
-06:  value ← proposal \* used to communicate the voted value to others (proposal or 丄)
-07:  evidence ← nil   \* used to communicate optional evidence for the voted value
+05:  timeout_rebroadcast ← timeout + 1 // Any value larger than timeout, at implementation discretion.
+06:  value ← proposal // Used to communicate the voted value to others (proposal or 丄)
+07:  evidence ← nil   // Used to communicate evidence for the voted value
 08:  C ← {baseChain}
 09:  step ← nil
-10:  own_msgs ← {} \* specified as a set of msgs, exact data structure can be implementation specific
+10:  own_msgs ← {} // Set of msgs sent by this participant
 
 11:  while (step != DECIDE)  {
+       // QUALTIY
 12:    if (round = 0)
-13:      BEBroadcast <QUALITY, value, instance>; trigger (timeout)
+13:      BEBroadcast <QUALITY, value>; trigger (timeout)
 14:      step ← QUALITY
 15:      collect a clean set M of valid QUALITY messages from this instance 
            until HasStrongQuorum(proposal, M) OR timeout expires
 17:      C ← C ∪ {prefix : IsPrefix(prefix,proposal) and HasStrongQuorum(prefix,M)}
-18:      proposal ← heaviest prefix ∈ C \* this becomes baseChain or sth heavier
+18:      proposal ← longest prefix ∈ C  // At least baseChain, or something longer
 19:      value ← proposal
 
-20:    if (round > 0)     \* CONVERGE
+       // CONVERGE
+20:    if (round > 0)
 21:      ticket ← VRF(Randomness(baseChain) || instance || round)
-22:      value ← proposal \* set local proposal as value in CONVERGE message
-23:      reBroadcast <CONVERGE, value, instance, round, evidence, ticket>; trigger(timeout)
+22:      value ← proposal  // set local proposal as value
+23:      reBroadcast <CONVERGE, value, round, evidence, ticket>; trigger(timeout)
 25:      collect a clean set M of valid CONVERGE msgs from this round and instance
            until timeout expires
-26:      value, justification ← GreatestTicketProposal(M)     \* leader election
-27:      if (evidence is a strong quorum of PREPAREs AND mayHaveStrongQuorum(value, r-1, COMMIT, 1/3))
+26:      value, justification ← GreatestTicketProposal(M)  // Leader election
+27:      if (justification step is PREPARE AND mayHaveStrongQuorum(value, r-1, COMMIT, 1/3))
 28:        C ← C ∪ {value}
 29:      if (value ∈ C)
-30:        proposal ← value \* we sway proposal if the value is EC compatible (i.e., in C)
-31:        evidence ← justification \* otherwise keep existing proposal and evidence
+30:        proposal ← value // Sway proposal if the value is EC compatible (i.e., in C)
+31:        evidence ← justification //  Otherwise keep existing proposal and evidence
 
-32:    reBroadcast <PREPARE, value, instance, round, evidence>; trigger(timeout) 
-       \* note that evidence is nil in round=0
+       // PREPARE
+       // Note that evidence is nil in round 0.
+32:    reBroadcast <PREPARE, value, round, evidence>; trigger(timeout) 
 33:    collect a clean set M of valid PREPARE messages from this round and instance 
          until (HasStrongQuorumValue(M) AND StrongQuorumValue(M) = proposal)
            OR (NOT mayHaveStrongQuorum(proposal, round, PREPARE, 0))
            OR (timeout expires AND isStrongQuorum(M))
 34:    if (HasStrongQuorumValue AND StrongQuorumValue(M) = proposal) 
-       \* strong quorum of PREPAREs for local proposal
-35:      value ← proposal \* vote for deciding proposal (COMMIT)
-36:      evidence ← Aggregate(M) \* strong quorum of PREPAREs is evidence
+         // Strong quorum of PREPAREs for local proposal
+35:      value ← proposal  // Vote for deciding this proposal
+36:      evidence ← Aggregate(M)  // strong quorum of PREPAREs is evidence
 37:    else
-38:      value ← 丄 \* vote for not deciding in this round
+38:      value ← 丄  // Vote for not deciding in this round
 39:      evidence ← nil
 
-40:    reBroadcast <COMMIT, value, instance, round, evidence>; trigger(timeout)
+40:    reBroadcast <COMMIT, value, round, evidence>; trigger(timeout)
 41:    collect a clean set M of valid COMMIT messages from this round and instance
          until HasStrongQuorumValue(M) OR (timeout expires AND IsStrongQuorum(M))
 42:    if (HasStrongQuorumValue(M))
-43:      if (StrongQuorumValue(M) ≠ 丄)    \* decide
+43:      if (StrongQuorumValue(M) ≠ 丄)  // Decide
+           // This broadcast sets step = DECIDE which will break the outer loop
 44:        evidence ← Aggregate(M)
-45:        reBroadcast <DECIDE, StrongQuorumValue(M), instance, evidence>  
-           \* effectively breaks the while loop, next line is 56 - wait for other DECIDE messages
-46:      else \* no participant decided in this round
-47:        evidence ← Aggregate(M) \* strong quorum of COMMITs for 丄 is evidence
-48:    if (∃ m ∈ M: m.value ≠ 丄) \* m.value was possibly decided by others
-49:      C ← C ∪ {m.value}           \* add to candidate values if not there
-50:      proposal ← m.value; \* sway local proposal to possibly decided value
-51:      evidence ← m.evidence \* strong PREPARE quorum is inherited evidence
+45:        reBroadcast <DECIDE, StrongQuorumValue(M), evidence>  
+46:      else  
+           // No participant decided in this round, carry forward existing proposal
+47:        evidence ← Aggregate(M)  // Strong quorum of COMMITs for 丄 is evidence
+48:    if (∃ m ∈ M: m.value ≠ 丄)  // Value was possibly decided by others
+49:      C ← C ∪ {m.value}  // Add to candidate values if not there
+50:      proposal ← m.value  // Sway local proposal to possibly decided value
+51:      evidence ← m.evidence  // Strong PREPARE quorum is inherited evidence
 52:    round ← round + 1;
-53:    timeout ← updateTimeout(timeout, round)
-54:    timeout_rebroadcast ← max(timeout+1, timeout_rebroadcast)
-55:  }  \*end while
+53:    timeout ← 2 * Δ * pow(BackOffExponent, round)
+54:    timeout_rebroadcast ← timeout + 1  // Arbitrary increment
+55:  }
 
-56:  collect a clean set M of valid DECIDE messages
-       until (HasStrongQuorumValue(M)) \* collect a strong quorum of decide outside the round loop
-57:  return (StrongQuorumValue(M), Aggregate(M)) \* terminate the algorithm with a decision
-```
-```
-\* decide anytime
-58:  upon reception of a valid <DECIDE, instance, v, evidence> AND not decideSent
-59:    reBroadcast <DECIDE, v, instance, evidence>
-60:    go to line 56. 
+56:  collect a clean set M of valid DECIDE messages from this instance
+       until (HasStrongQuorumValue(M)) // Collect a strong quorum of DECIDE outside the round loop
+57:  return (StrongQuorumValue(M), Aggregate(M)) // Terminate with a decision
 ```
 
-The helper function mayHaveStrongQuorum returns False if, given the already delivered messages, the participant knows for a fact that no correct participant could have decided the given value in the given round, even in the presence of an adversary controlling advPower the relative amount of total QAP equivocating, and True otherwise. The parameter advPower can be set to 0 in order to consider the possibility of the participant locally deciding, whereas when set to 1/3 it considers the possibility of any participant deciding:
+A participant jumps immediately to the DECIDE step upon receiving a DECIDE message from another participant. That message will carry evidence of a strong quorum of the committee COMMITting to that value.
+
+```
+     // Decide anytime
+58:  upon reception of a valid <DECIDE, v, evidence>, if step != DECIDE
+59:    reBroadcast <DECIDE, v, evidence>
+60:    go to line 56
+```
+
+The helper function mayHaveStrongQuorum returns whether, given the already delivered messages and assuming the presence of an equivocating adversary, some correct participant could have observed strong quorum for a value at some round and step. The parameter advPower can be set to 0 in order to consider the possibility of the participant locally observing strong quorum, or ⅓ to consider the possibility of any participant doing so. Note that where only two values are possible, a false return for one of them does not imply that the other has necessarily reached strong quorum (e.g. an exact ⅔ to ⅓ split).
 
 ```
 61:  mayHaveStrongQuorum(value, round, step, advPower): 
-62:    M  ← { m | m.step = step AND m.round = round AND m is valid} /* clean set of messages
+62:    M  ← { m | m.step = step AND m.round = round AND m is valid} // Clean set of messages
 63:    M' ← { m | m ∈ M AND m.value = value } 
-64:    if Power(M') + (1-Power(M)) < ⅔ - advPower  : \* value cannot have been decided 
-65:      return False
-66:    return True
+64:    return Power(M') + (1-Power(M)) + advPower > ⅔ 
 ```
 
-The reBroadcast function rebroadcasts all the messages in the current round if the participant cannot terminate the step that it is in by the time the timeout has expired. 
+The reBroadcast function broadcasts and remembers a message. It then sets a timeout to rebroadcast a subset of the messages in the current and previous round if the participant cannot terminate the step that it is in. 
 
 ```
-67:  reBroadcast(msg): 
+67:  reBroadcast(msg):
 68:    own_msgs = own_msgs ∪ {msg}
 69:    BEBroadcast(msg)
-70:    trigger(timeout_rebroadcast) 
+70:    trigger(timeout_rebroadcast)
 71:    step ← msg.step
 72:    upon timeout_rebroadcast expires:
 73:      if step = msg.step AND msg.round = round AND msg.instance = instance 
-         \* stuck, need to rebroadcast
+           // Stuck, need to rebroadcast
 74:        switch (msg.step) {
 75:          case DECIDE:
-76:            BEBroadcast(m ∈ own_msgs: m.round=0 AND m.type=DECIDE) \* only rebroadcast DECIDE
+76:            BEBroadcast(m ∈ own_msgs: m.round=0 AND m.type=DECIDE) // only rebroadcast DECIDE
 77:            break;  // Exit, no cascading
 78:          case COMMIT:
 79:            BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=COMMIT) 
-               \* no break, cascade to broadcast PREPARE, CONVERGE
+               // Cascade to broadcast PREPARE, CONVERGE
 80:          case PREPARE:
 81:            BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=PREPARE) 
-               \* no break, cascade to broadcast CONVERGE
-82:          default: \send CONVERGE here because of cascading effect of switch cases
+               // Cascade to broadcast CONVERGE
+82:          default: // CONVERGE
 83:            if msg.round > 0:
 84:              BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=CONVERGE)
 85:              BEBroadcast(m ∈ own_msgs: m.round=msg.round-1 AND m.type=COMMIT)
 86:              BEBroadcast(m ∈ own_msgs: m.round=msg.round-1 AND m.type=PREPARE)
 87:              break;
 88:        }
-89:        update(timeout_rebroadcast); \* increase and trigger again timeout_rebroadcast 
+           // Increase and trigger timeout_rebroadcast again.
+           // The amount to increase is at the discretion of the participant.
+89:        timeout_rebroadcast = timeout_rebroadcast + 1
 90:        trigger(timeout_rebroadcast) 
 ```
-The conditions for skipping rounds and buffering messages are shown below (below, max_lookahead_rounds is an implementation config parameter):
+
+A participant may skip to a subsequent round upon receiving sufficient messages to demonstrate that a strong quorum of other participants have reached that round.
+
+In order to avoid unbounded accumulation of state, some messages from some future rounds are immediately dropped.
 
 ```
-100:  upon reception of a valid msg: 
-      \* validity assumes same instance as currently running
-      \* different instances treated elsewhere (not scope of this doc)
+100:  upon reception of a valid msg for this instance: 
 101:    if (msg.round > round + max_lookahead_rounds) AND msg.step = COMMIT AND msg.value = 丄  
-102:		  return \* drop message
-103:	  deliver(msg) 
-104:    if  (msg' ← shouldJump(round, step) s.t. msg' != nil) 	
-        \* one of the rest of conditions to be able to jump
+102:      return  // Drop message
+103:    deliver(msg)  // Otherwise make the message available to the main algorithm
+104:    if (msg' ← shouldJump(round, step) s.t. msg' != nil)
+          // The msg' is a CONVERGE for round
 105:      round ← msg'.round;
-106:      timeout ← 2*Δ*backOffExponent**msg'.round
-107:      timeout_rebroadcast ← max(timeout+1, timeout_rebroadcast)
-108:      if msg'.evidence.step = PREPARE: \* either this or strong quorum of COMMITs for 丄
-109:        C ← C ∪ {msg'.value}       \* add to candidate values if not there
-110:        proposal ← msg'.value;     \* sway local proposal to possibly decided value
+106:      timeout ← 2 * Δ * pow(BackOffExponent, round)
+107:      timeout_rebroadcast ← timeout + 1 // Arbitrary increment
+108:      if msg'.evidence.step = PREPARE: // Evidence is strong quorum of either PREPAREs of COMMITs for 丄
+109:        C ← C ∪ {msg'.value}       // Add to candidate values if not there
+110:        proposal ← msg'.value;     // Sway local proposal to possibly decided value
+          // Inherit evidence for the value from CONVERGE message 
 111:      evidence ← msg'.evidence   
-          \* strong PREPARE quorum is inherited evidence for the value 
-          \* it exists because the value might have been decided
-112:      go to line 21  \* start new round>0 by jumping forward
+112:      go to line 21  // Start new round>0 by jumping forward
 
 113:  shouldJump(round, step): 
-114:    if step = DECIDE: \* never jump once up to DECIDE step
+114:    if step = DECIDE:
 115:      return nil
-116:    if (∃ msg' st. msg'.step = CONVERGE \* there must be a CONVERGE for the new round
-            AND msg'.round > round          \* round must be greater
+116:    if (∃ msg' st. msg'.step = CONVERGE // There must be a CONVERGE for the new round
+            AND msg'.round > round          // Round must be greater
             AND ∃ M s.t. M is clean and valid and contains a weak quorum of PREPAREs for msg'.round)
 117:      return msg'
 118:    return nil
 ```
 
-Note that the selection of the heaviest prefix in line 18 does not need access to the tipsets' EC weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or viceversa (since the adversary controls < ⅓ of the QAP). As a result, selecting the heaviest prefix is as simple as selecting the highest blockheight (greatest number of blocks), while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
+The parameter max_lookahead_rounds may be set at the discretion of an implementation. 
+
+Note that the selection of the heaviest prefix in line 18 does not need access to the tipsets' EC weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or vice-versa (since the adversary controls < ⅓ of the QAP). As a result, selecting the heaviest prefix is as simple as selecting the longest chain, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
 
 Implementations may optimise this algorithm to treat the reception of an aggregated signature over some (MsgType, Instance, Round, Value) as evidence of a message as if it had received the same tuple of values directly from each participant in the aggregate. This may be used to effectively skip a partially-complete step. In the particular case of a DECIDE message, which carries evidence of a strong quorum of COMMITs for the same round and value, a participant immediately sends its own DECIDE for the same value (copying the evidence) and exits the loop at line 11.
 
-Also, we restrict the set C of candidate values that the participant contributes to deciding to only values that either (i) pass the QUALITY step or (ii) may have been decided by other participants (hence the function `mayHaveStrongQuorum`).
+Also, the set C of candidate values that the participant contributes to deciding is restricted to only values that either (i) pass the QUALITY step or (ii) may have been decided by other participants.
 
 When a participant is in receipt of multiple messages at once (such as when starting an instance with queued messages), a decision to jump ahead rounds should be taken only after processing all available messages. This will enable the participant to contribute to a decision other than the base chain.
 
@@ -547,7 +578,7 @@ Valid(m):                                    | For a message m to be valid,
   if m.sender has zero power or is unknown:  |   The sender must have power and be known.
     return False                             | 
   if NOT (m.value = 丄 OR                    |   m's value must extend baseChain
-          baseChain.isPrefix(m.value))       |   or be 丄
+          IsPrefix(baseChain, m.value))      |    or be 丄
     return False                             | 
   if m.step != CONVERGE AND m.ticket != nil  |   ticket must be nil if not CONVERGE
     return False                             | 
@@ -561,14 +592,14 @@ Valid(m):                                    | For a message m to be valid,
   if m.step = DECIDE AND                     |   A DECIDE message must
     (m.round != 0 OR m.value = 丄)           |   have round 0 and non-丄 value.
     return False                             |  
-  if m.step IN {QUALITY}                     |   If the step never requires evidence
+  if m.step = QUALITY                        |   If the step never requires evidence
     if m.evidence != nil:                    |   (QUALITY), evidence should not be present.
       return False                           |
     if len(m.value) > 100:                   |   Proposal's head must be at most 99 tipsets
       return False                           |   ahead of baseChain's head.
   else                                       | 
     return ValidEvidence(m)                  | 
-  return True                                | 
+  return True                                |   No evidence for QUALITY
 ```
 
 The $\texttt{ValidEvidence}()$ predicate is defined below. Note that QUALITY messages do not need evidence.
@@ -605,32 +636,27 @@ OR (step=COMMIT                                            | valid COMMIT eviden
 OR (step = DECIDE                                          | valid DECIDE evidence
       AND (∃ M: IsStrongQuorum(M) AND evidence=Aggregate(M)| is a strong quorum 
         AND ∀ m’ ∈ M: m’.step = COMMIT                     | of COMMIT messages
-        AND ∀ m’,m'' ∈ M: m’.round = m''.round             | from the same round 
+        AND ∀ m’,m’’ ∈ M: m’.round = m’’.round             | from the same (any) round as each other
         AND ∀ m’ ∈ M: m’.value = value))                   | for the same value 
 ```
 
 ### Evidence verification complexity
-Note that during the validation of each CONVERGE, COMMIT, and DECIDE message, two signatures need to be verified: (1) the signature of the message contents, produced by the sender of the message (first check above) and (2) the aggregate signature in $m.evidence$ ($\texttt{ValidEvidence}(m)$ above). The former can be verified using the sender's public key (stored in the power table). The latter, being an aggregated signature, requires aggregating public keys of all the participants whose signatures it combines. Notice that the evidence of each message can be signed by a different set of participants, which requires aggregating a linear number of public BLS keys (in system size) per evidence verification.
-
-However, a participant only needs to verify the evidence once for each *unique* message (in terms of (step, round, value)) received. Moreover, verification can further be reduced to those messages a participant uses to make progress (such as advancing to the next step or deciding), ignoring the rest as they are not needed for progress. This reduces the number of evidence verifications in each step to at most one.
+Note that during the validation of each CONVERGE, COMMIT, and DECIDE message, two signatures need to be verified: (1) the signature of the message contents, produced by the sender of the message (first check above) and (2) the aggregate signature in $m.evidence$ ($\texttt{ValidEvidence}(m)$ above). The former can be verified using the sender's public key (stored in the power table). The latter, being an aggregated signature, requires aggregating public keys of all the participants whose signatures it combines. Notice that the evidence of each message can be signed by a different set of participants, which requires aggregating a linear number of public BLS keys (in system size) per evidence verification. However, a participant only needs to verify the evidence once for each *unique* message (in terms of (step, round, value)) received.
 
 #### Randomness
 
-An instance of GossiPBFT requires a seed σ that must be common among all participants due to the dependency on a VRF in the CONVERGE step. As only one random seed is required per GossiPBFT instance, and there is only one GossiPBFT instance per epoch (see below), the random seed for GossiPBFT can be sourced from drand's output for that epoch in EC.
+An instance of GossiPBFT requires a seed that must be common among all participants due to the dependency on a VRF in the CONVERGE step. As only one random seed is required per GossiPBFT instance, and there is only one GossiPBFT instance per epoch (see below), the random seed for GossiPBFT is be sourced from drand's output for the EC epoch from which the committee is formed.
 
 
 ### Synchronization of Participants in the Current Instance
 
 GossiPBFT ensures termination provided that (i) all participants start the instance at most $\Delta$ apart, and (ii) the estimate on Δ is large enough for $\Delta$-synchrony in some round (either because of the real network delay recovering from asynchrony or because of the estimate increasing).
 
-[Given prior tests performed on GossipSub](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf) (see also [here](https://gist.github.com/jsoares/9ce4c0ba6ebcfd2afa8f8993890e2d98)), we expect that sent messages will reach almost all participants within $Δ=3s$, with a majority receiving them even after $Δ=2s$. However, if several participants start the instance $Δ + ε$ after some other participants, termination is not guaranteed for the selected timeouts of $2*Δ$. Thus, we do not rely on an explicit synchrony bound for correctness. Instead, we increase the estimate of Δ locally within an instance as rounds progress without decision.
+[Given prior tests performed on GossipSub](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf) (see also [here](https://gist.github.com/jsoares/9ce4c0ba6ebcfd2afa8f8993890e2d98)), sent messages are expected to reach almost all participants within 3 seconds, with a majority receiving them even after 2 seconds. However, if several participants start the instance $Δ + ε$ after some other participants, termination is not guaranteed for the selected timeouts of $2*Δ$. Thus, the protocol does not rely on an explicit synchrony bound for correctness. Instead, the estimate of Δ is increased locally within an instance as rounds progress without decision.
 
-The synchronization of participants is performed in the call to $\texttt{updateTimeout(timeout, round)}$ (line 53), and works as follows:
+The synchronization of participants within an instance is achieved with a timeout exponentially increasing each round. Participants start each instance with `Δ=3s` and for each round, set the step timeout to `2 * Δ * BackOffExponent^{round}`.
 
-* Participants start an instance with `Δ=2s`.
-* Participants set their timeout for the current round to `Δ*backOffExpoinent^{r}` where $r$ is the round number ($r=0$ for the first round) and `backOffExponent=2`.
-
-Additionally, as an optimization, participants may continue to the subsequent step once the execution of the current step has been determined, without waiting for the timeout. For example, if a participant receives QUALITY messages from all participants, it can proceed to the next step without waiting for the timeout. More generally, if the remaining valid messages to be received cannot change the execution of the step, regardless of the values contained in the messages, then a participant may continue to the next step.
+As an optimization, participants may finish a step once its execution is determined by the received messages, without waiting for the timeout. For example, if a participant receives QUALITY messages from all participants, it can proceed to the next step without waiting for the timeout. More generally, if the remaining valid messages to be received cannot change the execution of the step, regardless of the values contained in the messages, then a participant may continue to the next step.
 
 
 ### Synchronization of Participants across Instances
@@ -672,12 +698,12 @@ type PowerTableDelta struct {
 }
 ```
 
-A finality certificate is analogous to a full block in the EC block exchange protocol.
-
+Certificates for the same instance and decision may vary across participants in which signatures are aggregated to provide the strong quorum.
 
 #### Exchange protocol
 
-Like with EC block exchange, participants follow **a simple request/response protocol to provide a contiguous sequence of finality certificates**. Note that the sequence of certificates is traversed backward, matching block exchange. A finality certificate contains the tipset and the PoF of the tipset ($Signature$). PoFs may vary across participants, but all PoFs must be for the same tipset at the same instance number $i$.
+A finality certificate is analogous to a full block in the EC block exchange protocol.
+Like with EC block exchange, participants follow **a simple request/response protocol to provide a contiguous sequence of finality certificates**. Note that the sequence of certificates is traversed backward, matching block exchange. 
 
 ```
 type Request struct {
@@ -750,20 +776,18 @@ Only one such smart contract is needed on a single blockchain execution environm
 
 ### Merkle Tree Format
 
-This protocol uses merkle trees as vector commitments to commit to both (a) the tipsets in an instance and (b) the values committed to in each tipset. We use a single binary merkle tree format in both cases.
-
-Specifically, we use a balanced binary merkle tree where:
+This protocol uses merkle trees as vector commitments to commit to both (a) the tipsets in an instance and (b) the values committed to in each tipset. It uses a single, balanced binary merkle tree format in both cases, where:
 
 1. The hash function is `keccak256` (same as Ethereum) for maximum EVM compatibility.
 2. Each internal node is prefixed with a single `0x0` byte before hashing (`keccak256([0] + left + right)`).
 3. Each leaf is prefixed with a single `0x1` byte before hashing (`keccak256([1] + value)`).
 4. Missing values and empty sub-trees hash to `[32]byte{}` (32 `0x0` bytes).
 
-In our tree, we prove that some value `v` is committed to at index `i` in the merkle tree rooted at `r` by providing the "uncles" (the branches not taken) of the merkle path from `v` to `r` (bottom to top). This algorithm is best described in [code](../resources/fip-0086/merkletree.go).
+In this tree, a proof that some value `v` is committed to at index `i` in the merkle tree rooted at `r` comprises the "uncles" (the branches not taken) of the merkle path from `v` to `r` (bottom to top). This algorithm is best described in [code](../resources/fip-0086/merkletree.go).
 
 ## Design Rationale
 
-Many possibilities were considered for faster finality. We justify the architecture of F3 as the best candidate to achieve fast finality in Filecoin by comparing it with other options:
+Many possibilities were considered for faster finality. Other options considered include:
 
 * _Improvements to Filecoin's EC_: Longest chain protocols rely on the increasing probability over time that some state is consistent across all participants. In all existing implementations of longest-chain protocols, finalization thus incurs at least tens of minutes.
 * _Best-effort finality gadgets_: Ethereum's approach to faster finality involves the introduction of a novel finality gadget. However, this finality gadget requires at least two epochs for finalization, translating to at least more than 30 seconds in Filecoin. In contrast, GossiPBFT can achieve sub-epoch finalization and is only limited by the network speed. Moreover, Ethereum's protocol is yet to be proven correct. In fact, multiple attacks have been described in the literature that show how an adversary can keep the system from ever finalizing blocks, even after fixes.
@@ -783,13 +807,13 @@ The `ECTipset` contains 4 values:
 3. A CID of the power table.
 4. The root of the commitements merkle tree.
 
-We included the epoch directly in the `ECTipset` object itself because we expect proofs of the form "event X happened before/after/at epoch Y" to be common in cross-chain interactions.
+The epoch is included directly in the `ECTipset` object itself to support proofs of the form "event X happened before/after/at epoch Y", common in cross-chain interactions.
 
-The tipset key is required as this is the main value F3 is finalizing. While off-chain light-clients will use the tipset key, cross-chain bridges likely won't which is why we _hash_ the tipset key before signing (so we won't have to send the full tipset key to bridge contracts, saving gas).
+The tipset key is required as this is the main value F3 is finalizing. While off-chain light-clients will use the tipset key, cross-chain bridges likely won't. Thus, the tipset key is _hashed_ before signing (so the full tipset key need not be sent to bridge contracts, saving gas).
 
-We include a blake2b hash of the power table to aid in syncing the F3 chain. In theory we could have added it to the commitment merkle tree and left it out of the root `ECTipset` object, but being able to validate a chain of finality certificates without any additional merkle-proofs is convenient and the an extra 32 bytes is not an unreasonable cost (512 gas on Ethereum) .
+A blake2b hash of the power table is included to aid in syncing the F3 chain. In theory it could be added to the commitment merkle tree and left it out of the root `ECTipset` object, but being able to validate a chain of finality certificates without any additional merkle-proofs is convenient and the an extra 32 bytes is not an unreasonable cost (512 gas on Ethereum) .
 
-Finally, we include the root hash of the commitments merkle-tree. This tree is _empty_ at the moment but will eventually include:
+Finally, the structure includes the root hash of a commitments merkle-tree. This tree is _empty_ at the moment but will eventually include:
 
 1. Commitements to snark-friendly representations of the power table.
 2. Events, likely indexed by emitter (useful for cross-chain messaging).
@@ -798,16 +822,16 @@ And probably more. Importantly, the network can easily commit to additional valu
 
 #### Wire Format v. Signing Format
 
-For both the `Payload` and the `ECTIpset`s themselves, we encode them one way for signing and another when sending them over the network.
+Both the `Payload` and the `ECTIpset`s themselves are encoded them one way for signing and another when sending them over the network.
 
-1. Even though we end up signing a root of a merkle-tree of the tipsets, we have to send the full list of tipsets over the network as the protocol needs a way to find common prefixes.
-2. Even though we end up signing a CID of the tipset key, we have to send the full tipset key over the wire because the Filecoin chainsync protocol names tipsets by tipset key, not tipset CID/hash. By sending the full key, a client can learn about _new_ tipsets from F3 if it doesn't hear about them from its peers.
+1. Even though the root of a merkle-tree of the tipsets is signed, the full list of tipsets must be sent over the network as the protocol needs a way to find common prefixes.
+2. Even though a CID of the tipset key is signed, the full tipset key must be sent over the wire because the Filecoin chainsync protocol names tipsets by tipset key, not tipset CID/hash. By sending the full key, a client can learn about _new_ tipsets from F3 if it doesn't hear about them from its peers.
 
-On the other hand, when signing, we tend to sign hashes and merkle-trees so we can easily omit unnecessary data from proofs sent across bridges.
+On the other hand, hashes and merkle-trees are signed so unnecessary data may be easily omitted from proofs sent across bridges.
 
 ##### Certificate/Decision Signing Format
 
-Decision payloads are designed to be easy to work with in the EVM (32-byte alignment) and within zkSNARKs (small with fixed-length fields). Instead of naively signing a CBOR-encoded value, we sign `Payload` objects such that decisions are encoded as follows:
+Decision payloads are designed to be easy to work with in the EVM (32-byte alignment) and within zkSNARKs (small with fixed-length fields). Instead of naively signing a CBOR-encoded value, `Payload` objects are encoded as follows:
 
 
 |             | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15  | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 |
@@ -838,27 +862,21 @@ Additionally, the epoch comes _before_ the commitments as it lets the bridge arr
 
 #### Merkle Trees
 
-We put both the tipsets and the commitments inside tipsets into merkle trees to keep proof-sizes (for bridges) small, even if we have a large instance with many tipsets.
+Both the tipsets and the commitments inside tipsets are nested into merkle trees to keep proof-sizes (for bridges) small, even if a large instance has many tipsets.
 
-Our merkle tree is heavily based on the [merkle tree from CometBFT][comet-merkle], but that one:
+The merkle tree is heavily based on the [merkle tree from CometBFT][comet-merkle], but that one:
 
 1. Uses sha256 (not EVM friendly).
 2. Requires more complex math on validation. This lets it avoid a few hash operations in some cases, but that likely isn't worth the complexity.
 3. Needs additional out-of-band information to be a _true_ vector commitment. Optimization 2 in the CometBFT merkle tree means that a proof for item 7/7 can be treated as a proof of an item 6/6.
 
-Most other well-known merkle tree formats (verkle trees, etc.) optimize for sparse trees and where we have _full_ trees, so the complexity isn't worth it.
+Most other well-known merkle tree formats (verkle trees, etc.) optimize for sparse trees and where this protocol will have _full_ trees, so the complexity isn't worth it.
 
 [comet-merkle]: https://github.com/cometbft/cometbft/blob/main/spec/core/encoding.md#merkle-trees
 
 ## Backwards Compatibility
 
-The implementation of F3 involves three main tasks:
-
-1. Implementing GossiPBFT in a modular way (no changes to existing codebase).
-2. Re-formulating the fork-choice rule to the heaviest suffix of the heaviest finalized chain.
-3. Implementating the F3 component, which reads the EC chain and marks blocks as final locally.
-
-Because of changes to the EC fork choice rule, this FIP requires a network upgrade to take effect.
+This FIP requires a network upgrade to take effect since it changes the EC fork choice rule.
 
 
 ## Test Cases
@@ -953,22 +971,19 @@ Because of changes to the EC fork choice rule, this FIP requires a network upgra
 
 ## Security Considerations
 
-The modifications proposed in this FIP have far-reaching implications for the security of the system. This FIP changes Filecoin at a fundamental level: from considering tipsets as final after some time to finalizing them after a quorum of participants reach an agreement. We list here the security considerations this modification entails.
+The modifications proposed in this FIP have far-reaching implications for the security of the system. This FIP changes Filecoin at a fundamental level: from considering tipsets as final after some time to finalizing them after a quorum of participants reach an agreement. Some security considerations this modification entails:
 
-* **Censorship.** F3 and GossiPBFT are designed with censorship resistance in mind. The updated fork choice rule means that an adversary controlling at least more than ⅓ QAP can try to perform a censorship attack if honest participants start an instance of GossiPBFT proposing at least two distinct inputs. While this attack is theoretically possible, it is notably hard to perform on F3 given the QUALITY step of GossiPBFT and other mitigation strategies specifically put in place to protect against this. We strongly believe that, even against a majority adversary, the mitigations designed will prevent such an attack.
+* **Censorship.** F3 and GossiPBFT are designed with censorship resistance in mind. The updated fork choice rule means that an adversary controlling at least more than ⅓ QAP can try to perform a censorship attack if honest participants start an instance of GossiPBFT proposing at least two distinct inputs. While this attack is theoretically possible, it is notably hard to perform on F3 given the QUALITY step of GossiPBFT and other mitigation strategies specifically put in place to protect against this. The mitigations designed will prevent such an attack, even against a majority adversary.
 * **Liveness.** Implementing F3 introduces the risk that an adversary controlling at least ⅓ QAP prevents termination of a GossiPBFT instance. In that case, the F3 component would halt, not finalizing any tipset anymore. At the same time, EC would still operate, outputting tipsets and considering them final after 900 epochs. The liveness of the system is thus not affected by attacks on the liveness of F3.
 * **Safety.** Implementing F3 ensures the safety of finalized outputs during regular or even congested networks against a Byzantine adversary controlling less than ⅓ QAP. For stronger adversaries, F3 provides mitigations to prevent censorship attacks, as outlined above. If deemed necessary, the punishment and recovery from coalitions in the event of an attempted attack on safety can be explored in future FIPs. Note that the (safe) finality time is already significantly improved by F3 compared to the status quo: F3 provides safety of finalized outputs two orders of magnitude faster than the current parameter of 900 epochs during regular network operation.
 * **Denial-of-service (DoS).** The implementation of the F3 preserves resistance against DoS attacks currently ensured by Filecoin, thanks to the fully leaderless nature of GossiPBFT and to the use of a VRF to self-assign tickets during the CONVERGE step.
-* **Committees.** This FIP proposes to have all participants run all instances of GossiPBFT. While this ensures optimal resilience against a Byzantine adversary, it can render the system unusable if the number of participants grows too large. While we are still evaluating the maximum practical number of participants in F3, it is expected to be at least one order of magnitude greater than the current number of participants in Filecoin. This introduces an attack vector: if the scalability limit is 100,000 participants, a participant holding as little as 3% of the current QAP can perform a Sybil attack to render the system unusable, with the minimum QAP required per identity. As a result, the implementation should favor the messages of the more powerful participants if the number of participants grows too large. Given that favoring more powerful participants discriminates against the rest, affecting decentralization, amending F3 to use committees in the event of the number of participants exceeding the practical limit will be the topic of a future FIP, as well as the analysis of optimized message aggregation in the presence of self-selected committees.
+* **Committees.** This FIP proposes to have all eligible EC participants run all instances of GossiPBFT. While this ensures optimal resilience against a Byzantine adversary, it can render the system unusable if the number of participants grows too large. This introduces an attack vector: if the scalability limit is 100,000 participants, a participant holding as little as 3% of the current QAP can perform a Sybil attack to render the system unusable, with the minimum QAP required per identity. As a result, the implementation should favor the messages of the more powerful participants if the number of participants grows too large. Given that favoring more powerful participants discriminates against the rest, affecting decentralization, amending F3 to use committees in the event of the number of participants exceeding the practical limit might be the topic of a future FIP, as well as the analysis of optimized message aggregation in the presence of self-selected committees.
 
 The supplementary material (../resources/fip-0086/) provides the proofs of correctness for the protocol.
 
 ## Incentive Considerations
 
-Participating in GossiPBFT only entails verifying $O(n)$ and generating $O(1)$ signatures per participant. If not enough participants follow the protocol, the liveness of F3 will be affected. This means that the service offered is affected, but also that participants do not receive rewards from block proposals for the period in which they do not participate, until the legacy finality of 900 epochs applies. Consequently, we do not believe additional incentives for participation are necessary, as the modifications in this FIP significantly improve the system and the additional computational and communication costs do not substantially alter the cost structure of running a Filecoin node.
-
-Furthermore, incentivizing all messages and verification thereof is impossible: this would require consensus on which messages have been sent (which would entail even more messages, these new ones unverified). Nevertheless, subsequent FIPs can provide more incentives, such as rewarding participants whose signatures are listed in agreed-upon PoFs or slash/denylist participants who sign equivocating messages.
-
+Participating in GossiPBFT entails a modest cost of verifying $O(n)$ and generating $O(1)$ signatures per participant, per round. If not enough participants follow the protocol, the liveness of F3 may be reduced. This means that the service offered is impaired, and also that rewards for EC block proposals may be delayed until the legacy probabilistic finality of 900 epochs is reached. The modifications in this FIP significantly improve the system and the additional computational and communication costs do not substantially alter the cost structure of running a Filecoin node. Thus, additional incentives for participation are not proposed.
 
 ## Product Considerations
 
@@ -979,7 +994,7 @@ Furthermore, incentivizing all messages and verification thereof is impossible: 
 
 ## Implementation
 
-We refer to the stand-alone implementation in a simulated environment in the [go-f3](https://github.com/filecoin-project/go-f3) repository. Work is ongoing on a reference lotus implementation (to be provided soon).
+Provided in the [go-f3](https://github.com/filecoin-project/go-f3) repository.
 
 
 ## Copyright

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -488,7 +488,7 @@ The helper function mayHaveStrongQuorum returns whether, given the already deliv
 61:  mayHaveStrongQuorum(value, round, step, advPower): 
 62:    M  ← { m | m.step = step AND m.round = round AND m is valid} // Clean set of messages
 63:    M' ← { m | m ∈ M AND m.value = value } 
-64:    return Power(M') + (1-Power(M)) + advPower > ⅔ 
+64:    return Power(M') + (1-Power(M)) + advPower >= ⅔ 
 ```
 
 The reBroadcast function broadcasts and remembers a message. It then sets a timeout to rebroadcast a subset of the messages in the current and previous round if the participant cannot terminate the step that it is in. 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -170,16 +170,34 @@ The F3 algorithm is specified by pseudo-code:
 // Initialized with a genesis which needs no proof.
 finalizedTipsets[0] ← {tipset: genesis, certificate: nil}
 
+// The number of epochs by which instance start is delayed relative to 
+// epoch of last finalised chain head.
+startBackoffEpochs ← 0
+
+// The number of times instance start is retried due to empty tipsets.
+startRetryAttempts ← 0
+
 // The first instance number after genesis is 1.
 i ← 1
 while True:
-   // Delay start until EC is 2 epochs ahead of last finalised chain.
-  wait until EC.CurrentEpoch() >= finalizedTipsets[i-1].Head().epoch + 2
+  // Delay start until EC is ahead of last finalised chain plus instance start backoff.
+  wait until EC.CurrentEpoch() >= finalisedTipsets[i-1].Head().epoch + startBackoffEpochs
+  // Delay start until EC is 2 epochs ahead of last finalised chain.
+  wait until EC.CurrentEpoch() >= finalizedTipsets[i-1].Head().epoch + 2 
   // Fetch tipsets from locally-observed EC chain from (inclusive) the last finalised tipset.
   proposal ← EC.HeaviestUnfinalizedChain()
   if proposal.Head().epoch = EC.CurrentEpoch()
     // Remove current epoch tipset, as pre-agreement is unlikely
     proposal ← proposal[:-1]
+  if proposal.Head() = finalizedTipsets[i-1].Head()
+    // EC has produced empty tipsets. Increase backoff parameters, and retry.
+    startBackoffEpochs ← startBackoffEpochs + nextStartBackoffIncrement(startRetryAttempts)
+    startRetryAttempts ← startRetryAttempts + 1
+    continue // Skip to the next iteration.
+  else
+    // Reset backoff parameters. 
+    startBackoffEpochs ← 0
+    startRetryAttempts ← 0
   // Get the power table from previously-finalised tipset from lookback instances ago.
   // Use genesis power for initial instances.
   lookback ← min(i, PowerTableLookback)
@@ -193,7 +211,9 @@ while True:
 
 A participant considers a tipset _final_ if it is included in, or is an ancestor of, any finalized tipset.
 
-Note that if EC produces empty tipsets, EC epochs progress regardless. F3 will then repeatedly propose and finalize the same base chain until a non-empty tipset is produced. 
+Note that if EC produces empty tipsets, EC epochs progress regardless. Therefore, delaying start of the next instance based on EC epoch alone can cause F3 to repeatedly propose and finalize the same base chain until a non-empty tipset is produced. The `startBackoffEpochs` mitigates this issue by introducing a backoff mechanism to slow down F3 instantiation, allowing EC to catch up and preventing continuous termination and re-initiation of instances. This controlled delay maintains the stability and efficiency of the F3 component by preventing unnecessary rapid cycling through instances.
+
+The function `nextStartBackoffIncrement(int)` returns the number of epochs by which `startBackoffEpochs` should be increased based on the number of attempts, referred to as `startRetryAttempts`. Implementers may choose any increment function at their discretion, but for each instance number `i` the increment amount relative to the number of attempts must be consistent across all participants.
 
 ### Changes to EC: Fork Choice Rule
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -47,14 +47,14 @@ In EC and, generally, longest-chain protocols, the probability of a path from so
 
 ### F3 Overview and Interaction with EC
 
-This proposal introduces an F3 component, which works alongside EC in Filecoin client nodes (participants).
+This proposal introduces an F3 component, which works alongside EC in Filecoin client nodes.
 
 The participants in F3 are the storage providers (SPs) of the Filecoin network. The participation of each SP is weighted according to its quality-adjusted power (QAP), which is a function of the storage power that the SP has committed to the network. This information is maintained in a built-in actor called the _power actor_ (f04). Only SPs that hold more than the threshold of power to participate in EC can participate in F3.
 
-In short, each participant $p$ in the Filecoin network (i.e., a storage provider with power) runs F3 in a loop and feeds its input from EC. F3 returns a finalized prefix chain to EC, which updates the canonical chain to extend this F3-finalized prefix. More precisely, in each loop iteration $i$ (corresponding to the i-th instance of F3):
+In short, each participant $p$ in the Filecoin network runs F3 in a loop and feeds its input from EC. F3 returns a finalized prefix chain to EC, which updates the canonical chain to extend this F3-finalized prefix. More precisely, in each loop iteration $i$ (corresponding to the i-th instance of F3):
 
 - **EC/F3 interface:** Participant $p$ feeds its current canonical chain $canonical$ and its previously F3-finalized chain, called the $baseChain$, to F3. The $baseChain$ (with some lookback parameter) fixes the power table used by F3 and randomness seed used to configure the F3 instance, while $p$'s current canonical chain is the chain $p$ proposes to be finalized.
-- **F3 consensus:** F3 establishes network-wide consensus on finalized tipsets and produces a _Certificate of Finality_ for a tipset finalized in instance $i$, $t_i$. Every certificate output by F3 is signed by ≥ ⅔ of the total QAP, i.e., a super-majority of the power table. This vouches that honest participants with more than ⅓ QAP consider tipset $t_i$ final (assuming up to ⅓ QAP may be dishonest).
+- **F3 consensus:** F3 establishes network-wide consensus on finalized tipsets and produces a _certificate of finality_ for a tipset finalized in instance $i$, $t_i$. Every certificate output by F3 is signed by ≥ ⅔ of the total QAP, i.e., a super-majority of the power table. This vouches that honest participants with more than ⅓ QAP consider tipset $t_i$ final (assuming up to ⅓ QAP may be dishonest).
 - **EC:** Participant $p$ updates its local EC chain and commits not to reorganize the finalized tipset $t_i$, i.e., the tipset must stay in $p$'s EC canonical chain for good. Apart from this change, EC continues operating as it currently does. In particular, EC still does a 900-epoch lookback for its power table (which can therefore differ from the one used by F3) and continues operating “normally” if F3 assumptions are violated and F3 halts, with the combined EC/F3 protocol favoring availability over consistency (in CAP theorem parlance).
 - **F3 synchronization:** Participants disseminate information about each finalized tipset and associated certificate to all other participants, light clients, and smart contracts. The main goal of F3 synchronization is to allow an external party (or a lagging F3 participant) to fetch a sequence of messages that prove the finality of some recent final tipset. The sequence demonstrates a chain of eligible participants deciding on a final tipset and, thus, the eligible power table for the next round. Verifying the finality of a tipset from genesis does not require access to the EC chain.
 
@@ -87,7 +87,7 @@ The _no duplication_ property of a traditional best-effort broadcast primitive i
 
 A system is $\Delta$-_synchronous_ if the combined computation and communication delay between any two honest participants is smaller than $\Delta$. Under $\Delta$-synchrony, any message broadcast by an honest participant is delivered by every honest participant within a time bound of $\Delta$.
 
-In practice, if GossipSub is used for _BEBroadcast_, $\Delta$ is an assumed upper bound on GossipSub latency (e.g., a few seconds).
+In practice, if GossipSub is used for _BEBroadcast_, $\Delta$ is an assumed upper bound on GossipSub latency.
 
 For termination, a classical partially synchronous model is assumed, with an unknown bound on communication delays among non-Byzantine participants.
 
@@ -112,7 +112,7 @@ The parameter $PowerTableLookback$ takes the value 10.
 
 ### Properties of F3
 
-F3 is not identical to classical consensus, however similar to it. In a nutshell, the reasons why EC and Filecoin should not rely on classical consensus properties (implemented by existing off-the-shelf BFT consensus protocol) for fast finality are twofold: EC-compatibility and resilience to Filecoin power leakage attacks in case of a strong adversary. 
+F3 is not identical to classical consensus, however similar to it. In a nutshell, the reasons why EC and Filecoin should not rely on classical consensus properties (implemented by existing off-the-shelf BFT consensus protocol) for fast finality are twofold: EC compatibility and resilience to Filecoin power leakage attacks in case of a strong adversary. 
 
 With this in mind, the F3 component interface and properties are given below.
 
@@ -126,7 +126,7 @@ With this in mind, the F3 component interface and properties are given below.
 >
 > **Validity.** If an honest participant finalizes $(i,h,\ast)$, then $h$ is a prefix of the canonical input chain of some honest participant $p'$ in instance $i$.
 >
-> **Proof of Finality.** If an honest participant finalizes $(i,h,certificate)$, then certificate is signed by ⅔ QAP majority corresponding to the committee input to instance $i$ of some honest participant $p'$.
+> **Proof of Finality.** If an honest participant finalizes $(i,h,certificate)$, then $certificate$ is signed by ⅔ QAP majority corresponding to the committee input to instance $i$ of some honest participant $p'$.
 >
 > **Progress.** If the system is $\Delta$-synchronous, i.e.,
 > * All honest participants can communicate within a known time bound $\Delta$, and
@@ -138,7 +138,7 @@ With this in mind, the F3 component interface and properties are given below.
 >
 > **EC compatibility.** An honest participant never contributes to gathering ⅔ QAP (super-majority) of votes for a chain $c$ which its local EC instance did not already deliver unless it already observes evidence of such a super-majority for chain $c$.
 
-The $\Delta$ parameter is specified (See [below](#Synchronization-of-Participants-in-the-Current-Instance)).
+The $\Delta$ parameter is specified [below](#Synchronization-of-Participants-in-the-Current-Instance).
 
 
 ### Consensus Interface
@@ -225,7 +225,7 @@ The fork choice rule is modified in the presence of a finalized prefix:
 
 A competing tipset $t'$ that is a superset of finalized tipset $t$ at the same epoch is not heavier than $t$ itself, despite it being backed by more EC power.
 
-This redefinition of the fork choice rule is consistent with the abstract notion of the heaviest chain being backed by the most power because a finalized tipset has been backed by a super-majority of the committee in GossiPBFT. In contrast, any non-finalized block in the same epoch is only backed in that epoch by it's proposer.
+This redefinition of the fork choice rule is consistent with the abstract notion of the heaviest chain being backed by the most power because a finalized tipset has been backed by a super-majority of the committee in GossiPBFT. In contrast, any non-finalized block in the same epoch is only backed in that epoch by its proposer.
 
 The updated rule is illustrated in the following figure, where blocks in blue are finalized blocks, and all blocks are assumed to be proposed by a proposer holding only one EC ticket (the weight of a chain is the number of blocks):
 
@@ -245,7 +245,7 @@ Integrating F3 into Filecoin follows the usual path for Filecoin upgrades. One e
 
 This section provides the specification of GossiPBFT, the consensus protocol that is iteratively instantiated by the F3 loop and returns a decision (in the form of an F3-finalized chain) and a certificate per instance.
 
-GossiPBFT is a Byzantine fault-tolerant consensus protocol that is resilient optimal, i.e., it tolerates up to less than ⅓ QAP being controlled by a Byzantine adversary. The committee for each instance of the protocol is known. Each participant inputs a proposal value, and the protocol outputs one of the input values as the final decision value. Unlike a longest-chain protocol, the output of GossiPBFT is permanent.
+GossiPBFT is a Byzantine fault-tolerant consensus protocol that is resilient-optimal, i.e., it tolerates up to less than ⅓ QAP being controlled by a Byzantine adversary. The committee for each instance of the protocol is known. Each participant inputs a proposal value, and the protocol outputs one of the input values as the final decision value. Unlike a longest-chain protocol, the output of GossiPBFT is permanent.
 
 GossiPBFT was designed with the Filecoin network in mind and presents a set of features that make it desirable in that context:
 
@@ -319,12 +319,12 @@ type Payload struct {
 
 type ECTipset struct {
   Epoch uint64         // The Filecoin epoch
-  TipsetKey []byte     // A canonical concatination of the block-header CIDs in a tipset.
+  TipsetKey []byte     // A canonical concatenation of the block-header CIDs in a tipset.
   PowerTable CID       // A blake2b-256 CID of the cbor-encoded power-table.
   Commitments [32]byte // Root of a Merkle tree containing additional commitments.
 }
 
-// Table of nodes eligible for the committee, with their weights public keys.
+// Table of nodes eligible for the committee, with their weights and public keys.
 // This is expected to be calculated from the EC chain state and provided to GossiPBFT.
 // Ordered by (power descending, participant ascending).
 type PowerTable = []PowerTableEntry
@@ -346,7 +346,7 @@ Values for step numbers are:
 | COMMIT    | 4     |
 | DECIDE    | 5     |
 
-All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over `"GPBFT:filecoin:":15 || Step:1 || Round:8 || Instance:8 || SupplementalData.Commitments:32 || MerkelizeValue(Value):32 || SUpplementalData.PowerTable` (where `Round` and `Instance` are big-endian encoded). The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
+All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over `"GPBFT:filecoin:":15 || Step:1 || Round:8 || Instance:8 || SupplementalData.Commitments:32 || MerkelizeValue(Value):32 || SupplementalData.PowerTable` (where `Round` and `Instance` are big-endian encoded). The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
 
 The receiver of a message only considers messages with matching supplemental data and valid signatures, and discards all other messages as invalid. The sender ID and signatures are omitted in further descriptions for better readability.
 
@@ -511,7 +511,7 @@ The helper function mayHaveStrongQuorum returns whether, given the already deliv
 64:    return Power(M') + (1-Power(M)) + advPower >= ⅔ 
 ```
 
-The reBroadcast function broadcasts and remembers a message. It then sets a timeout to rebroadcast a subset of the messages in the current and previous round if the participant cannot terminate the step that it is in. 
+The reBroadcast function broadcasts and remembers a message. It then sets a timeout to rebroadcast a subset of the messages in the current and previous round if the participant cannot terminate the step in which it is.
 
 ```
 67:  reBroadcast(msg):
@@ -576,7 +576,7 @@ In order to avoid unbounded accumulation of state, some messages from some futur
 118:    return nil
 ```
 
-The parameter max_lookahead_rounds may be set at the discretion of an implementation. 
+The parameter `max_lookahead_rounds` may be set at the discretion of an implementation. 
 
 Note that the selection of the heaviest prefix in line 18 does not need access to the tipsets' EC weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or vice-versa (since the adversary controls < ⅓ of the QAP). As a result, selecting the heaviest prefix is as simple as selecting the longest chain, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
 
@@ -661,7 +661,7 @@ OR (step = DECIDE                                          | valid DECIDE eviden
 ```
 
 ### Evidence verification complexity
-Note that during the validation of each CONVERGE, COMMIT, and DECIDE message, two signatures need to be verified: (1) the signature of the message contents, produced by the sender of the message (first check above) and (2) the aggregate signature in $m.evidence$ ($\texttt{ValidEvidence}(m)$ above). The former can be verified using the sender's public key (stored in the power table). The latter, being an aggregated signature, requires aggregating public keys of all the participants whose signatures it combines. Notice that the evidence of each message can be signed by a different set of participants, which requires aggregating a linear number of public BLS keys (in system size) per evidence verification. However, a participant only needs to verify the evidence once for each *unique* message (in terms of (step, round, value)) received.
+Note that during the validation of each CONVERGE, COMMIT, and DECIDE message, two signatures need to be verified: (1) the signature of the message contents, produced by the sender of the message (first check above) and (2) the aggregate signature in $m.evidence$ ($\texttt{ValidEvidence}(m)$ above). The former can be verified using the sender's public key (stored in the power table). The latter, being an aggregated signature, requires aggregating public keys of all the participants whose signatures it combines. Notice that the evidence of each message can be signed by a different set of participants, which requires aggregating a linear number of BLS public keys (in system size) per evidence verification. However, a participant only needs to verify the evidence once for each *unique* message (in terms of (step, round, value)) received.
 
 #### Randomness
 
@@ -723,7 +723,7 @@ Certificates for the same instance and decision may vary across participants in 
 #### Exchange protocol
 
 A finality certificate is analogous to a full block in the EC block exchange protocol.
-Like with EC block exchange, participants follow **a simple request/response protocol to provide a contiguous sequence of finality certificates**. Note that the sequence of certificates is traversed backward, matching block exchange. 
+Like with EC block exchange, participants follow a simple request/response protocol to provide a contiguous sequence of finality certificates. Note that the sequence of certificates is traversed backward, matching block exchange. 
 
 ```
 type Request struct {
@@ -831,7 +831,7 @@ The epoch is included directly in the `ECTipset` object itself to support proofs
 
 The tipset key is required as this is the main value F3 is finalizing. While off-chain light-clients will use the tipset key, cross-chain bridges likely won't. Thus, the tipset key is _hashed_ before signing (so the full tipset key need not be sent to bridge contracts, saving gas).
 
-A blake2b hash of the power table is included to aid in syncing the F3 chain. In theory it could be added to the commitment merkle tree and left it out of the root `ECTipset` object, but being able to validate a chain of finality certificates without any additional merkle-proofs is convenient and the an extra 32 bytes is not an unreasonable cost (512 gas on Ethereum) .
+A blake2b hash of the power table is included to aid in syncing the F3 chain. In theory, it could be added to the commitment merkle tree and left out of the root `ECTipset` object, but being able to validate a chain of finality certificates without any additional merkle-proofs is convenient and the extra 32 bytes is not an unreasonable cost (512 gas on Ethereum) .
 
 Finally, the structure includes the root hash of a commitments merkle-tree. This tree is _empty_ at the moment but will eventually include:
 
@@ -882,7 +882,7 @@ Additionally, the epoch comes _before_ the commitments as it lets the bridge arr
 
 #### Merkle Trees
 
-Both the tipsets and the commitments inside tipsets are nested into merkle trees to keep proof-sizes (for bridges) small, even if a large instance has many tipsets.
+Both the tipsets and the commitments inside tipsets are nested into merkle trees to keep proof sizes small, even if a large instance has many tipsets.
 
 The merkle tree is heavily based on the [merkle tree from CometBFT][comet-merkle], but that one:
 
@@ -890,7 +890,7 @@ The merkle tree is heavily based on the [merkle tree from CometBFT][comet-merkle
 2. Requires more complex math on validation. This lets it avoid a few hash operations in some cases, but that likely isn't worth the complexity.
 3. Needs additional out-of-band information to be a _true_ vector commitment. Optimization 2 in the CometBFT merkle tree means that a proof for item 7/7 can be treated as a proof of an item 6/6.
 
-Most other well-known merkle tree formats (verkle trees, etc.) optimize for sparse trees and where this protocol will have _full_ trees, so the complexity isn't worth it.
+Most other well-known merkle tree formats (verkle trees, etc.) optimize for sparse trees whereas this protocol will have _full_ trees.
 
 [comet-merkle]: https://github.com/cometbft/cometbft/blob/main/spec/core/encoding.md#merkle-trees
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -842,7 +842,7 @@ And probably more. Importantly, the network can easily commit to additional valu
 
 #### Wire Format v. Signing Format
 
-Both the `Payload` and the `ECTIpset`s themselves are encoded them one way for signing and another when sending them over the network.
+Both the `Payload` and the `ECTIpset`s themselves are encoded one way for signing and another when sending them over the network.
 
 1. Even though the root of a merkle-tree of the tipsets is signed, the full list of tipsets must be sent over the network as the protocol needs a way to find common prefixes.
 2. Even though a CID of the tipset key is signed, the full tipset key must be sent over the wire because the Filecoin chainsync protocol names tipsets by tipset key, not tipset CID/hash. By sending the full key, a client can learn about _new_ tipsets from F3 if it doesn't hear about them from its peers.

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -20,7 +20,7 @@ Filecoin clients currently consider blocks irreversible after 900 epochs, hinder
 
 The current Filecoin consensus mechanism only provides probabilistic finality. To simplify client implementations and provide some form of determinism, the protocol also includes a soft finality threshold, whereby miners at round $N$ reject all blocks that fork off before $N-900$. This finalization delay of 900 epochs (7.5 hours) hinders user experience and limits applications built on Filecoin.
 
-We specify a mechanism for fast finality with the F3 component. F3 is expected to finalize tipsets within tens of seconds during regular network operation, compared to the current 900-epoch finalization delay. It does so by leveraging GossiPBFT, an optimally resilient partially synchronous BFT consensus protocol, which runs in parallel with the current protocol, taking EC tipsets as input and providing finalized prefixes as output. The fork choice rule of EC is modified to ensure it never selects a chain other than the F3-finalized chain.
+This proposal provides a mechanism for fast finality with the F3 component. F3 is expected to finalize tipsets within tens of seconds during regular network operation, compared to the current 900-epoch finalization delay. It does so by leveraging GossiPBFT, an optimally resilient partially synchronous BFT consensus protocol, which runs in parallel with the current protocol, taking EC tipsets as input and providing finalized prefixes as output. The fork choice rule of EC is modified to ensure it never selects a chain other than the F3-finalized chain.
 
 
 ## Change Motivation
@@ -40,31 +40,31 @@ We specify a mechanism for fast finality with the F3 component. F3 is expected t
 
 ![](../resources/fip-0086/chain.png)
 
-Two or more tipsets of the same epoch with different ancestor tipsets (like tipsets $C$ and $C'$ above) form a _fork_ in the chain. Forks are resolved using a _fork choice rule_, a deterministic algorithm that, given a blockchain data structure, returns the heaviest tipset, called the _head_. We refer to the path from genesis to the head as the _canonical chain_. Participants may have different views of the blockchain, resulting in other canonical chains. For example, if a participant $p_1$ is not (yet) aware of tipset $D$, it would consider $C$ the heaviest tipset with the canonical chain $[G A B C]$. Another participant $p_2$ aware of tipset $D$ will consider $[G A C' D]$ to be the canonical chain. Once $p_1$ becomes aware of tipset $D$, it will update its canonical chain to $[G A C' D]$ - this is called _reorganization_. We say a tipset is _finalized_ when a reorganization involving that tipset is impossible, i.e., when a different path that does not contain the tipset cannot become the canonical chain.
+Two or more tipsets of the same epoch with different ancestor tipsets (like tipsets $C$ and $C'$ above) form a _fork_ in the chain. Forks are resolved using a _fork choice rule_, a deterministic algorithm that, given a blockchain data structure, returns the heaviest tipset, called the _head_. The path from genesis to the head is termed the _canonical chain_. Participants may have different views of the blockchain, resulting in other canonical chains. For example, if a participant $p_1$ is not (yet) aware of tipset $D$, it would consider $C$ the heaviest tipset with the canonical chain $[G A B C]$. Another participant $p_2$ aware of tipset $D$ will consider $[G A C' D]$ to be the canonical chain. Once $p_1$ becomes aware of tipset $D$, it will update its canonical chain to $[G A C' D]$ - this is called _reorganization_. A tipset is _finalized_ when a reorganization involving that tipset is impossible, i.e., when a different path that does not contain the tipset cannot become the canonical chain.
 
 In EC and, generally, longest-chain protocols, the probability of a path from some tipset $h$ to the genesis tipset becoming finalized increases with the number of descendant tipsets of $h$. This happens because the weight of the heaviest chain increases the fastest, as the tipsets with the most new blocks are appended to it (assuming that honest participants form a majority). In the particular case of EC, in each epoch, most created blocks are expected to come from honest participants and thus extend the heaviest chain. Consequently, it becomes progressively harder for a different path to overcome that weight. Over time, the probability of a tipset never undergoing a reorganization becomes high enough that the tipset is considered final for all practical purposes. In the Filecoin network, a tipset that is part of the heaviest chain is considered final after 900 epochs (or, equivalently, 7.5 hours) from its proposal.
 
 
 ### F3 Overview and Interaction with EC
 
-We propose implementing fast finality in Filecoin by introducing an F3 component, which works alongside EC in Filecoin client nodes (participants).
+This proposal introduces an F3 component, which works alongside EC in Filecoin client nodes (participants).
 
 The participants in F3 are the storage providers (SPs) of the Filecoin network. The participation of each SP is weighted according to its quality-adjusted power (QAP), which is a function of the storage power that the SP has committed to the network. This information is maintained in a built-in actor called the _power actor_ (f04). Only SPs that hold more than the threshold of power to participate in EC can participate in F3.
 
 In short, each participant $p$ in the Filecoin network (i.e., a storage provider with power) runs F3 in a loop and feeds its input from EC. F3 returns a finalized prefix chain to EC, which updates the canonical chain to extend this F3-finalized prefix. More precisely, in each loop iteration $i$ (corresponding to the i-th instance of F3):
 
-- **EC/F3 interface:** Participant $p$ feeds its current canonical chain $canonical$ and its previously F3-finalized chain, which we call the $baseChain$, to F3. The $baseChain$ defines the power table **used by F3** and seeds the randomness used to configure the F3 instance, while $p$'s current canonical chain is the chain $p$ proposes to be finalized. Periodically, $p$ also feeds to F3 tipset updates from EC that extend $p$'s canonical chain as EC delivers these tipsets.
-- **F3 consensus:** F3 establishes network-wide consensus on finalized tipsets and produces a _Proof of Finality (PoF)_ for a tipset finalized in instance $i$, $t_i$. Every _PoF_ output by F3 is signed by ≥ ⅔ of the total QAP, i.e., a super-majority of the power table vouching that honest participants with more than ⅓ QAP consider tipset $t_i$ final.
+- **EC/F3 interface:** Participant $p$ feeds its current canonical chain $canonical$ and its previously F3-finalized chain, called the $baseChain$, to F3. The $baseChain$ (with some lookback parameter) fixes the power table used by F3 and randomness seed used to configure the F3 instance, while $p$'s current canonical chain is the chain $p$ proposes to be finalized.
+- **F3 consensus:** F3 establishes network-wide consensus on finalized tipsets and produces a _Proof of Finality (PoF)_ for a tipset finalized in instance $i$, $t_i$. Every _PoF_ output by F3 is signed by ≥ ⅔ of the total QAP, i.e., a super-majority of the power table. This vouches that honest participants with more than ⅓ QAP consider tipset $t_i$ final (assuming up to ⅓ QAP may be dishonest).
 - **EC:** Participant $p$ updates its local EC chain and commits not to reorganize the finalized tipset $t_i$, i.e., the tipset must stay in $p$'s EC canonical chain for good. Apart from this change, EC continues operating as it currently does. In particular, EC still does a 900-epoch lookback for its power table (which can therefore differ from the one used by F3) and continues operating “normally” if F3 assumptions are violated and F3 halts, with the combined EC/F3 protocol favoring availability over consistency (in CAP theorem parlance).
-- **F3 synchronization:** Participants disseminate information about finalized tipset $t_i$ and its proof $PoF_i$ to all other participants, light clients, and smart contracts. The main goal of F3 synchronization is to allow an external party (or a lagging F3 participant) to fetch a sequence of messages that prove the finality of some recent final tipset. The sequence demonstrates a chain of eligible participants deciding on a final tipset and, thus, the eligible power table for the next round. Verifying the finality of a tipset from genesis does not require validating the EC chain.
+- **F3 synchronization:** Participants disseminate information about finalized tipset $t_i$ and its proof $PoF_i$ to all other participants, light clients, and smart contracts. The main goal of F3 synchronization is to allow an external party (or a lagging F3 participant) to fetch a sequence of messages that prove the finality of some recent final tipset. The sequence demonstrates a chain of eligible participants deciding on a final tipset and, thus, the eligible power table for the next round. Verifying the finality of a tipset from genesis does not require access to the EC chain.
 
 ![](../resources/fip-0086/flow.png)
 
 ### F3 Adversarial Model
 
-Honest participants follow the protocol at all times. Byzantine participants deviate arbitrarily from the protocol. Rational participants deviate from the protocol to pursue a greater (expected) pay-off according to their utility function. We consider a Byzantine adversary able to control and orchestrate up to less than ⅓ QAP.
+Honest participants follow the protocol at all times. Byzantine participants deviate arbitrarily from the protocol. Rational participants deviate from the protocol to pursue a greater (expected) pay-off according to their utility function. A Byzantine adversary is able to control and orchestrate up to less than ⅓ QAP.
 
-We further adapt our protocols to align the actions of honest and rational participants by ensuring that rational participants never contribute to finalizing a chain they do not locally possess. Without this, If a participant $p$ were to finalize a chain it didn't have, then $p$ would not be able to mine in EC until it retrieved the required blocks and thus, in the meantime, could not obtain the cryptoeconomic rewards that EC offers. To this end, F3 provides _EC compatibility_.
+The actions of honest and rational participants are aligned by ensuring that rational participants never contribute to finalizing a chain they do not locally possess. Without this, If a participant $p$ were to finalize a chain it didn't have, then $p$ would not be able to mine in EC until it retrieved the required blocks and thus, in the meantime, could not obtain the cryptoeconomic rewards that EC offers. To this end, F3 provides _EC compatibility_.
 
 F3 and its implementation GossiPBFT provide additional robustness for strong adversaries that control more than ⅓ QAP, such as:
 
@@ -72,31 +72,34 @@ F3 and its implementation GossiPBFT provide additional robustness for strong adv
 * Resilience to long-range attacks by an adversary controlling up to less than ⅔ QAP of any old power table.
 
 
-### Best-effort Broadcast and Gossipsub
+### Best-effort Broadcast and GossipSub
 
-F3 uses GossipSub (like Filecoin EC) to disseminate protocol messages, implementing a broadcast channel among participants. We assume and model GossipSub to satisfy the following properties of the _best-effort broadcast primitive_ (denoted _BEBroadcast_ hereafter):
+F3 uses GossipSub (like Filecoin EC) to disseminate protocol messages, implementing a broadcast channel among participants. GossipSub is assumed to satisfy the following properties of the _best-effort broadcast primitive_ (denoted _BEBroadcast_ hereafter):
 
-* If $p$ and $p'$ are honest, then every message broadcast by $p$ is eventually delivered by $p'$.
-* No message with sender $p$ is delivered unless it was previously broadcast by $p$.
+* _No creation_: No message with sender $p$ is delivered unless it was previously broadcast by $p$.
+* _Validity_: If $p$ and $p'$ are honest, then every message broadcast by $p$ is eventually delivered by $p'$.
 
+Note that academic nomenclature may be misleading, and "every message broadcast is eventually delivered" does not mean the broadcast is reliable. Messages may be lost if the sender, receiver, or link fail, but will be delivered if they don't.
+
+The _no duplication_ property of a traditional best-effort broadcast primitive is not needed; indeed F3 explicitly rebroadcasts messages to overcome loss. 
 
 ### Partially Synchronous Model and Δ-Synchrony
 
-We say the system is $\Delta$-_synchronous_ if the combined computation and communication delay between any two honest participants is smaller than $\Delta$. We assume that, under $\Delta$-synchrony, any message broadcast by an honest participant is delivered by every honest participant within a time bound of $\Delta$.
+A system is $\Delta$-_synchronous_ if the combined computation and communication delay between any two honest participants is smaller than $\Delta$. Under $\Delta$-synchrony, any message broadcast by an honest participant is delivered by every honest participant within a time bound of $\Delta$.
 
-In practice, if GossipSub is used for _BEBroadcast_, $\Delta$ is effectively the assumed upper bound on GossipSub latency (e.g., a few seconds).
+In practice, if GossipSub is used for _BEBroadcast_, $\Delta$ is an assumed upper bound on GossipSub latency (e.g., a few seconds).
 
-For termination, we assume a classical partially synchronous model with an unknown bound on communication delays among non-Byzantine participants.
+For termination, a classical partially synchronous model is assumed, with an unknown bound on communication delays among non-Byzantine participants.
 
 ### Properties of F3
 
-F3 is not identical to classical consensus, however similar to it. In a nutshell, the reasons why EC and Filecoin should not rely on classical consensus properties (implemented by existing off-the-shelf BFT consensus protocol) for fast finality are twofold: EC compatibility and resilience to Filecoin power leakage attacks in case of a strong adversary. 
+F3 is not identical to classical consensus, however similar to it. In a nutshell, the reasons why EC and Filecoin should not rely on classical consensus properties (implemented by existing off-the-shelf BFT consensus protocol) for fast finality are twofold: EC-compatibility and resilience to Filecoin power leakage attacks in case of a strong adversary. 
 
 With this in mind, the F3 component interface and properties are given below.
 
 > **Interface and properties of F3 at participant p:**
 >
-> `F3.invoke (int i, chain canonical, chain baseChain)` **returns** (we say finalizes) `(int i, chain h, proof_of_finality PoF)`
+> `F3.invoke (int i, chain canonical, chain baseChain)` **returns** ("finalizes") `(int i, chain h, proof_of_finality PoF)`
 >
 > **Properties:**
 >
@@ -116,20 +119,20 @@ With this in mind, the F3 component interface and properties are given below.
 >
 > **EC compatibility.** An honest participant never contributes to gathering ⅔ QAP (super-majority) of votes for a chain $c$ which its local EC instance did not already deliver unless it already observes evidence of such a super-majority for chain $c$.
 
-We later show the specific estimate chosen for $\Delta$ to optimize termination (See [here](#Synchronization-of-Participants-in-the-Current-Instance)).
+The $\Delta$ parameter is specified (See [below](#Synchronization-of-Participants-in-the-Current-Instance)).
 
 
 ### Consensus Interface
 
-The GossiPBFT consensus protocol is the main dependency of the F3. We will treat GossiPBFT as a black box here and defer the explanation of its internals to the [respective section](#GossiPBFT-Consensus) of this FIP. For now, it suffices to say that it is a Byzantine fault-tolerant consensus protocol that provides the typical properties of (1) agreement (no two honest participants decide differently), (2) validity (the decided value must pass a validity predicate), and (3) termination (every honest participant eventually decides).
+The GossiPBFT consensus protocol is detailed [below](#GossiPBFT-Consensus). It is a Byzantine fault-tolerant consensus protocol that provides the typical properties of (1) agreement (no two honest participants decide differently), (2) validity (the decided value must pass a validity predicate), and (3) termination (every honest participant eventually decides).
 
-We denote the invocation of a consensus instance from a participant as follows:
+Invocation of a consensus instance from a participant is denoted:
 
 ```
 GossiPBFT(i, proposal, baseChain, participants) → decision, PoF
 ```
 
-A participant that invokes the $\texttt{GossiPBFT()}$ function starts a consensus instance identified by the sequence number $i$ and with an input value $proposal$. The $baseChain$ parameter represents the default value (agreement on not finalizing any new tipset). The $participants$ parameter is composed of the SPs that participate in this instance along with their respective individual weights (i.e., quality-adjusted power). The next section explains how the $participants$ are obtained from the power table. The invocation eventually returns a $decision$ value and a proof of finality $PoF$ that proves $decision$ is indeed the output of this consensus instance. In any invocation from F3, $decision$ is a finalized chain prefix in the form of a tipset. $PoF$ can be verified by using the $\texttt{Verify}()$ function that we explain below:
+A participant that invokes the $\texttt{GossiPBFT()}$ function starts a consensus instance identified by the sequence number $i$ and with an input value $proposal$. The $baseChain$ parameter represents the default value (agreement on not finalizing any new tipset). The $participants$ parameter is composed of the SPs that participate in this instance along with their respective individual weights (i.e., quality-adjusted power). The next section explains how the $participants$ are obtained from the power table. The invocation eventually returns a $decision$ value and a proof of finality $PoF$ that proves $decision$ is indeed the output of this consensus instance. In any invocation from F3, $decision$ is a finalized chain prefix in the form of a tipset. $PoF$ can be verified by using the $\texttt{Verify}()$ function:
 
 ```
 Verify(PoF, decision, participants) → boolean
@@ -140,14 +143,13 @@ This function uses the $PoF$ to verify that $decision$ was the output of some in
 
 ### Power Table and Consensus Participants
 
-The _power table_ in the power actor maintains, among other things, the quality-adjusted power of each SP. Each tipset $t$ in the chain corresponds to a particular version of the power table denoted $\texttt{PowerTable}(t)$ that results from executing all messages in the chain from genesis to $t$. The participants of an instance of GossiPBFT are determined by the power table resulting from the tipset finalized by the previous instance. More rigorously, the input parameter $participants$ of an instance $i$ is obtained from $\texttt{PowerTable}(decision_{i-1})$, where $decision_{i-1}$ is the tipset output by instance $i-1$. If $i$ is the first consensus instance, $decision_{i-1}$ is the genesis tipset.
+The _power table_ in the existing power actor maintains, among other things, the quality-adjusted power of each SP. Each tipset $t$ in the chain commits to a particular power table denoted $\texttt{PowerTable}(t)$ that results from executing all messages in the chain from genesis to $t$. The participants of an instance of GossiPBFT are determined by the power table resulting from the tipset finalized by a previous instance. More rigorously, the input parameter $participants$ of an instance $i$ is obtained from $\texttt{PowerTable}(decision_{i-PowerTableLookback})$, where $decision_{i-PowerTableLookback}$ is the tipset output by instance $i-PowerTableLookback$. If $i$ is less than $PowerTableLookback$, $participants$ is the power table committed by genesis tipset.
 
-We assume that $\texttt{PowerTable}(t)$ ignores any unnecessary data in the power table and returns the set consisting of each participant's identity and weight.
-
+The parameter $PowerTableLookback$ takes the value 10.
 
 ### F3 Pseudocode
 
-We now present the pseudocode of the F3 algorithm:
+The F3 algorithm is specified by pseudo-code:
 
 ```
 // finalizedTipsets is a list of records with tipset and PoF fields representing
@@ -160,13 +162,13 @@ finalizedTipsets[0].PoF ← nil
 i ← 1
 while True:
   wait until EC.CurrentEpoch() >= finalizedTipsets[i-1].Head().epoch + 2: // do not start until 2 epochs ahead
-  if i > 10:
-  	participants ← PowerTable(finalizedTipsets[i-10].tipset)
-  else:
-	participants ← PowerTable(finalizedTipsets[0].tipset) // use finalizedTipsets[0]'s table the first 10 instances.
   proposal ← EC.HeaviestUnfinalizedChain() // get heaviest chain from EC
   if proposal.Head().epoch = EC.CurrentEpoch()
 	proposal = proposal[-1] // remove head from current epoch, as pre-agreement is unlikely
+  if i > PowerTableLookback:
+  	participants ← PowerTable(finalizedTipsets[i-PowerTableLookback].tipset)
+  else:
+	participants ← PowerTable(finalizedTipsets[0].tipset) // use genesis table the first 10 instances.
   finalizedTipset, PoF ← GossiPBFT(i, proposal, finalizedTipsets[i-1], participants)
   finalizedTipsets[i].tipset ← finalizedTipset
   finalizedTipsets[i].PoF ← PoF
@@ -178,25 +180,24 @@ Each participant keeps track of the finalized tipsets and respective proofs of f
 The algorithm starts by initializing $finalizedTipsets[0]$ with the genesis tipset. This tipset is pre-defined as finalized and does not require a PoF. Then, in each iteration $i$ of the loop, it takes the following steps:
 
 1. Wait until the current epoch is at least two epochs from that of the latest finalized head.
-2. Obtain the set of participants of instance $i$ from the power table determined by the finalized tipset 10 instances ago.
-3. Call the $\texttt{HeaviestUnfinalizedChain}()$ function that returns the tipsets of the locally observed chain constructed by EC from finalizedTipset[i-1].Head (including the head of the finalized chain) and sets the $proposal$ variable to the returned value. We assume that such a function is available to the finalizer. Note that the proposal is pruned so that its head is at most a tipset from the previous epoch, not the current epoch.
+2. Obtain the set of participants of instance $i$ from the power table determined by the finalized tipset $PowerTableLookback$ instances ago.
+3. Call the $\texttt{HeaviestUnfinalizedChain}()$ function that returns the tipsets of the locally observed chain constructed by EC from finalizedTipset[i-1].Head (including the head of the finalized chain) and sets the $proposal$ variable to the returned value. Note that the proposal is pruned so that its head is at most a tipset from the previous epoch, not the current epoch.
 4. Execute the instance $i$ of GossiPBFT consensus.
 5. Add the returned tipset from the consensus execution to the $finalizedTipsets$ list.
 
-To prevent useless instances of GossiPBFT deciding on the same $baseChain$ because of the lack of a new epoch that provides a new proposal, we make the $\texttt{ChainHead}()$ function blocking in that it does not return a proposal unless the current chain head is different from the chain head of the finalized chain.
-
+Note that if EC produces empty tipsets, EC epochs progress regardless. F3 will then repeatedly propose and finalize the same base chain until a non-empty tipset is produced. 
 
 ### Changes to EC: Fork Choice Rule
 
-EC needs to be modified to accommodate the finalization of tipsets by F3. **This is the only change to EC this FIP introduces.**
+EC is modified to accommodate the finalization of tipsets by F3. **This is the only change to EC this FIP introduces.**
 
 The current EC fork-choice rule selects, from all the known tipsets, the tipset backed by the most weight. As the F3 component finalizes tipsets, the fork-choice rule must ensure that the heaviest finalized chain is always a prefix of the heaviest chain, preventing reorganizations of the already finalized chain.
 
-We achieve this by adjusting the fork choice rule in the presence of a finalized prefix: the fork choice rule selects the heaviest chain out of all chians with a prefix that **matches exactly all tipsets finalized by F3**, in that a tipset $t'$ that is a superset of finalized tipset $t$ in the same epoch is not heavier than $t$ itself, despite it being backed by more EC power.
+The fork choice rule is adjusted in the presence of a finalized prefix: the fork choice rule selects the heaviest chain out of all chians with a prefix that **matches exactly all tipsets finalized by F3**, in that a tipset $t'$ that is a superset of finalized tipset $t$ in the same epoch is not heavier than $t$ itself, despite it being backed by more EC power.
 
 This redefinition of the fork choice rule is consistent with the abstract notion of the heaviest chain being backed by the most power because a finalized tipset has been backed by a super-majority of participants in GossiPBFT. In contrast, any non-finalized block in the same epoch is only backed in that epoch by the EC proposer.
 
-We illustrate the updated rule in the following figure, where blocks in blue are finalized blocks, and all blocks are assumed to be proposed by a proposer holding only one EC ticket (the weight of a chain is the number of blocks):
+The updated rule is illustrated in the following figure, where blocks in blue are finalized blocks, and all blocks are assumed to be proposed by a proposer holding only one EC ticket (the weight of a chain is the number of blocks):
 
 ![](../resources/fip-0086/fork.png)
 
@@ -214,14 +215,14 @@ Integrating F3 into Filecoin follows the usual path for Filecoin upgrades. One e
 
 This section provides the specification of GossiPBFT, the consensus protocol that is iteratively instantiated by the F3 loop and returns a decision (in the form of an F3-finalized chain) and a PoF per instance.
 
-GossiPBFT is a Byzantine fault-tolerant consensus protocol that is resilient optimal, i.e., it tolerates up to less than ⅓ QAP being controlled by a Byzantine adversary. Each instance of the protocol has a known set of participants. Each participant inputs a proposal value, and the protocol outputs one of the input values as the final decision value. We emphasize _final_ because, unlike a longest-chain protocol, the output of GossiPBFT is permanent.
+GossiPBFT is a Byzantine fault-tolerant consensus protocol that is resilient optimal, i.e., it tolerates up to less than ⅓ QAP being controlled by a Byzantine adversary. Each instance of the protocol has a known set of participants. Each participant inputs a proposal value, and the protocol outputs one of the input values as the final decision value. Unlike a longest-chain protocol, the output of GossiPBFT is permanent.
 
 GossiPBFT was designed with the Filecoin network in mind and presents a set of features that make it desirable in that context:
 
-* Participants can have different weights, which aligns with how storage providers have different amounts of storage committed to the network. A participant's weight in executing the protocol is proportional to their share of QAP.
+* Participants can have different weights, which aligns with how storage providers have different amounts of power in the network. A participant's weight in executing the protocol is proportional to their share of QAP.
 * The protocol has optimal resilience, i.e., it tolerates a Byzantine adversary controlling up to less than ⅓ QAP.
-* Unlike PBFT, HotStuff, Tendermint, and many other protocols in this space, GossiPBFT is a leaderless protocol. This property makes it resistant to denial of service attacks because no designated participant represents the weakest link.
-* Low latency. During periods of synchrony and honest proposers, GossiPBFT will finish in three communication steps. We expect this to happen within tens of seconds.
+* GossiPBFT is a leaderless protocol. This property makes it resistant to denial of service attacks because no designated participant represents the weakest link.
+* During periods of synchrony and honest proposers, GossiPBFT will finish in three communication steps (within tens of seconds).
 * GossiPBFT has been tailored with Filecoin and open blockchains in mind, with strong resilience against censorship attacks and EC compatibility for rational participants.
 * GossiPBFT is tailored to using a broadcast communication primitive, GossipSub, which Filecoin already uses.
 * GossipPBFT internal invariants, on which the protocol correctness is based, are very similar to those of the seminal PBFT protocol, making protocol correctness easier to establish.

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -72,14 +72,14 @@ F3 and its implementation GossiPBFT provide additional robustness for strong adv
 * Resilience to long-range attacks by an adversary controlling up to less than ⅔ QAP of any old power table.
 
 
-### Best-effort Broadcast and GossipSub
+### Best-effort Broadcast and Gossipsub
 
-F3 uses GossipSub (like Filecoin EC) to disseminate protocol messages, implementing a broadcast channel among participants. GossipSub is assumed to satisfy the following properties of the _best-effort broadcast primitive_ (denoted _BEBroadcast_ hereafter):
+F3 uses Gossipsub (like Filecoin EC) to disseminate protocol messages, implementing a broadcast channel among participants. Gossipsub is assumed to satisfy the following properties of the _best-effort broadcast primitive_ (denoted _BEBroadcast_ hereafter):
 
 * _No creation_: No message with sender $p$ is delivered unless it was previously broadcast by $p$.
 * _Validity_: If $p$ and $p'$ are honest, then every message broadcast by $p$ is eventually delivered by $p'$.
 
-Note that academic nomenclature may be misleading, and "every message broadcast is eventually delivered" does not mean the broadcast is reliable. Messages may be lost if the sender, receiver, or link fail, but will be delivered if they don't.
+Note that "honest" carries assumptions that both parties and the link are reliable. Messages may be lost if the sender, receiver, or link fail, but will be delivered if they don't.
 
 The _no duplication_ property of a traditional best-effort broadcast primitive is not needed; indeed F3 explicitly rebroadcasts messages to overcome loss. 
 
@@ -87,7 +87,7 @@ The _no duplication_ property of a traditional best-effort broadcast primitive i
 
 A system is $\Delta$-_synchronous_ if the combined computation and communication delay between any two honest participants is smaller than $\Delta$. Under $\Delta$-synchrony, any message broadcast by an honest participant is delivered by every honest participant within a time bound of $\Delta$.
 
-In practice, if GossipSub is used for _BEBroadcast_, $\Delta$ is an assumed upper bound on GossipSub latency.
+In practice, if Gossipsub is used for _BEBroadcast_, $\Delta$ is an assumed upper bound on Gossipsub latency.
 
 For termination, a classical partially synchronous model is assumed, with an unknown bound on communication delays among non-Byzantine participants.
 
@@ -118,7 +118,7 @@ With this in mind, the F3 component interface and properties are given below.
 
 > **Interface and properties of F3 at participant p:**
 >
-> `F3.invoke (int i, chain canonical, chain baseChain)` **returns** ("finalizes") `(int i, chain h, proof_of_finality certificate)`
+> `F3.invoke (int i, chain canonical, chain baseChain)` **returns** ("finalizes") `(int i, chain h, finality_certificate fc)`
 >
 > **Properties:**
 >
@@ -132,14 +132,11 @@ With this in mind, the F3 component interface and properties are given below.
 > * All honest participants can communicate within a known time bound $\Delta$, and
 > * All honest participants invoke $\texttt{F3}(i, \ast, \ast)$ at most $\Delta$ apart from each other,
 >
-> Let c be the heaviest common prefix of the inputs of all honest participants in instance $i$. Then, if an honest participant finalizes $(i,c',\ast)$, $c$ is a prefix of $c'$ with probability equal to the proportion of honest participants.
+> Let c be the longest common prefix of the inputs of all honest participants in instance $i$. Then, if an honest participant finalizes $(i,c',\ast)$, $c$ is a prefix of $c'$ with probability equal to the proportion of honest participants.
 > 
 > **Termination.** Every call to F3 eventually returns with probability 1.
 >
 > **EC compatibility.** An honest participant never contributes to gathering ⅔ QAP (super-majority) of votes for a chain $c$ which its local EC instance did not already deliver unless it already observes evidence of such a super-majority for chain $c$.
-
-The $\Delta$ parameter is specified [below](#Synchronization-of-Participants-in-the-Current-Instance).
-
 
 ### Consensus Interface
 
@@ -162,7 +159,7 @@ This function uses the certificate to verify that $decision$ was the output of s
 
 ### F3 Pseudocode
 
-The F3 algorithm is specified by pseudo-code:
+The F3 algorithm is specified by pseudocode:
 
 ```
 // A list of all finalized tipsets with their respective certificates.
@@ -171,7 +168,7 @@ The F3 algorithm is specified by pseudo-code:
 finalizedTipsets[0] ← {tipset: genesis, certificate: nil}
 
 // The number of epochs by which instance start is delayed relative to 
-// epoch of last finalised chain head.
+// epoch of last finalized chain head.
 startBackoffEpochs ← 0
 
 // The number of times instance start is retried due to empty tipsets.
@@ -180,11 +177,11 @@ startRetryAttempts ← 0
 // The first instance number after genesis is 1.
 i ← 1
 while True:
-  // Delay start until EC is ahead of last finalised chain plus instance start backoff.
-  wait until EC.CurrentEpoch() >= finalisedTipsets[i-1].Head().epoch + startBackoffEpochs
-  // Delay start until EC is 2 epochs ahead of last finalised chain.
+  // Delay start until EC is ahead of last finalized chain plus instance start backoff.
+  wait until EC.CurrentEpoch() >= finalizedTipsets[i-1].Head().epoch + startBackoffEpochs
+  // Delay start until EC is 2 epochs ahead of last finalized chain.
   wait until EC.CurrentEpoch() >= finalizedTipsets[i-1].Head().epoch + 2 
-  // Fetch tipsets from locally-observed EC chain from (inclusive) the last finalised tipset.
+  // Fetch tipsets from locally-observed EC chain from (inclusive) the last finalized tipset.
   proposal ← EC.HeaviestUnfinalizedChain()
   if proposal.Head().epoch = EC.CurrentEpoch()
     // Remove current epoch tipset, as pre-agreement is unlikely
@@ -198,7 +195,7 @@ while True:
     // Reset backoff parameters. 
     startBackoffEpochs ← 0
     startRetryAttempts ← 0
-  // Get the power table from previously-finalised tipset from lookback instances ago.
+  // Get the power table from previously-finalized tipset from lookback instances ago.
   // Use genesis power for initial instances.
   lookback ← min(i, PowerTableLookback)
   committee ← MakeCommittee(finalizedTipsets[i-lookback].tipset)
@@ -254,7 +251,7 @@ GossiPBFT was designed with the Filecoin network in mind and presents a set of f
 * GossiPBFT is a leaderless protocol. This property makes it resistant to denial of service attacks because no designated participant represents the weakest link.
 * During periods of synchrony and honest proposers, GossiPBFT will finish in three communication steps (within tens of seconds).
 * GossiPBFT has been tailored with Filecoin and open blockchains in mind, with strong resilience against censorship attacks and EC compatibility for rational participants.
-* GossiPBFT is tailored to using a broadcast communication primitive, GossipSub, which Filecoin already uses.
+* GossiPBFT is tailored to using a broadcast communication primitive, Gossipsub, which Filecoin already uses.
 * GossipPBFT internal invariants, on which the protocol correctness is based, are very similar to those of the seminal PBFT protocol, making protocol correctness easier to establish.
 
 
@@ -294,7 +291,7 @@ type Evidence struct {
 // Additional per-instance data that all participants must agree on a priori before
 // starting an instance.
 type SupplementalData struct {
-  // Merkle-tree of instance-specific commitments. Currently empty (0) but this will
+  // Merkle tree of instance-specific commitments. Currently empty (0) but this will
   // eventually include things like snark-friendly power-table commitments.
   Commitments [32]byte
   // The DagCBOR-blake2b256 CID of the power table / committee to be used to validate the *next*
@@ -313,7 +310,7 @@ type Payload struct {
   // Common data all nodes are expected to commit to in the given instance.
   SupplementalData SupplementalData
   // Chain of ECTipset objects proposed/voted for finalisation.
-  // Always non-empty; the first entry is the base tipset finalised in the previous instance.
+  // Always non-empty; the first entry is the base tipset finalized in the previous instance.
   Value []ECTipset
 }
 
@@ -350,13 +347,13 @@ All messages broadcast by a participant have their participant ID in the sender 
 
 The receiver of a message only considers messages with matching supplemental data and valid signatures, and discards all other messages as invalid. The sender ID and signatures are omitted in further descriptions for better readability.
 
-Two (or more) messages $m1$ and $m2$ are called _equivocating messages_ if $m1.Sender=m2.Sender \land m1.Instance=m2.Instance \land m1.Value ≠ m2.Value \land m1.MsgType=m2.MsgType \land \texttt(if applicable)\ m1.Round=m2.Round$. $m1.Sender$ is called an _equivocating sender_.
+Two (or more) messages $m1$ and $m2$ are called _equivocating messages_ if they have the same type, sender, instance, round, but different value. The sender is called an _equivocating sender_.
 
 A set of messages $M$ that does not contain equivocating messages is called _clean_. Participants discard all equivocating messages when forming clean sets.
 
 ##### `MerkelizeValue`
 
-Instead of encoding `Payload.Value` as CBOR and signing the result, it is converted into a merkle-tree and format the individual `ECTipset` objects in a way that's easy to parse within both snarks and EVM-based blockchains.
+Instead of encoding `Payload.Value` as CBOR and signing the result, it is converted into a Merkle tree and format the individual `ECTipset` objects in a way that's easy to parse within both snarks and EVM-based blockchains.
 
 Specifically, each `ECTipset` is encoded by concatenating:
 
@@ -408,11 +405,9 @@ A [merkle tree](#merkle-tree-format) is built from these encoded `ECTipset` valu
 
 #### GossiPBFT pseudocode (main algorithm)
 
-The GossiPBFT algorithm is specified by pseudo-code below. It consists of 3 steps per round (QUALITY/CONVERGE, PREPARE, COMMIT) and an additional step outside the round loop (DECIDE). Message fields that are constant for the instance are omitted for readability. 
+The GossiPBFT algorithm is specified by pseudocode below. It consists of 3 steps per round (QUALITY/CONVERGE, PREPARE, COMMIT) and an additional step outside the round loop (DECIDE). Message fields that are constant for the instance are omitted for readability. 
 
 Messages are delivered to the participant in some order, whereupon a predicate over the set of received messages is evaluated, depending on the algorithm's current round and step.
-
-See also the simplified [PlusCal/TLA+ specification](https://github.com/filecoin-project/tla-f3).
 
 ```
 GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
@@ -483,7 +478,7 @@ GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
 49:      C ← C ∪ {m.value}  // Add to candidate values if not there
 50:      proposal ← m.value  // Sway local proposal to possibly decided value
 51:      evidence ← m.evidence  // Strong PREPARE quorum is inherited evidence
-52:    round ← round + 1;
+52:    round ← round + 1
 53:    timeout ← 2 * Δ * pow(BackOffExponent, round)
 54:    timeout_rebroadcast ← timeout + 1  // Arbitrary increment
 55:  }
@@ -525,7 +520,7 @@ The reBroadcast function broadcasts and remembers a message. It then sets a time
 74:        switch (msg.step) {
 75:          case DECIDE:
 76:            BEBroadcast(m ∈ own_msgs: m.round=0 AND m.type=DECIDE) // only rebroadcast DECIDE
-77:            break;  // Exit, no cascading
+77:            break  // Exit, no cascading
 78:          case COMMIT:
 79:            BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=COMMIT) 
                // Cascade to broadcast PREPARE, CONVERGE
@@ -537,7 +532,7 @@ The reBroadcast function broadcasts and remembers a message. It then sets a time
 84:              BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=CONVERGE)
 85:              BEBroadcast(m ∈ own_msgs: m.round=msg.round-1 AND m.type=COMMIT)
 86:              BEBroadcast(m ∈ own_msgs: m.round=msg.round-1 AND m.type=PREPARE)
-87:              break;
+87:              break
 88:        }
            // Increase and trigger timeout_rebroadcast again.
            // The amount to increase is at the discretion of the participant.
@@ -556,12 +551,12 @@ In order to avoid unbounded accumulation of state, some messages from some futur
 103:    deliver(msg)  // Otherwise make the message available to the main algorithm
 104:    if (msg' ← shouldJump(round, step) s.t. msg' != nil)
           // The msg' is a CONVERGE for round
-105:      round ← msg'.round;
+105:      round ← msg'.round
 106:      timeout ← 2 * Δ * pow(BackOffExponent, round)
 107:      timeout_rebroadcast ← timeout + 1 // Arbitrary increment
 108:      if msg'.evidence.step = PREPARE: // Evidence is strong quorum of either PREPAREs of COMMITs for 丄
 109:        C ← C ∪ {msg'.value}       // Add to candidate values if not there
-110:        proposal ← msg'.value;     // Sway local proposal to possibly decided value
+110:        proposal ← msg'.value     // Sway local proposal to possibly decided value
           // Inherit evidence for the value from CONVERGE message 
 111:      evidence ← msg'.evidence   
 112:      go to line 21  // Start new round>0 by jumping forward
@@ -578,7 +573,7 @@ In order to avoid unbounded accumulation of state, some messages from some futur
 
 The parameter `max_lookahead_rounds` may be set at the discretion of an implementation. 
 
-Note that the selection of the heaviest prefix in line 18 does not need access to the tipsets' EC weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or vice-versa (since the adversary controls < ⅓ of the QAP). As a result, selecting the heaviest prefix is as simple as selecting the longest chain, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
+Note that the selection of the longest prefix in line 18 does not need access to the tipsets' EC weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or vice-versa (since the adversary controls < ⅓ of the QAP). As a result, selecting the longest prefix is as simple as selecting the longest chain, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
 
 Implementations may optimise this algorithm to treat the reception of an aggregated signature over some (MsgType, Instance, Round, Value) as evidence of a message as if it had received the same tuple of values directly from each participant in the aggregate. This may be used to effectively skip a partially-complete step. In the particular case of a DECIDE message, which carries evidence of a strong quorum of COMMITs for the same round and value, a participant immediately sends its own DECIDE for the same value (copying the evidence) and exits the loop at line 11.
 
@@ -672,7 +667,7 @@ An instance of GossiPBFT requires a seed that must be common among all participa
 
 GossiPBFT ensures termination provided that (i) all participants start the instance at most $\Delta$ apart, and (ii) the estimate on Δ is large enough for $\Delta$-synchrony in some round (either because of the real network delay recovering from asynchrony or because of the estimate increasing).
 
-[Given prior tests performed on GossipSub](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf) (see also [here](https://gist.github.com/jsoares/9ce4c0ba6ebcfd2afa8f8993890e2d98)), sent messages are expected to reach almost all participants within 3 seconds, with a majority receiving them even after 2 seconds. However, if several participants start the instance $Δ + ε$ after some other participants, termination is not guaranteed for the selected timeouts of $2*Δ$. Thus, the protocol does not rely on an explicit synchrony bound for correctness. Instead, the estimate of Δ is increased locally within an instance as rounds progress without decision.
+[Given prior tests performed on Gossipsub](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf) (see also [here](https://gist.github.com/jsoares/9ce4c0ba6ebcfd2afa8f8993890e2d98)), sent messages are expected to reach almost all participants within 3 seconds, with a majority receiving them even after 2 seconds. However, if several participants start the instance $Δ + ε$ after some other participants, termination is not guaranteed for the selected timeouts of $2*Δ$. Thus, the protocol does not rely on an explicit synchrony bound for correctness. Instead, the estimate of Δ is increased locally within an instance as rounds progress without decision.
 
 The synchronization of participants within an instance is achieved with a timeout exponentially increasing each round. Participants start each instance with `Δ=3s` and for each round, set the step timeout to `2 * Δ * BackOffExponent^{round}`.
 
@@ -801,7 +796,7 @@ This protocol uses merkle trees as vector commitments to commit to both (a) the 
 1. The hash function is `keccak256` (same as Ethereum) for maximum EVM compatibility.
 2. Each internal node is prefixed with a single `0x0` byte before hashing (`keccak256([0] + left + right)`).
 3. Each leaf is prefixed with a single `0x1` byte before hashing (`keccak256([1] + value)`).
-4. Missing values and empty sub-trees hash to `[32]byte{}` (32 `0x0` bytes).
+4. Missing values and empty subtrees hash to `[32]byte{}` (32 `0x0` bytes).
 
 In this tree, a proof that some value `v` is committed to at index `i` in the merkle tree rooted at `r` comprises the "uncles" (the branches not taken) of the merkle path from `v` to `r` (bottom to top). This algorithm is best described in [code](../resources/fip-0086/merkletree.go).
 
@@ -833,7 +828,7 @@ The tipset key is required as this is the main value F3 is finalizing. While off
 
 A blake2b hash of the power table is included to aid in syncing the F3 chain. In theory, it could be added to the commitment merkle tree and left out of the root `ECTipset` object, but being able to validate a chain of finality certificates without any additional merkle-proofs is convenient and the extra 32 bytes is not an unreasonable cost (512 gas on Ethereum) .
 
-Finally, the structure includes the root hash of a commitments merkle-tree. This tree is _empty_ at the moment but will eventually include:
+Finally, the structure includes the root hash of a commitments Merkle tree. This tree is _empty_ at the moment but will eventually include:
 
 1. Commitements to snark-friendly representations of the power table.
 2. Events, likely indexed by emitter (useful for cross-chain messaging).
@@ -844,10 +839,10 @@ And probably more. Importantly, the network can easily commit to additional valu
 
 Both the `Payload` and the `ECTIpset`s themselves are encoded one way for signing and another when sending them over the network.
 
-1. Even though the root of a merkle-tree of the tipsets is signed, the full list of tipsets must be sent over the network as the protocol needs a way to find common prefixes.
+1. Even though the root of a Merkle tree of the tipsets is signed, the full list of tipsets must be sent over the network as the protocol needs a way to find common prefixes.
 2. Even though a CID of the tipset key is signed, the full tipset key must be sent over the wire because the Filecoin chainsync protocol names tipsets by tipset key, not tipset CID/hash. By sending the full key, a client can learn about _new_ tipsets from F3 if it doesn't hear about them from its peers.
 
-On the other hand, hashes and merkle-trees are signed so unnecessary data may be easily omitted from proofs sent across bridges.
+On the other hand, hashes and Merkle trees are signed so unnecessary data may be easily omitted from proofs sent across bridges.
 
 ##### Certificate/Decision Signing Format
 
@@ -862,7 +857,7 @@ Decision payloads are designed to be easy to work with in the EVM (32-byte align
 | **96-127**  | z | z | z | z | z | z | z | z | z | z | z  | z  | z  | z  | z  | z   | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  |
 | **126-133** | z | z | z | z | z | z |   |   |   |   |    |    |    |    |    |     |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
 
-Where `.` is a zero byte, `iii` is the instance (64bit BigEndian integer), `xxx` is the root hash of the per-instance commitmenets tree (from the supplemental data), `yyy` is the root hash of the tipset merkle tree, and `zzz` is the power table CID used to validate the next instance.
+Where `.` is a zero byte, `iii` is the instance (64bit BigEndian integer), `xxx` is the root hash of the per-instance commitments tree (from the supplemental data), `yyy` is the root hash of the tipset merkle tree, and `zzz` is the power table CID used to validate the next instance.
 
 Importantly, the instance, commitments, and merkle tree root are 32-byte aligned and bytes 0-24 are constant. The final "power table CID" is 38 bytes long and therefore doesn't fit into a single EVM word, but eventual cross-chain bridges will likely use an EVM and/or snark friendly commitment to the power table (witnessed by the per-instance `commitments` tree) rather than the raw power table CID.
 
@@ -903,8 +898,8 @@ This FIP requires a network upgrade to take effect since it changes the EC fork 
 
 1. Unit tests
 2. Test propagation times during network load to set an estimate on $\Delta$
-   1. 3.5k participants sending messages of size >120B over GossipSub (and measure time to receive first, a strong quorum, and all messages).
-   2. Same test but for DECIDE messages (which include the passive nodes, not just participants, in the corresponding GossipSub topic).
+   1. 3.5k participants sending messages of size >120B over Gossipsub (and measure time to receive first, a strong quorum, and all messages).
+   2. Same test but for DECIDE messages (which include the passive nodes, not just participants, in the corresponding Gossipsub topic).
 3. Protocol-specific tests:
    - Correctness tests (synchrony is assumed for tests unless stated otherwise):
      * Best case: all participants start with the same input.

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -261,6 +261,17 @@ type Evidence struct {
   Signature []byte
 }
 
+// Additional per-instance data that all participants must agree on a priori before
+// starting an instance.
+type SupplementalData struct {
+  // Merkle-tree of instance-specific commitments. Currently empty (0) but this will
+  // eventually include things like snark-friendly power-table commitments.
+  Commitments [32]byte
+  // The DagCBOR-blake2b256 CID of the power table used to validate the next
+  // instance, taking lookback into account.
+  PowerTable CID
+}
+
 // Fields of the message that make up the signature payload.
 type Payload struct {
   // GossiPBFT instance number.
@@ -269,6 +280,8 @@ type Payload struct {
   Round uint64
   // GossiPBFT step number.
   Step uint8
+  // Common data all nodes are expected to commit to in the given instance.
+  SupplementalData SupplementalData
   // Chain of ECTipset objects proposed/voted for finalisation.
   // Always non-empty; the first entry is the base tipset finalised in the previous instance.
   Value []ECTipset
@@ -293,9 +306,9 @@ type PowerTableEntry struct {
 }
 ```
 
-All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over `"GPBFT:filecoin:":15 || Step:1 || Round:8 || Instance:8 || MerkelizeValue(Value):32` (where `Round` and `Instance` are big-endian encoded). The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
+All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over `"GPBFT:filecoin:":15 || Step:1 || Round:8 || Instance:8 || SupplementalData.Commitments:32 || MerkelizeValue(Value):32 || SUpplementalData.PowerTable` (where `Round` and `Instance` are big-endian encoded). The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
 
-The receiver of a message only considers messages with valid signatures and discards all other messages as invalid. We sometimes omit the sender IDs and signatures in further descriptions for better readability.
+The receiver of a message only considers messages with matching supplemental data and valid signatures, discarding all other messages as invalid. We sometimes omit the sender IDs and signatures in further descriptions for better readability.
 
 Two (or more) messages $m1$ and $m2$ are called _equivocating messages_ if $m1.Sender=m2.Sender \land m1.Instance=m2.Instance \land m1.Value ≠ m2.Value \land m1.MsgType=m2.MsgType \land \texttt(if applicable)\ m1.Round=m2.Round$. We call $m1.Sender$ an _equivocating sender_.
 
@@ -634,9 +647,13 @@ A finality certificate brings them together.
 
 ```
 type FinalityCertificate struct {
-  // Instance, Value as for GossiPBFTMessage (DECIDE)
-  Instance int
-  Value []ECTipset
+  // Payload.Instance from a justified DECIDE message.
+  GPBFTInstance int
+  // Payload.Value from a justified DECIDE message.
+  ECChain []ECTipset
+  // Payload.SupplementalData from a justified DECIDE message.
+  // the power table used in the next instance.
+  SupplementalData gpbft.SupplementalData
   // Indexes in the base power table of the certifiers (bitset)
   Signers []bytes
   // Aggregated signature of the certifiers
@@ -793,14 +810,17 @@ On the other hand, when signing, we tend to sign hashes and merkle-trees so we c
 Decision payloads are designed to be easy to work with in the EVM (32-byte alignment) and within zkSNARKs (small with fixed-length fields). Instead of naively signing a CBOR-encoded value, we sign `Payload` objects such that decisions are encoded as follows:
 
 
-|           | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15  | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 |
-|-----------|---|---|---|---|---|---|---|---|---|---|----|----|----|----|----|-----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|
-| **00-31** | G | P | B | F | T | : | f | i | l | e | c  | o  | i  | n  | :  | 0x5 | .  | .  | .  | .  | .  | .  | .  | .  | x  | x  | x  | x  | x  | x  | x  | x  |
-| **32-63** | y | y | y | y | y | y | y | y | y | y | y  | y  | y  | y  | y  | y   | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  |
+|             | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15  | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 |
+|-------------|---|---|---|---|---|---|---|---|---|---|----|----|----|----|----|-----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|
+| **00-31**   | G | P | B | F | T | : | f | i | l | e | c  | o  | i  | n  | :  | 0x5 | .  | .  | .  | .  | .  | .  | .  | .  | i  | i  | i  | i  | i  | i  | i  | i  |
+| **32-63**   | x | x | x | x | x | x | x | x | x | x | x  | x  | x  | x  | x  | x   | x  | x  | x  | x  | x  | x  | x  | x  | x  | x  | x  | x  | x  | x  | x  | x  |
+| **64-95**   | y | y | y | y | y | y | y | y | y | y | y  | y  | y  | y  | y  | y   | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  | y  |
+| **96-127**  | z | z | z | z | z | z | z | z | z | z | z  | z  | z  | z  | z  | z   | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  | z  |
+| **126-133** | z | z | z | z | z | z |   |   |   |   |    |    |    |    |    |     |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
 
-Where `.` is a zero byte, `xxx` is the instance (64bit BigEndian integer) and `yyy` is the root hash of the tipset merkle tree.
+Where `.` is a zero byte, `iii` is the instance (64bit BigEndian integer), `xxx` is the root hash of the per-instance commitmenets tree (from the supplemental data), `yyy` is the root hash of the tipset merkle tree, and `zzz` is the power table CID used to validate the next instance.
 
-Importantly, the instance and merkle tree root are 32-byte aligned and bytes 0-24 are constant.
+Importantly, the instance, commitments, and merkle tree root are 32-byte aligned and bytes 0-24 are constant. The final "power table CID" is 38 bytes long and therefore doesn't fit into a single EVM word, but eventual cross-chain bridges will likely use an EVM and/or snark friendly commitment to the power table (witnessed by the per-instance `commitments` tree) rather than the raw power table CID.
 
 However, note that:
 


### PR DESCRIPTION
Two notable changes feeding back from the implementation, plus some smaller improvements:
- There is not (yet) any mechanism to slow F3 if EC is producing only empty tipsets
- The `mayHaveStrongQuorum` function is changed to treat boundary conditions "correctly"
- Described F3 committee lookback
- Specified filters to power table eligibility (TODO: confirm with @Stebalien, especially around ticket math)
- Specified power scaling/truncation
- Specified values for step numbers

Tightened up some language and formatting:
- Removed some unnecessary phrases.
- Removed lingering tab characters.
- Unified commenting style in pseudocode to use `//`.
- Replaced some academic argument-style language (especially use of"we") with declarative statements.

A potentially clarifying change we could make would be a change in terminology from power table & power (EC concepts) to committee and weight (F3 concepts). These terms are currently a bit ambiguous since the concepts are not 1:1. I refrained for now.