### PR TITLE
Post nv23 FIP updates

### DIFF
--- a/FIPS/fip-0065.md
+++ b/FIPS/fip-0065.md
@@ -3,7 +3,7 @@ fip: "0065"
 title: Ignore built-in market locked balance in circulating supply calculation
 author: "Alex North <@anorth>"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/719
-status: Accepted
+status: Final
 type: Technical
 category: Core
 created: 2023-06-16

--- a/FIPS/fip-0079.md
+++ b/FIPS/fip-0079.md
@@ -3,7 +3,7 @@ fip: "0079"
 title: Add BLS Aggregate Signatures to FVM
 author: "Jake (@drpetervannostrand)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/840
-status: Accepted
+status: Final
 type: Technical (Core)
 category: Core
 created: 2023-09-27

--- a/FIPS/fip-0082.md
+++ b/FIPS/fip-0082.md
@@ -3,7 +3,7 @@ fip: "0082"
 title: Add support for aggregated replica update proofs
 author: nemo (@cryptonemo), Jake (@DrPeterVanNostrand), @anorth
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/752
-status: Accepted
+status: Final
 type: Technical
 category: Core
 created: 2023-09-26

--- a/FIPS/fip-0084.md
+++ b/FIPS/fip-0084.md
@@ -4,7 +4,7 @@ fip: "0084"
 title:  Remove Storage Miner Actor Method `ProveCommitSectors`  
 author: Jennifer Wang (@jennijuju)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/899
-status: Accepted
+status: Final
 type: Technical 
 category: Core
 created: 2023-09-03

--- a/FIPS/fip-0085.md
+++ b/FIPS/fip-0085.md
@@ -3,7 +3,7 @@ fip: "0085"
 title: Convert f090 Mining Reserve actor to a keyless account actor
 author: Jennifer Wang (@jennijuju), Jon Victor (@jnthnvctr)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/901
-status: Accepted
+status: Final
 type: Technical
 category: Core
 created: 2024-01-04

--- a/FIPS/fip-0092.md
+++ b/FIPS/fip-0092.md
@@ -3,7 +3,7 @@ fip: "0092"
 title: Non-Interactive PoRep
 author: luca (@lucaniz), kuba (@Kubuxu), nicola (@nicola), nemo (@cryptonemo), volker (@vmx), irene (@irenegia), Alex North (@anorth), orjan (@Phi-rjan)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/854 and https://github.com/filecoin-project/FIPs/discussions/1007
-status: Accepted
+status: Final
 replaces: FIP-0090
 type: Technical
 category: Core

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0061](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0061.md) | WindowPoSt Grindability Fix | FIP | @cryptonemo @Kubuxu @DrPeterVanNostrand @Nicola @porcuquine @vmx @arajasek| Final |
 | [0062](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0062.md) | Fallback Method Handler for the Multisig Actor | FIP | Dimitris Vyzovitis (@vyzo), Raúl Kripalani (@raulk)| Final |
 | [0063](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0063.md) | Switching to new Drand mainnet network | FIP | @yiannisbot, @CluEleSsUK, @AnomalRoil, @nikkolasg, @willscott | Final |
-| [0065](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0065.md) | Ignore built-in market locked balance in circulating supply calculation | FIP | @anorth | Accepted |
+| [0065](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0065.md) | Ignore built-in market locked balance in circulating supply calculation | FIP | @anorth | Final |
 | [0066](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0066.md) | Piece Retrieval Gateway | FRC | @willscott, @dirkmc | Draft |
 | [0067](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0067.md) | PoRep Security Policy & Replacement Sealing Enforcement | FIP | @Kubuxu, @anorth, @irenegia, @lucaniz | Accepted |
 | [0068](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0068.md) | Deal-Making Between SPs and FVM Smart Contracts | FRC | @aashidham, @raulk, @skottie86, @jennijuju, @nonsense, @shrenujbansal | Draft |
@@ -116,16 +116,16 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0076](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md) | Direct data onboarding | FIP | @anorth, @zenground0 | Final |
 | [0077](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0077.md) | Add Cost Opportunity For New Miner Creation | FIP | Zac (@remakeZK), Mike Li (@hunjixin)| Draft |
 | [0078](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0078.md) | Remove Restrictions on the Minting of Datacap | FIP | Fatman13 (@Fatman13), flyworker (@flyworker), stuberman (@stuberman), Eliovp (@Eliovp), dcasem (@dcasem), and The-Wayvy (@The-Wayvy)| Draft |
-| [0079](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0079.md) | Add BLS Aggregate Signatures to FVM | FIP | Jake (@drpetervannostrand) | Accepted |
+| [0079](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0079.md) | Add BLS Aggregate Signatures to FVM | FIP | Jake (@drpetervannostrand) | Final |
 | [0080](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0080.md) | Phasing Out Fil+ and Restoring Deal Quality Multiplier to 1x | FIP | @Fatman13, @ArthurWang1255, @stuberman, @Eliovp, @dcasem, @The-Wayvy | Draft |
 | [0081](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0081.md) | Introduce lower bound for sector initial pledge | FIP | @anorth, @vkalghatgi | Draft |
-| [0082](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0082.md) | Add support for aggregated replica update proofs | FIP | nemo (@cryptonemo), Jake (@drpetervannostrand), @anorth | Accepted |
+| [0082](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0082.md) | Add support for aggregated replica update proofs | FIP | nemo (@cryptonemo), Jake (@drpetervannostrand), @anorth | Final |
 | [0083](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0083.md) | Add built-in Actor events in the Verified Registry, Miner and Market Actors | FIP | Aarsh (@aarshkshah1992)| Final |
-| [0084](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0084.md) | Remove Storage Miner Actor Method `ProveCommitSectors` | FIP | Jennifer Wang (@jennijuju)| Accepted |
-| [0085](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0085.md) | Convert f090 Mining Reserve actor to a keyless account actor | FIP | Jennifer Wang (@jennijuju), Jon Victor (@jnthnvctr)| Accepted |
+| [0084](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0084.md) | Remove Storage Miner Actor Method `ProveCommitSectors` | FIP | Jennifer Wang (@jennijuju)| Final |
+| [0085](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0085.md) | Convert f090 Mining Reserve actor to a keyless account actor | FIP | Jennifer Wang (@jennijuju), Jon Victor (@jnthnvctr)| Final |
 | [0086](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md) | Fast Finality in Filecoin (F3) | FIP | @stebalien, @masih, @mb1896, @hmoniz, @anorth, @matejpavlovic, @arajasek, @ranchalp, @jsoares, @Kubuxu, @vukolic, @jennijuju | Accepted |
 | [0087](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0087.md) | FVM-Enabled Deal Aggregation | FRC | @aashidham, @honghao, @raulk, @nonsense | Draft |
 | [0089](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0089.md) | A Finality Calculator for Filecoin | FRC | @guy-goren, @jsoares | Draft |
 | [0090](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0090.md) | Non-Interactive PoRep | FIP | luca (@lucaniz), kuba (@Kubuxu), nicola (@nicola), nemo (@cryptonemo), volker (@vmx), irene (@irenegia) | Superseded by [FIP0092](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0092.md) |
 | [0091](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0091.md) | Add support for Homestead and EIP-155 Ethereum Transactions ("legacy" Ethereum Transactions) | FIP | Aarsh (@aarshkshah1992)| Accepted |
-| [0092](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0092.md) | Non-Interactive PoRep | FIP | luca (@lucaniz), kuba (@Kubuxu), nicola (@nicola), nemo (@cryptonemo), volker (@vmx), irene (@irenegia), Alex North (@anorth), orjan (@Phi-rjan) | Accepted |
+| [0092](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0092.md) | Non-Interactive PoRep | FIP | luca (@lucaniz), kuba (@Kubuxu), nicola (@nicola), nemo (@cryptonemo), volker (@vmx), irene (@irenegia), Alex North (@anorth), orjan (@Phi-rjan) | Final |


### PR DESCRIPTION
This PR is to set nv23 FIPs from 'Accepted' to 'Final' reflecting that they are active onchain and finalized. 