### PR TITLE
Specify backoff when EC produces empty tipsets

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -170,16 +170,28 @@ The F3 algorithm is specified by pseudo-code:
 // Initialized with a genesis which needs no proof.
 finalizedTipsets[0] ← {tipset: genesis, certificate: nil}
 
+// The instance start backoff duration.
+instanceStartBackoff ← 0
+
 // The first instance number after genesis is 1.
 i ← 1
 while True:
-   // Delay start until EC is 2 epochs ahead of last finalised chain.
-  wait until EC.CurrentEpoch() >= finalizedTipsets[i-1].Head().epoch + 2
+  // Await until the instance start backoff duration has elapsed.
+  wait until instanceStartBackoff has elapsed
+  // Delay start until EC is 2 epochs ahead of last finalised chain.
+  wait until EC.CurrentEpoch() >= finalizedTipsets[i-1].Head().epoch + 2 
   // Fetch tipsets from locally-observed EC chain from (inclusive) the last finalised tipset.
   proposal ← EC.HeaviestUnfinalizedChain()
   if proposal.Head().epoch = EC.CurrentEpoch()
     // Remove current epoch tipset, as pre-agreement is unlikely
     proposal ← proposal[:-1]
+  if proposal.Head() = finalizedTipsets[i-1].Head()
+    // EC has produced empty tipsets. Increase instanceStartBackoff and retry.
+    instanceStartBackoff ← instanceStartBackoff + 1 // Any value larger than instanceStartBackoff, at implementation discretion.
+    continue // Skip to the next iteration
+  else
+    // Reset instanceStartBackoff duration. 
+    instanceStartBackoff ← 0
   // Get the power table from previously-finalised tipset from lookback instances ago.
   // Use genesis power for initial instances.
   lookback ← min(i, PowerTableLookback)
@@ -193,7 +205,8 @@ while True:
 
 A participant considers a tipset _final_ if it is included in, or is an ancestor of, any finalized tipset.
 
-Note that if EC produces empty tipsets, EC epochs progress regardless. F3 will then repeatedly propose and finalize the same base chain until a non-empty tipset is produced. 
+Note that if EC produces empty tipsets, EC epochs progress regardless. Therefore, delaying start of the next instance based on EC epoch alone can cause F3 to repeatedly propose and finalize the same base chain until a non-empty tipset is produced. The `instanceStartBackoff` mitigates this issue by introducing a backoff mechanism to slow down F3 instantiation, allowing EC to catch up and preventing continuous termination and re-initiation of instances. This controlled delay maintains the stability and efficiency of the F3 component by preventing unnecessary rapid cycling through instances.
+
 
 ### Changes to EC: Fork Choice Rule
 

--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -170,14 +170,18 @@ The F3 algorithm is specified by pseudo-code:
 // Initialized with a genesis which needs no proof.
 finalizedTipsets[0] ← {tipset: genesis, certificate: nil}
 
-// The instance start backoff duration.
-instanceStartBackoff ← 0
+// The number of epochs by which instance start is delayed relative to 
+// epoch of last finalised chain head.
+startBackoffEpochs ← 0
+
+// The number of times instance start is retried due to empty tipsets.
+startRetryAttempts ← 0
 
 // The first instance number after genesis is 1.
 i ← 1
 while True:
-  // Await until the instance start backoff duration has elapsed.
-  wait until instanceStartBackoff has elapsed
+  // Delay start until EC is ahead of last finalised chain plus instance start backoff.
+  wait until EC.CurrentEpoch() >= finalisedTipsets[i-1].Head().epoch + startBackoffEpochs
   // Delay start until EC is 2 epochs ahead of last finalised chain.
   wait until EC.CurrentEpoch() >= finalizedTipsets[i-1].Head().epoch + 2 
   // Fetch tipsets from locally-observed EC chain from (inclusive) the last finalised tipset.
@@ -186,12 +190,14 @@ while True:
     // Remove current epoch tipset, as pre-agreement is unlikely
     proposal ← proposal[:-1]
   if proposal.Head() = finalizedTipsets[i-1].Head()
-    // EC has produced empty tipsets. Increase instanceStartBackoff and retry.
-    instanceStartBackoff ← instanceStartBackoff + 1 // Any value larger than instanceStartBackoff, at implementation discretion.
-    continue // Skip to the next iteration
+    // EC has produced empty tipsets. Increase backoff parameters, and retry.
+    startBackoffEpochs ← startBackoffEpochs + nextStartBackoffIncrement(startRetryAttempts)
+    startRetryAttempts ← startRetryAttempts + 1
+    continue // Skip to the next iteration.
   else
-    // Reset instanceStartBackoff duration. 
-    instanceStartBackoff ← 0
+    // Reset backoff parameters. 
+    startBackoffEpochs ← 0
+    startRetryAttempts ← 0
   // Get the power table from previously-finalised tipset from lookback instances ago.
   // Use genesis power for initial instances.
   lookback ← min(i, PowerTableLookback)
@@ -205,8 +211,9 @@ while True:
 
 A participant considers a tipset _final_ if it is included in, or is an ancestor of, any finalized tipset.
 
-Note that if EC produces empty tipsets, EC epochs progress regardless. Therefore, delaying start of the next instance based on EC epoch alone can cause F3 to repeatedly propose and finalize the same base chain until a non-empty tipset is produced. The `instanceStartBackoff` mitigates this issue by introducing a backoff mechanism to slow down F3 instantiation, allowing EC to catch up and preventing continuous termination and re-initiation of instances. This controlled delay maintains the stability and efficiency of the F3 component by preventing unnecessary rapid cycling through instances.
+Note that if EC produces empty tipsets, EC epochs progress regardless. Therefore, delaying start of the next instance based on EC epoch alone can cause F3 to repeatedly propose and finalize the same base chain until a non-empty tipset is produced. The `startBackoffEpochs` mitigates this issue by introducing a backoff mechanism to slow down F3 instantiation, allowing EC to catch up and preventing continuous termination and re-initiation of instances. This controlled delay maintains the stability and efficiency of the F3 component by preventing unnecessary rapid cycling through instances.
 
+The function `nextStartBackoffIncrement(int)` returns the number of epochs by which `startBackoffEpochs` should be increased based on the number of attempts, referred to as `startRetryAttempts`. Implementers may choose any increment function at their discretion, but for each instance number `i` the increment amount relative to the number of attempts must be consistent across all participants.
 
 ### Changes to EC: Fork Choice Rule
 


### PR DESCRIPTION
Update FIP to backoff when starting a new instance when EC produces empty tipsets.

Relates to https://github.com/filecoin-project/go-f3/issues/371
