### PR TITLE
Add @rvagg as a FIP editor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @momack2 @arajasek @jennijuju @kaitlin-beegle @anorth @raulk @jsoares @TippyFlitsUK
+*       @momack2 @arajasek @jennijuju @kaitlin-beegle @anorth @raulk @jsoares @TippyFlitsUK @rvagg

--- a/FIPS/fip-0001.md
+++ b/FIPS/fip-0001.md
@@ -221,6 +221,7 @@ The current FIP editors are
 * Raúl Kripalani (@raulk) 
 * Jorge Soares (@jsoares) 
 * James Bluett (@TippyFlitsUK)
+* Rod Vagg (@rvagg)
 
 ## FIP Editor Responsibilities
 


### PR DESCRIPTION
I propose @rvagg to be added as as a FIP editor, to increase our numbers a little with an experienced technical expert, especially while we are considering [removing editors who have ceased contributing](https://github.com/filecoin-project/FIPs/pull/991). 

@rvagg is already a frequent contributor to FIP discussions and PR review, and I think we can recognize this and gain some more responsiveness on the administrivia by adding him to the crew.

Note to others: we'd still like to add more, especially from outside FilOz. Rod sets a good example of the type of engagement that would encourage us all to want you as a colleague. 

Initially proposed in Slack [here](https://filecoinproject.slack.com/archives/C01EU76LPCJ/p1724798594112089).

Editors: please leave this PR open for some time after the first two approvals so all current editors have a reasonable chance to comment.