### PR TITLE
FIP-0086: Rename `Step` to `Phase` for consistency

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -305,8 +305,8 @@ type Payload struct {
   Instance uint64
   // GossiPBFT round number.
   Round uint64
-  // GossiPBFT step number.
-  Step uint8
+  // GossiPBFT phase number.
+  Phase uint8
   // Common data all nodes are expected to commit to in the given instance.
   SupplementalData SupplementalData
   // Chain of ECTipset objects proposed/voted for finalisation.
@@ -333,17 +333,17 @@ type PowerTableEntry struct {
 }
 ```
 
-Values for step numbers are:
+Values for phase numbers are:
 
-| Step name | Value |
-|-----------|-------|
-| QUALITY   | 1     |
-| CONVERGE  | 2     |
-| PREPARE   | 3     |
-| COMMIT    | 4     |
-| DECIDE    | 5     |
+| Phase name | Value |
+|------------|-------|
+| QUALITY    | 1     |
+| CONVERGE   | 2     |
+| PREPARE    | 3     |
+| COMMIT     | 4     |
+| DECIDE     | 5     |
 
-All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over `"GPBFT:filecoin:":15 || Step:1 || Round:8 || Instance:8 || SupplementalData.Commitments:32 || MerkelizeValue(Value):32 || SupplementalData.PowerTable` (where `Round` and `Instance` are big-endian encoded). The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
+All messages broadcast by a participant have their participant ID in the sender field and contain a digital signature by that participant $(m.Signature)$ over `"GPBFT:filecoin:":15 || Phase:1 || Round:8 || Instance:8 || SupplementalData.Commitments:32 || MerkelizeValue(Value):32 || SupplementalData.PowerTable` (where `Round` and `Instance` are big-endian encoded). The protocol assumes aggregatable signatures (e.g., BLS, Schnorr), resilient to [rogue public key attacks](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html) (see [Boneh, Drijvers, and Neven](https://eprint.iacr.org/2018/483.pdf) construction).
 
 The receiver of a message only considers messages with matching supplemental data and valid signatures, and discards all other messages as invalid. The sender ID and signatures are omitted in further descriptions for better readability.
 
@@ -406,9 +406,9 @@ A [merkle tree](#merkle-tree-format) is built from these encoded `ECTipset` valu
 
 #### GossiPBFT pseudocode (main algorithm)
 
-The GossiPBFT algorithm is specified by pseudocode below. It consists of 3 steps per round (QUALITY/CONVERGE, PREPARE, COMMIT) and an additional step outside the round loop (DECIDE). Message fields that are constant for the instance are omitted for readability. 
+The GossiPBFT algorithm is specified by pseudocode below. It consists of 3 phases per round (QUALITY/CONVERGE, PREPARE, COMMIT) and an additional phase outside the round loop (DECIDE). Message fields that are constant for the instance are omitted for readability. 
 
-Messages are delivered to the participant in some order, whereupon a predicate over the set of received messages is evaluated, depending on the algorithm's current round and step.
+Messages are delivered to the participant in some order, whereupon a predicate over the set of received messages is evaluated, depending on the algorithm's current round and phase.
 
 ```
 GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
@@ -421,14 +421,14 @@ GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
 06:  value ← proposal // Used to communicate the voted value to others (proposal or 丄)
 07:  evidence ← nil   // Used to communicate evidence for the voted value
 08:  C ← {baseChain}
-09:  step ← nil
+09:  phase ← nil
 10:  own_msgs ← {} // Set of msgs sent by this participant
 
-11:  while (step != DECIDE)  {
+11:  while (phase != DECIDE)  {
        // QUALTIY
 12:    if (round = 0)
 13:      BEBroadcast <QUALITY, value>; trigger (timeout)
-14:      step ← QUALITY
+14:      phase ← QUALITY
 15:      collect a clean set M of valid QUALITY messages from this instance 
            until HasStrongQuorum(proposal, M) OR timeout expires
 17:      C ← C ∪ {prefix : IsPrefix(prefix,proposal) and HasStrongQuorum(prefix,M)}
@@ -443,7 +443,7 @@ GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
 25:      collect a clean set M of valid CONVERGE msgs from this round and instance
            until timeout expires
 26:      value, justification ← BestTicketProposal(M)  // Leader election
-27:      if (justification step is PREPARE AND mayHaveStrongQuorum(value, r-1, COMMIT, 1/3))
+27:      if (justification phase is PREPARE AND mayHaveStrongQuorum(value, r-1, COMMIT, 1/3))
 28:        C ← C ∪ {value}
 29:      if (value ∈ C)
 30:        proposal ← value // Sway proposal if the value is EC compatible (i.e., in C)
@@ -469,7 +469,7 @@ GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
          until HasStrongQuorumValue(M) OR (timeout expires AND IsStrongQuorum(M))
 42:    if (HasStrongQuorumValue(M))
 43:      if (StrongQuorumValue(M) ≠ 丄)  // Decide
-           // This broadcast sets step = DECIDE which will break the outer loop
+           // This broadcast sets phase = DECIDE which will break the outer loop
 44:        evidence ← Aggregate(M)
 45:        reBroadcast <DECIDE, StrongQuorumValue(M), evidence>  
 46:      else  
@@ -489,36 +489,36 @@ GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
 57:  return (StrongQuorumValue(M), Aggregate(M)) // Terminate with a decision
 ```
 
-A participant jumps immediately to the DECIDE step upon receiving a DECIDE message from another participant. That message will carry evidence of a strong quorum of the committee COMMITting to that value.
+A participant jumps immediately to the DECIDE phase upon receiving a DECIDE message from another participant. That message will carry evidence of a strong quorum of the committee COMMITting to that value.
 
 ```
      // Decide anytime
-58:  upon reception of a valid <DECIDE, v, evidence>, if step != DECIDE
+58:  upon reception of a valid <DECIDE, v, evidence>, if phase != DECIDE
 59:    reBroadcast <DECIDE, v, evidence>
 60:    go to line 56
 ```
 
-The helper function mayHaveStrongQuorum returns whether, given the already delivered messages and assuming the presence of an equivocating adversary, some correct participant could have observed strong quorum for a value at some round and step. The parameter advPower can be set to 0 in order to consider the possibility of the participant locally observing strong quorum, or ⅓ to consider the possibility of any participant doing so. Note that where only two values are possible, a false return for one of them does not imply that the other has necessarily reached strong quorum (e.g. an exact ⅔ to ⅓ split).
+The helper function mayHaveStrongQuorum returns whether, given the already delivered messages and assuming the presence of an equivocating adversary, some correct participant could have observed strong quorum for a value at some round and phase. The parameter advPower can be set to 0 in order to consider the possibility of the participant locally observing strong quorum, or ⅓ to consider the possibility of any participant doing so. Note that where only two values are possible, a false return for one of them does not imply that the other has necessarily reached strong quorum (e.g. an exact ⅔ to ⅓ split).
 
 ```
-61:  mayHaveStrongQuorum(value, round, step, advPower): 
-62:    M  ← { m | m.step = step AND m.round = round AND m is valid} // Clean set of messages
+61:  mayHaveStrongQuorum(value, round, phase, advPower): 
+62:    M  ← { m | m.phase = phase AND m.round = round AND m is valid} // Clean set of messages
 63:    M' ← { m | m ∈ M AND m.value = value } 
 64:    return Power(M') + (1-Power(M)) + advPower >= ⅔ 
 ```
 
-The reBroadcast function broadcasts and remembers a message. It then sets a timeout to rebroadcast a subset of the messages in the current and previous round if the participant cannot terminate the step in which it is.
+The reBroadcast function broadcasts and remembers a message. It then sets a timeout to rebroadcast a subset of the messages in the current and previous round if the participant cannot terminate the phase in which it is.
 
 ```
 67:  reBroadcast(msg):
 68:    own_msgs = own_msgs ∪ {msg}
 69:    BEBroadcast(msg)
 70:    trigger(timeout_rebroadcast)
-71:    step ← msg.step
+71:    phase ← msg.phase
 72:    upon timeout_rebroadcast expires:
-73:      if step = msg.step AND msg.round = round AND msg.instance = instance 
+73:      if phase = msg.phase AND msg.round = round AND msg.instance = instance 
            // Stuck, need to rebroadcast
-74:        switch (msg.step) {
+74:        switch (msg.phase) {
 75:          case DECIDE:
 76:            BEBroadcast(m ∈ own_msgs: m.round=0 AND m.type=DECIDE) // only rebroadcast DECIDE
 77:            break  // Exit, no cascading
@@ -547,25 +547,25 @@ In order to avoid unbounded accumulation of state, some messages from some futur
 
 ```
 100:  upon reception of a valid msg for this instance: 
-101:    if (msg.round > round + max_lookahead_rounds) AND msg.step = COMMIT AND msg.value = 丄  
+101:    if (msg.round > round + max_lookahead_rounds) AND msg.phase = COMMIT AND msg.value = 丄  
 102:      return  // Drop message
 103:    deliver(msg)  // Otherwise make the message available to the main algorithm
-104:    if (msg' ← shouldJump(round, step) s.t. msg' != nil)
+104:    if (msg' ← shouldJump(round, phase) s.t. msg' != nil)
           // The msg' is a CONVERGE for round
 105:      round ← msg'.round
 106:      timeout ← 2 * Δ * pow(BackOffExponent, round)
 107:      timeout_rebroadcast ← timeout + 1 // Arbitrary increment
-108:      if msg'.evidence.step = PREPARE: // Evidence is strong quorum of either PREPAREs of COMMITs for 丄
+108:      if msg'.evidence.phase = PREPARE: // Evidence is strong quorum of either PREPAREs of COMMITs for 丄
 109:        C ← C ∪ {msg'.value}       // Add to candidate values if not there
 110:        proposal ← msg'.value     // Sway local proposal to possibly decided value
           // Inherit evidence for the value from CONVERGE message 
 111:      evidence ← msg'.evidence   
 112:      go to line 21  // Start new round>0 by jumping forward
 
-113:  shouldJump(round, step): 
-114:    if step = DECIDE:
+113:  shouldJump(round, phase): 
+114:    if phase = DECIDE:
 115:      return nil
-116:    if (∃ msg' st. msg'.step = CONVERGE // There must be a CONVERGE for the new round
+116:    if (∃ msg' st. msg'.phase = CONVERGE // There must be a CONVERGE for the new round
             AND msg'.round > round          // Round must be greater
             AND ∃ M s.t. M is clean and valid and contains a weak quorum of PREPAREs for msg'.round)
 117:      return msg'
@@ -576,9 +576,9 @@ The parameter `max_lookahead_rounds` may be set at the discretion of an implemen
 
 Note that the selection of the longest prefix in line 18 does not need access to the tipsets' EC weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or vice-versa (since the adversary controls < ⅓ of the QAP). As a result, selecting the longest prefix is as simple as selecting the longest chain, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
 
-Implementations may optimise this algorithm to treat the reception of an aggregated signature over some (MsgType, Instance, Round, Value) as evidence of a message as if it had received the same tuple of values directly from each participant in the aggregate. This may be used to effectively skip a partially-complete step. In the particular case of a DECIDE message, which carries evidence of a strong quorum of COMMITs for the same round and value, a participant immediately sends its own DECIDE for the same value (copying the evidence) and exits the loop at line 11.
+Implementations may optimise this algorithm to treat the reception of an aggregated signature over some (MsgType, Instance, Round, Value) as evidence of a message as if it had received the same tuple of values directly from each participant in the aggregate. This may be used to effectively skip a partially-complete phase. In the particular case of a DECIDE message, which carries evidence of a strong quorum of COMMITs for the same round and value, a participant immediately sends its own DECIDE for the same value (copying the evidence) and exits the loop at line 11.
 
-Also, the set C of candidate values that the participant contributes to deciding is restricted to only values that either (i) pass the QUALITY step or (ii) may have been decided by other participants.
+Also, the set C of candidate values that the participant contributes to deciding is restricted to only values that either (i) pass the QUALITY phase or (ii) may have been decided by other participants.
 
 When a participant is in receipt of multiple messages at once (such as when starting an instance with queued messages), a decision to jump ahead rounds should be taken only after processing all available messages. This will enable the participant to contribute to a decision other than the base chain.
 
@@ -586,48 +586,48 @@ When a participant is in receipt of multiple messages at once (such as when star
 
 The $\texttt{Valid}()$ predicate (referred to in lines 15, 25, 33, 41, 56, 58, 62, 100 and 116) is defined below.
 ```
-Valid(m):                                    | For a message m to be valid,
-  if m.signature does not verify             |   m must be properly signed.
-    return False                             | 
-  if m.instance != instance                  |   m must match the instance ID.
-    return False                             | 
-  if m.sender has zero power or is unknown:  |   The sender must have power and be known.
-    return False                             | 
-  if NOT (m.value = 丄 OR                    |   m's value must extend baseChain
-          IsPrefix(baseChain, m.value))      |    or be 丄
-    return False                             | 
-  if m.step != CONVERGE AND m.ticket != nil  |   ticket must be nil if not CONVERGE
-    return False                             | 
-  if m.step = QUALITY AND                    |   A QUALITY message must
-     (m.round != 0 OR m.value = 丄)          |   have round 0 and non-丄 value.
-    return False                             | 
-  if m.step = CONVERGE AND                   |   A CONVERGE message must
-    (m.round = 0 OR m.value = 丄 OR          |   have non-zero round, non-丄 value,
-     m.ticket does not pass VRF validation)  |   and a valid ticket.
-    return False                             | 
-  if m.step = DECIDE AND                     |   A DECIDE message must
-    (m.round != 0 OR m.value = 丄)           |   have round 0 and non-丄 value.
-    return False                             |  
-  if m.step = QUALITY                        |   If the step never requires evidence
-    if m.evidence != nil:                    |   (QUALITY), evidence should not be present.
-      return False                           |
-    if len(m.value) > 100:                   |   Proposal's head must be at most 99 tipsets
-      return False                           |   ahead of baseChain's head.
-  else                                       | 
-    return ValidEvidence(m)                  | 
-  return True                                |   No evidence for QUALITY
+Valid(m):                                     | For a message m to be valid,
+  if m.signature does not verify              |   m must be properly signed.
+    return False                              | 
+  if m.instance != instance                   |   m must match the instance ID.
+    return False                              | 
+  if m.sender has zero power or is unknown:   |   The sender must have power and be known.
+    return False                              | 
+  if NOT (m.value = 丄 OR                     |   m's value must extend baseChain
+          IsPrefix(baseChain, m.value))       |    or be 丄
+    return False                              | 
+  if m.phase != CONVERGE AND m.ticket != nil  |   ticket must be nil if not CONVERGE
+    return False                              | 
+  if m.phase = QUALITY AND                    |   A QUALITY message must
+     (m.round != 0 OR m.value = 丄)           |   have round 0 and non-丄 value.
+    return False                              | 
+  if m.phase = CONVERGE AND                   |   A CONVERGE message must
+    (m.round = 0 OR m.value = 丄 OR           |   have non-zero round, non-丄 value,
+     m.ticket does not pass VRF validation)   |   and a valid ticket.
+    return False                              | 
+  if m.phase = DECIDE AND                     |   A DECIDE message must
+    (m.round != 0 OR m.value = 丄)            |   have round 0 and non-丄 value.
+    return False                              |  
+  if m.phase = QUALITY                        |   If the phase never requires evidence
+    if m.evidence != nil:                     |   (QUALITY), evidence should not be present.
+      return False                            |
+    if len(m.value) > 100:                    |   Proposal's head must be at most 99 tipsets
+      return False                            |   ahead of baseChain's head.
+  else                                        | 
+    return ValidEvidence(m)                   | 
+  return True                                 |   No evidence for QUALITY
 ```
 
 The $\texttt{ValidEvidence}()$ predicate is defined below. Note that QUALITY messages do not need evidence.
 
 ```
-ValidEvidence(m= <step, value, instance, round, evidence, ticket>):
+ValidEvidence(m= <phase, value, instance, round, evidence, ticket>):
 
-if (step = PREPARE AND round = 0) AND                      | in the first round, for PREPARE
+if (phase = PREPARE AND round = 0) AND                      | in the first round, for PREPARE
    (evidence = nil)                                        | evidence is nil
   return True                                            
 
-if (step = COMMIT and value = 丄) AND                      | a COMMIT for 丄 
+if (phase = COMMIT and value = 丄) AND                      | a COMMIT for 丄 
    (evidence = nil)                                        | carries no evidence
   return True                    
 
@@ -635,33 +635,33 @@ if (evidence.instance != instance)                         | the instance of the
   return False                                             | same as that of the message
 
                                                            | valid evidences for
-return  (step = CONVERGE OR (step = PREPARE AND round>0)   | CONVERGE and PREPARE in 
+return  (phase = CONVERGE OR (phase = PREPARE AND round>0)   | CONVERGE and PREPARE in 
   AND (∃ M: IsStrongQuorum(M) AND evidence=Aggregate(M)    | round>0 is strong quorum 
-    AND ((∀ m’ ∈ M: m’.step = COMMIT AND m’.value = 丄)    | of COMMIT msgs for 丄
-      OR (∀ m’ ∈ M: m’.step = PREPARE AND                  | or PREPARE msgs for 
+    AND ((∀ m’ ∈ M: m’.phase = COMMIT AND m’.value = 丄)    | of COMMIT msgs for 丄
+      OR (∀ m’ ∈ M: m’.phase = PREPARE AND                  | or PREPARE msgs for 
             m’.value = value))                             | CONVERGE     value     
       AND (∀ m’ ∈ M: m’.round = round-1)))                 | from previous round 
 
      
-OR (step=COMMIT                                            | valid COMMIT evidence 
+OR (phase=COMMIT                                            | valid COMMIT evidence 
   AND (∃ M: IsStrongQuorum(M) AND evidence=Aggregate(M)    | is a strong quorum 
-      AND ∀ m’ ∈ M: m’.step = PREPARE                      | of PREPARE messages
+      AND ∀ m’ ∈ M: m’.phase = PREPARE                      | of PREPARE messages
       AND ∀ m’ ∈ M: m’.round = round                       | from the same round 
       AND ∀ m’ ∈ M: m’.value = value))                     | for the same value, or
 
-OR (step = DECIDE                                          | valid DECIDE evidence
+OR (phase = DECIDE                                          | valid DECIDE evidence
       AND (∃ M: IsStrongQuorum(M) AND evidence=Aggregate(M)| is a strong quorum 
-        AND ∀ m’ ∈ M: m’.step = COMMIT                     | of COMMIT messages
+        AND ∀ m’ ∈ M: m’.phase = COMMIT                     | of COMMIT messages
         AND ∀ m’,m’’ ∈ M: m’.round = m’’.round             | from the same (any) round as each other
         AND ∀ m’ ∈ M: m’.value = value))                   | for the same value 
 ```
 
 ### Evidence verification complexity
-Note that during the validation of each CONVERGE, COMMIT, and DECIDE message, two signatures need to be verified: (1) the signature of the message contents, produced by the sender of the message (first check above) and (2) the aggregate signature in $m.evidence$ ($\texttt{ValidEvidence}(m)$ above). The former can be verified using the sender's public key (stored in the power table). The latter, being an aggregated signature, requires aggregating public keys of all the participants whose signatures it combines. Notice that the evidence of each message can be signed by a different set of participants, which requires aggregating a linear number of BLS public keys (in system size) per evidence verification. However, a participant only needs to verify the evidence once for each *unique* message (in terms of (step, round, value)) received.
+Note that during the validation of each CONVERGE, COMMIT, and DECIDE message, two signatures need to be verified: (1) the signature of the message contents, produced by the sender of the message (first check above) and (2) the aggregate signature in $m.evidence$ ($\texttt{ValidEvidence}(m)$ above). The former can be verified using the sender's public key (stored in the power table). The latter, being an aggregated signature, requires aggregating public keys of all the participants whose signatures it combines. Notice that the evidence of each message can be signed by a different set of participants, which requires aggregating a linear number of BLS public keys (in system size) per evidence verification. However, a participant only needs to verify the evidence once for each *unique* message (in terms of (phase, round, value)) received.
 
 #### Randomness
 
-An instance of GossiPBFT requires a seed that must be common among all participants due to the dependency on a VRF in the CONVERGE step. As only one random seed is required per GossiPBFT instance, and there is only one GossiPBFT instance per epoch (see below), the random seed for GossiPBFT is be sourced from drand's output for the EC epoch from which the committee is formed.
+An instance of GossiPBFT requires a seed that must be common among all participants due to the dependency on a VRF in the CONVERGE phase. As only one random seed is required per GossiPBFT instance, and there is only one GossiPBFT instance per epoch (see below), the random seed for GossiPBFT is be sourced from drand's output for the EC epoch from which the committee is formed.
 
 
 ### Synchronization of Participants in the Current Instance
@@ -670,9 +670,9 @@ GossiPBFT ensures termination provided that (i) all participants start the insta
 
 [Given prior tests performed on Gossipsub](https://research.protocol.ai/publications/gossipsub-v1.1-evaluation-report/vyzovitis2020.pdf) (see also [here](https://gist.github.com/jsoares/9ce4c0ba6ebcfd2afa8f8993890e2d98)), sent messages are expected to reach almost all participants within 3 seconds, with a majority receiving them even after 2 seconds. However, if several participants start the instance $Δ + ε$ after some other participants, termination is not guaranteed for the selected timeouts of $2*Δ$. Thus, the protocol does not rely on an explicit synchrony bound for correctness. Instead, the estimate of Δ is increased locally within an instance as rounds progress without decision.
 
-The synchronization of participants within an instance is achieved with a timeout exponentially increasing each round. Participants start each instance with `Δ=3s` and for each round, set the step timeout to `2 * Δ * BackOffExponent^{round}`.
+The synchronization of participants within an instance is achieved with a timeout exponentially increasing each round. Participants start each instance with `Δ=3s` and for each round, set the phase timeout to `2 * Δ * BackOffExponent^{round}`.
 
-As an optimization, participants may finish a step once its execution is determined by the received messages, without waiting for the timeout. For example, if a participant receives QUALITY messages from all participants, it can proceed to the next step without waiting for the timeout. More generally, if the remaining valid messages to be received cannot change the execution of the step, regardless of the values contained in the messages, then a participant may continue to the next step.
+As an optimization, participants may finish a phase once its execution is determined by the received messages, without waiting for the timeout. For example, if a participant receives QUALITY messages from all participants, it can proceed to the next phase without waiting for the timeout. More generally, if the remaining valid messages to be received cannot change the execution of the phase, regardless of the values contained in the messages, then a participant may continue to the next phase.
 
 
 ### Synchronization of Participants across Instances
@@ -935,7 +935,7 @@ This FIP requires a network upgrade to take effect since it changes the EC fork 
            - Evidence insufficient by QAP according to the corresponding power table.
          * Invalid value
            - Value not extending the corresponding baseChain
-           - Value not being acceptable (after QUALITY step)
+           - Value not being acceptable (after QUALITY phase)
    - Tests under faults:
      * Crashing:
        - <⅓ QAP does not send any message from the beginning; the rest share the same input.
@@ -989,10 +989,10 @@ This FIP requires a network upgrade to take effect since it changes the EC fork 
 
 The modifications proposed in this FIP have far-reaching implications for the security of the system. This FIP changes Filecoin at a fundamental level: from considering tipsets as final after some time to finalizing them after a quorum of participants reach an agreement. Some security considerations this modification entails:
 
-* **Censorship.** F3 and GossiPBFT are designed with censorship resistance in mind. The updated fork choice rule means that an adversary controlling at least more than ⅓ QAP can try to perform a censorship attack if honest participants start an instance of GossiPBFT proposing at least two distinct inputs. While this attack is theoretically possible, it is notably hard to perform on F3 given the QUALITY step of GossiPBFT and other mitigation strategies specifically put in place to protect against this. The mitigations designed will prevent such an attack, even against a majority adversary.
+* **Censorship.** F3 and GossiPBFT are designed with censorship resistance in mind. The updated fork choice rule means that an adversary controlling at least more than ⅓ QAP can try to perform a censorship attack if honest participants start an instance of GossiPBFT proposing at least two distinct inputs. While this attack is theoretically possible, it is notably hard to perform on F3 given the QUALITY phase of GossiPBFT and other mitigation strategies specifically put in place to protect against this. The mitigations designed will prevent such an attack, even against a majority adversary.
 * **Liveness.** Implementing F3 introduces the risk that an adversary controlling at least ⅓ QAP prevents termination of a GossiPBFT instance. In that case, the F3 component would halt, not finalizing any tipset anymore. At the same time, EC would still operate, outputting tipsets and considering them final after 900 epochs. The liveness of the system is thus not affected by attacks on the liveness of F3.
 * **Safety.** Implementing F3 ensures the safety of finalized outputs during regular or even congested networks against a Byzantine adversary controlling less than ⅓ QAP. For stronger adversaries, F3 provides mitigations to prevent censorship attacks, as outlined above. If deemed necessary, the punishment and recovery from coalitions in the event of an attempted attack on safety can be explored in future FIPs. Note that the (safe) finality time is already significantly improved by F3 compared to the status quo: F3 provides safety of finalized outputs two orders of magnitude faster than the current parameter of 900 epochs during regular network operation.
-* **Denial-of-service (DoS).** The implementation of the F3 preserves resistance against DoS attacks currently ensured by Filecoin, thanks to the fully leaderless nature of GossiPBFT and to the use of a VRF to self-assign tickets during the CONVERGE step.
+* **Denial-of-service (DoS).** The implementation of the F3 preserves resistance against DoS attacks currently ensured by Filecoin, thanks to the fully leaderless nature of GossiPBFT and to the use of a VRF to self-assign tickets during the CONVERGE phase.
 * **Committees.** This FIP proposes to have all eligible EC participants run all instances of GossiPBFT. While this ensures optimal resilience against a Byzantine adversary, it can render the system unusable if the number of participants grows too large. This introduces an attack vector: if the scalability limit is 100,000 participants, a participant holding as little as 3% of the current QAP can perform a Sybil attack to render the system unusable, with the minimum QAP required per identity. As a result, the implementation should favor the messages of the more powerful participants if the number of participants grows too large. Given that favoring more powerful participants discriminates against the rest, affecting decentralization, amending F3 to use committees in the event of the number of participants exceeding the practical limit might be the topic of a future FIP, as well as the analysis of optimized message aggregation in the presence of self-selected committees.
 
 The supplementary material (../resources/fip-0086/) provides the proofs of correctness for the protocol.


### PR DESCRIPTION
Previously, the F3 implementation used "phase" and "step" inconsistently throughout the repository. For instance, the type name was referred to as "phase" while field names were labeled "step".

Following internal discussions, the implementation standardised the use "phase" across the codebase to align terminology. This commit updates the FIP documentation to reflect the changes for a consistent terminology between the implementation and documentation.

Note, these changes are purely mechanical and do not alter any functionality or behaviour.

Relates to https://github.com/filecoin-project/go-f3/pull/634
