### PR TITLE
Adjust ticket function in F3 to provide fairness

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -390,10 +390,11 @@ A [merkle tree](#merkle-tree-format) is built from these encoded `ECTipset` valu
       ```
 * `StrongQuorumValue(M)`
     * Returns $v$ if $\texttt{HasStrongQuorumValue}(M)$ holds, $nil$ otherwise.
-* `GreatestTicketProposal(M)`
+* `BestTicketProposal(M)`
     * Let $M$ be a clean set of CONVERGE messages for the same round.
     * If $M = ∅$, the predicate returns $baseChain$.
-    * If $M \ne ∅$, the predicate returns $m.value$ and $m.evidence$, such that $m$ is the message in $M$ with the greatest ticket after adjusting for the power of the sender ($m.ticket*m.sender.power$). M will never be empty as the participant must at least deliver its own CONVERGE message.
+    * If $M \ne ∅$, the predicate returns $m.value$ and $m.evidence$, such that $m$ is the message in $M$ with the smallest ticket after adjusting for the power of the sender ($\frac{-log(t)}{m.sender.power}$). M will never be empty as the participant must at least deliver its own CONVERGE message.
+    * The power adjustment is performed in exponentially distributed ticket space. The ticket is first hashed with Blake2b-256, truncated to 16 bytes which are then interpreted as big-endian fixed-point number with 128bits of precision. The resulting fixed-point number $t$ is in range $[0, 1)$. The $t' = \frac{-log(t)}{m.sender.power}$ provides exponentially distributed $t'$. The logarithm can be approximate, but should provide at least 32bits of precision. After this transformation, the $t'_m$ are compared and the smallest one is picked.
 
 * `Aggregate(M)`
     * Where $M$ is a clean set of messages of the same type $T$, round $r$, and instance $i$, with $v=\texttt{StrongQuorumValue}(M)≠nil$.
@@ -441,7 +442,7 @@ GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
 23:      reBroadcast <CONVERGE, value, round, evidence, ticket>; trigger(timeout)
 25:      collect a clean set M of valid CONVERGE msgs from this round and instance
            until timeout expires
-26:      value, justification ← GreatestTicketProposal(M)  // Leader election
+26:      value, justification ← BestTicketProposal(M)  // Leader election
 27:      if (justification step is PREPARE AND mayHaveStrongQuorum(value, r-1, COMMIT, 1/3))
 28:        C ← C ∪ {value}
 29:      if (value ∈ C)


### PR DESCRIPTION
Adjust ticket function in F3 to resolve fairness issue in ticket selection.
Adjusting for power with uniformly distributed tickets leads to bias towards larger power holders which can lead to very long instance times. By transforming tickets into exponentially distributed random variables and adjusting them in that space we avoid that issue.