### PR TITLE
FIP-0086: Accept QUALITY at any round and include in rebroadcast

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -358,7 +358,7 @@ Instead of encoding `Payload.Value` as CBOR and signing the result, it is conver
 Specifically, each `ECTipset` is encoded by concatenating:
 
 1. The `Epoch`, encoded as a big-endian 64bit value (8 bytes).
-2. The `Commitements` hash as-is (32 bytes).
+2. The `Commitments` hash as-is (32 bytes).
 3. The tipset _CID_, a blake2b CID of the `TipsetKey` encoded as a CBOR byte array (38 bytes). The resulting CID is the "tipset CID". Importantly, it's hash digest is the digest returned by the `BLOCKHASH` instruction in Filecoin's EVM implementation.
 4. The `PowerTable` CID .
 
@@ -415,78 +415,87 @@ GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
 // Committee is implicitly used to calculate quora.
 
 01:  round ← 0
-03:  proposal ← inputChain  // CHain that the participant locally believes should be decided.
-04:  timeout ← 2*Δ
-05:  timeout_rebroadcast ← timeout + 1 // Any value larger than timeout, at implementation discretion.
-06:  value ← proposal // Used to communicate the voted value to others (proposal or 丄)
-07:  evidence ← nil   // Used to communicate evidence for the voted value
-08:  C ← {baseChain}
-09:  phase ← nil
-10:  own_msgs ← {} // Set of msgs sent by this participant
+02:  proposal ← inputChain  // CHain that the participant locally believes should be decided.
+03:  timeout ← 2*Δ
+04:  timeout_rebroadcast ← timeout + 1 // Any value larger than timeout, at implementation discretion.
+05:  value ← proposal // Used to communicate the voted value to others (proposal or 丄)
+06:  evidence ← nil   // Used to communicate evidence for the voted value
+07:  C ← {baseChain}
+08:  phase ← nil
+09:  own_msgs ← {} // Set of msgs sent by this participant
 
-11:  while (phase != DECIDE)  {
+10:  while (phase != DECIDE)  {
        // QUALTIY
-12:    if (round = 0)
-13:      BEBroadcast <QUALITY, value>; trigger (timeout)
-14:      phase ← QUALITY
-15:      collect a clean set M of valid QUALITY messages from this instance 
+11:    if (round = 0)
+12:      BEBroadcast <QUALITY, value>; trigger (timeout)
+13:      phase ← QUALITY
+14:      collect a clean set M of valid QUALITY messages from this instance 
            until HasStrongQuorum(proposal, M) OR timeout expires
-17:      C ← C ∪ {prefix : IsPrefix(prefix,proposal) and HasStrongQuorum(prefix,M)}
-18:      proposal ← longest prefix ∈ C  // At least baseChain, or something longer
-19:      value ← proposal
+15:      C ← C ∪ {prefix : IsPrefix(prefix,proposal) and HasStrongQuorum(prefix,M)}
+16:      proposal ← longest prefix ∈ C  // At least baseChain, or something longer
+17:      value ← proposal
 
        // CONVERGE
-20:    if (round > 0)
-21:      ticket ← VRF(Randomness(baseChain) || instance || round)
-22:      value ← proposal  // set local proposal as value
-23:      reBroadcast <CONVERGE, value, round, evidence, ticket>; trigger(timeout)
-25:      collect a clean set M of valid CONVERGE msgs from this round and instance
+18:    if (round > 0)
+19:      ticket ← VRF(Randomness(baseChain) || instance || round)
+20:      value ← proposal  // set local proposal as value
+21:      reBroadcast <CONVERGE, value, round, evidence, ticket>; trigger(timeout)
+22:      collect a clean set M of valid CONVERGE msgs from this round and instance
            until timeout expires
-26:      value, justification ← BestTicketProposal(M)  // Leader election
-27:      if (justification phase is PREPARE AND mayHaveStrongQuorum(value, r-1, COMMIT, 1/3))
-28:        C ← C ∪ {value}
-29:      if (value ∈ C)
-30:        proposal ← value // Sway proposal if the value is EC compatible (i.e., in C)
-31:        evidence ← justification //  Otherwise keep existing proposal and evidence
+23:      value, justification ← BestTicketProposal(M)  // Leader election
+24:      if (justification phase is PREPARE AND mayHaveStrongQuorum(value, r-1, COMMIT, ⅓))
+25:        C ← C ∪ {value}
+26:      if (value ∈ C)
+27:        proposal ← value // Sway proposal if the value is EC compatible (i.e., in C)
+28:        evidence ← justification //  Otherwise keep existing proposal and evidence
 
        // PREPARE
        // Note that evidence is nil in round 0.
-32:    reBroadcast <PREPARE, value, round, evidence>; trigger(timeout) 
-33:    collect a clean set M of valid PREPARE messages from this round and instance 
+29:    reBroadcast <PREPARE, value, round, evidence>; trigger(timeout) 
+30:    collect a clean set M of valid PREPARE messages from this round and instance 
          until (HasStrongQuorumValue(M) AND StrongQuorumValue(M) = proposal)
            OR (NOT mayHaveStrongQuorum(proposal, round, PREPARE, 0))
            OR (timeout expires AND isStrongQuorum(M))
-34:    if (HasStrongQuorumValue AND StrongQuorumValue(M) = proposal) 
+31:    if (HasStrongQuorumValue AND StrongQuorumValue(M) = proposal) 
          // Strong quorum of PREPAREs for local proposal
-35:      value ← proposal  // Vote for deciding this proposal
-36:      evidence ← Aggregate(M)  // strong quorum of PREPAREs is evidence
-37:    else
-38:      value ← 丄  // Vote for not deciding in this round
-39:      evidence ← nil
+32:      value ← proposal  // Vote for deciding this proposal
+33:      evidence ← Aggregate(M)  // strong quorum of PREPAREs is evidence
+34:    else
+35:      value ← 丄  // Vote for not deciding in this round
+36:      evidence ← nil
 
-40:    reBroadcast <COMMIT, value, round, evidence>; trigger(timeout)
-41:    collect a clean set M of valid COMMIT messages from this round and instance
+37:    reBroadcast <COMMIT, value, round, evidence>; trigger(timeout)
+38:    collect a clean set M of valid COMMIT messages from this round and instance
          until HasStrongQuorumValue(M) OR (timeout expires AND IsStrongQuorum(M))
-42:    if (HasStrongQuorumValue(M))
-43:      if (StrongQuorumValue(M) ≠ 丄)  // Decide
+39:    if (HasStrongQuorumValue(M))
+40:      if (StrongQuorumValue(M) ≠ 丄)  // Decide
            // This broadcast sets phase = DECIDE which will break the outer loop
-44:        evidence ← Aggregate(M)
-45:        reBroadcast <DECIDE, StrongQuorumValue(M), evidence>  
-46:      else  
+41:        evidence ← Aggregate(M)
+42:        reBroadcast <DECIDE, StrongQuorumValue(M), evidence>  
+43:      else  
            // No participant decided in this round, carry forward existing proposal
-47:        evidence ← Aggregate(M)  // Strong quorum of COMMITs for 丄 is evidence
-48:    if (∃ m ∈ M: m.value ≠ 丄)  // Value was possibly decided by others
-49:      C ← C ∪ {m.value}  // Add to candidate values if not there
-50:      proposal ← m.value  // Sway local proposal to possibly decided value
-51:      evidence ← m.evidence  // Strong PREPARE quorum is inherited evidence
-52:    round ← round + 1
-53:    timeout ← 2 * Δ * pow(BackOffExponent, round)
-54:    timeout_rebroadcast ← timeout + 1  // Arbitrary increment
-55:  }
+44:        evidence ← Aggregate(M)  // Strong quorum of COMMITs for 丄 is evidence
+45:    if (∃ m ∈ M: m.value ≠ 丄)  // Value was possibly decided by others
+46:      C ← C ∪ {m.value}  // Add to candidate values if not there
+47:      proposal ← m.value  // Sway local proposal to possibly decided value
+48:      evidence ← m.evidence  // Strong PREPARE quorum is inherited evidence
+49:    round ← round + 1
+50:    timeout ← 2 * Δ * pow(BackOffExponent, round)
+51:    timeout_rebroadcast ← timeout + 1  // Arbitrary increment
+52:  }
 
-56:  collect a clean set M of valid DECIDE messages from this instance
+53:  collect a clean set M of valid DECIDE messages from this instance
        until (HasStrongQuorumValue(M)) // Collect a strong quorum of DECIDE outside the round loop
-57:  return (StrongQuorumValue(M), Aggregate(M)) // Terminate with a decision
+54:  return (StrongQuorumValue(M), Aggregate(M)) // Terminate with a decision
+```
+
+Late-arriving QUALITY messages are accepted in any round or phase, except during DECIDE. Upon the arrival of such QUALITY message after the QUALITY phase has completed, a participant may update the candidate set C if the value satisfies a strong quorum.
+
+```
+     // Late-arriving QUALITY
+55:  collect a clean set M of valid QUALITY messages from this instance
+56:  upon reception of a valid <QUALITY, value>, if phase != QUALITY
+57:    C ← C ∪ {prefix : IsPrefix(prefix,inputChain) and HasStrongQuorum(prefix,M)}
 ```
 
 A participant jumps immediately to the DECIDE phase upon receiving a DECIDE message from another participant. That message will carry evidence of a strong quorum of the committee COMMITting to that value.
@@ -495,7 +504,7 @@ A participant jumps immediately to the DECIDE phase upon receiving a DECIDE mess
      // Decide anytime
 58:  upon reception of a valid <DECIDE, v, evidence>, if phase != DECIDE
 59:    reBroadcast <DECIDE, v, evidence>
-60:    go to line 56
+60:    go to line 53
 ```
 
 The helper function mayHaveStrongQuorum returns whether, given the already delivered messages and assuming the presence of an equivocating adversary, some correct participant could have observed strong quorum for a value at some round and phase. The parameter advPower can be set to 0 in order to consider the possibility of the participant locally observing strong quorum, or ⅓ to consider the possibility of any participant doing so. Note that where only two values are possible, a false return for one of them does not imply that the other has necessarily reached strong quorum (e.g. an exact ⅔ to ⅓ split).
@@ -510,35 +519,36 @@ The helper function mayHaveStrongQuorum returns whether, given the already deliv
 The reBroadcast function broadcasts and remembers a message. It then sets a timeout to rebroadcast a subset of the messages in the current and previous round if the participant cannot terminate the phase in which it is.
 
 ```
-67:  reBroadcast(msg):
-68:    own_msgs = own_msgs ∪ {msg}
-69:    BEBroadcast(msg)
-70:    trigger(timeout_rebroadcast)
-71:    phase ← msg.phase
-72:    upon timeout_rebroadcast expires:
-73:      if phase = msg.phase AND msg.round = round AND msg.instance = instance 
+65:  reBroadcast(msg):
+66:    own_msgs = own_msgs ∪ {msg}
+67:    BEBroadcast(msg)
+68:    trigger(timeout_rebroadcast)
+69:    phase ← msg.phase
+70:    upon timeout_rebroadcast expires:
+71:      if phase = msg.phase AND msg.round = round AND msg.instance = instance 
            // Stuck, need to rebroadcast
-74:        switch (msg.phase) {
-75:          case DECIDE:
-76:            BEBroadcast(m ∈ own_msgs: m.round=0 AND m.type=DECIDE) // only rebroadcast DECIDE
-77:            break  // Exit, no cascading
-78:          case COMMIT:
-79:            BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=COMMIT) 
+72:        switch (msg.phase) {
+73:          case DECIDE:
+74:            BEBroadcast(m ∈ own_msgs: m.round=0 AND m.type=DECIDE) // only rebroadcast DECIDE
+75:            break  // Exit, no cascading
+76:          case COMMIT:
+77:            BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=COMMIT) 
                // Cascade to broadcast PREPARE, CONVERGE
-80:          case PREPARE:
-81:            BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=PREPARE) 
+78:          case PREPARE:
+79:            BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=PREPARE) 
                // Cascade to broadcast CONVERGE
-82:          default: // CONVERGE
-83:            if msg.round > 0:
-84:              BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=CONVERGE)
-85:              BEBroadcast(m ∈ own_msgs: m.round=msg.round-1 AND m.type=COMMIT)
-86:              BEBroadcast(m ∈ own_msgs: m.round=msg.round-1 AND m.type=PREPARE)
-87:              break
-88:        }
+80:          default: // CONVERGE
+81:            BEBroadcast(m ∈ own_msgs: m.round=0 AND m.type=QUALITY)
+82:            if msg.round > 0:
+83:              BEBroadcast(m ∈ own_msgs: m.round=msg.round AND m.type=CONVERGE)
+84:              BEBroadcast(m ∈ own_msgs: m.round=msg.round-1 AND m.type=COMMIT)
+85:              BEBroadcast(m ∈ own_msgs: m.round=msg.round-1 AND m.type=PREPARE)
+86:              break
+87:        }
            // Increase and trigger timeout_rebroadcast again.
            // The amount to increase is at the discretion of the participant.
-89:        timeout_rebroadcast = timeout_rebroadcast + 1
-90:        trigger(timeout_rebroadcast) 
+88:        timeout_rebroadcast = timeout_rebroadcast + 1
+89:        trigger(timeout_rebroadcast) 
 ```
 
 A participant may skip to a subsequent round upon receiving sufficient messages to demonstrate that a strong quorum of other participants have reached that round.
@@ -546,45 +556,45 @@ A participant may skip to a subsequent round upon receiving sufficient messages 
 In order to avoid unbounded accumulation of state, some messages from some future rounds are immediately dropped.
 
 ```
-100:  upon reception of a valid msg for this instance: 
-101:    if (msg.round > round + max_lookahead_rounds) AND msg.phase = COMMIT AND msg.value = 丄  
-102:      return  // Drop message
-103:    deliver(msg)  // Otherwise make the message available to the main algorithm
-104:    if (msg' ← shouldJump(round, phase) s.t. msg' != nil)
+ 90:  upon reception of a valid msg for this instance: 
+ 91:    if (msg.round > round + max_lookahead_rounds) AND msg.phase = COMMIT AND msg.value = 丄  
+ 92:      return  // Drop message
+ 93:    deliver(msg)  // Otherwise make the message available to the main algorithm
+ 94:    if (msg' ← shouldJump(round, phase) s.t. msg' != nil)
           // The msg' is a CONVERGE for round
-105:      round ← msg'.round
-106:      timeout ← 2 * Δ * pow(BackOffExponent, round)
-107:      timeout_rebroadcast ← timeout + 1 // Arbitrary increment
-108:      if msg'.evidence.phase = PREPARE: // Evidence is strong quorum of either PREPAREs of COMMITs for 丄
-109:        C ← C ∪ {msg'.value}       // Add to candidate values if not there
-110:        proposal ← msg'.value     // Sway local proposal to possibly decided value
+ 95:      round ← msg'.round
+ 96:      timeout ← 2 * Δ * pow(BackOffExponent, round)
+ 97:      timeout_rebroadcast ← timeout + 1 // Arbitrary increment
+ 98:      if msg'.evidence.phase = PREPARE: // Evidence is strong quorum of either PREPAREs of COMMITs for 丄
+ 99:        C ← C ∪ {msg'.value}       // Add to candidate values if not there
+100:        proposal ← msg'.value     // Sway local proposal to possibly decided value
           // Inherit evidence for the value from CONVERGE message 
-111:      evidence ← msg'.evidence   
-112:      go to line 21  // Start new round>0 by jumping forward
+101:      evidence ← msg'.evidence   
+102:      go to line 19  // Start new round>0 by jumping forward
 
-113:  shouldJump(round, phase): 
-114:    if phase = DECIDE:
-115:      return nil
-116:    if (∃ msg' st. msg'.phase = CONVERGE // There must be a CONVERGE for the new round
+103:  shouldJump(round, phase): 
+104:    if phase = DECIDE:
+105:      return nil
+106:    if (∃ msg' st. msg'.phase = CONVERGE // There must be a CONVERGE for the new round
             AND msg'.round > round          // Round must be greater
             AND ∃ M s.t. M is clean and valid and contains a weak quorum of PREPAREs for msg'.round)
-117:      return msg'
-118:    return nil
+107:      return msg'
+108:    return nil
 ```
 
 The parameter `max_lookahead_rounds` may be set at the discretion of an implementation. 
 
-Note that the selection of the longest prefix in line 18 does not need access to the tipsets' EC weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or vice-versa (since the adversary controls < ⅓ of the QAP). As a result, selecting the longest prefix is as simple as selecting the longest chain, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
+Note that the selection of the longest prefix in line 16 does not need access to the tipsets' EC weights, as only prefixes that extend each other can gather a strong quorum in QUALITY. In other words: if there are two tipsets $t_1, t_2$ that gather a strong quorum of QUALITY, then either the corresponding chain that has $t_1$ as head tipset is a prefix of the analogous chain that has $t_2$ as head, or vice-versa (since the adversary controls < ⅓ of the QAP). As a result, selecting the longest prefix is as simple as selecting the longest chain, while ensuring all proposed prefixes that gather a strong quorum in QUALITY extend each other as a sanity check.
 
-Implementations may optimise this algorithm to treat the reception of an aggregated signature over some (MsgType, Instance, Round, Value) as evidence of a message as if it had received the same tuple of values directly from each participant in the aggregate. This may be used to effectively skip a partially-complete phase. In the particular case of a DECIDE message, which carries evidence of a strong quorum of COMMITs for the same round and value, a participant immediately sends its own DECIDE for the same value (copying the evidence) and exits the loop at line 11.
+Implementations may optimise this algorithm to treat the reception of an aggregated signature over some (MsgType, Instance, Round, Value) as evidence of a message as if it had received the same tuple of values directly from each participant in the aggregate. This may be used to effectively skip a partially-complete phase. In the particular case of a DECIDE message, which carries evidence of a strong quorum of COMMITs for the same round and value, a participant immediately sends its own DECIDE for the same value (copying the evidence) and exits the loop at line 10.
 
-Also, the set C of candidate values that the participant contributes to deciding is restricted to only values that either (i) pass the QUALITY phase or (ii) may have been decided by other participants.
+Also, the set C of candidate values that the participant contributes to deciding is restricted to only values that (i) pass the QUALITY phase, (ii) result in strong quorum via late-arriving QUALITY messages, or (iii) may have been decided by other participants.
 
 When a participant is in receipt of multiple messages at once (such as when starting an instance with queued messages), a decision to jump ahead rounds should be taken only after processing all available messages. This will enable the participant to contribute to a decision other than the base chain.
 
 #### Valid messages and evidence
 
-The $\texttt{Valid}()$ predicate (referred to in lines 15, 25, 33, 41, 56, 58, 62, 100 and 116) is defined below.
+The $\texttt{Valid}()$ predicate (referred to in lines 14, 22, 30, 38, 53, 55, 56, 58, 62, 90 and 106) is defined below.
 ```
 Valid(m):                                     | For a message m to be valid,
   if m.signature does not verify              |   m must be properly signed.
@@ -838,7 +848,7 @@ The `ECTipset` contains 4 values:
 1. The epoch.
 2. The tipset key itself.
 3. A CID of the power table.
-4. The root of the commitements merkle tree.
+4. The root of the commitments merkle tree.
 
 The epoch is included directly in the `ECTipset` object itself to support proofs of the form "event X happened before/after/at epoch Y", common in cross-chain interactions.
 
@@ -848,7 +858,7 @@ A blake2b hash of the power table is included to aid in syncing the F3 chain. In
 
 Finally, the structure includes the root hash of a commitments Merkle tree. This tree is _empty_ at the moment but will eventually include:
 
-1. Commitements to snark-friendly representations of the power table.
+1. Commitments to snark-friendly representations of the power table.
 2. Events, likely indexed by emitter (useful for cross-chain messaging).
 
 And probably more. Importantly, the network can easily commit to additional values here without altering the `ECTipset` structure (and potentially breaking bridges).
@@ -888,7 +898,7 @@ However, note that:
 
 ECTipsets are encoded (for signing) as:
 
-1. Two fixed-sized values first: epoch (8 bytes) and the commitements root (32 bytes). That way, EVM smart contracts can extract these values at fixed offsets without any parsing.
+1. Two fixed-sized values first: epoch (8 bytes) and the commitments root (32 bytes). That way, EVM smart contracts can extract these values at fixed offsets without any parsing.
 2. Two "variable length" (although they'll be fixed-sized in practice) values: the tipset CID and the power table CID. Cross-chain bridges should generally ignore these values.
 
 Additionally, the epoch comes _before_ the commitments as it lets the bridge arrange for padding such that both the epoch and the commitments root hash are 32-byte aligned.
@@ -973,13 +983,13 @@ This FIP requires a network upgrade to take effect since it changes the EC fork 
          - Participants holding <⅓ QAP keep sending messages for future rounds/instances (as they do not require evidence), intending to flood memory.
            - EB: the system can handle buffering a large load of future messages.
        - Catch up within instance:
-         - Three partitions, P, Q and F, where F are Byzantine and such that QAP(P \cup F)>2/3. No synchrony initially between P and Q (and messages are dropped). F participants sending messages only to P, but F does not help P terminate. Then F halts, and synchrony is restored between P and Q.
+         - Three partitions, P, Q and F, where F are Byzantine and such that QAP(P \cup F)>⅔. No synchrony initially between P and Q (and messages are dropped). F participants sending messages only to P, but F does not help P terminate. Then F halts, and synchrony is restored between P and Q.
            - EB: Q is able to catch up to the round where P is, thanks to message rebroadcast, and termination occurs.
        - No catch up on decision:
          - Three partitions, P, Q and F, where F are Byzantine. P and Q start synchronized and with the same chain (should decide in 1st round), but F sends a CONVERGE for round 2 to P and Q before P and Q terminate round 1.
            - EB: P and Q do not jump to round 2, instead deciding in round 1.
        - Catch up across instances:
-         - Three partitions, P, Q and F, where F are Byzantine and such that QAP(P \cup F)>2/3. No synchrony initially P and Q have no synchrony (and messages are dropped). Participants in F sending messages only to P, until P decides. Then F halts, and synchrony is restored between P and Q.
+         - Three partitions, P, Q and F, where F are Byzantine and such that QAP(P \cup F)>⅔. No synchrony initially P and Q have no synchrony (and messages are dropped). Participants in F sending messages only to P, until P decides. Then F halts, and synchrony is restored between P and Q.
            - EB: Q is able to request and receive the finality certificate from P, terminating immediately.
        - Participants proposing chains that do not extend base chain (EB for all these is that these messages are discarded as the value is invalid):
          - Superset (chain proposed includes the $baseChain$ head tipset but not exactly the head tipset)


### PR DESCRIPTION
Further to discussion linked below, update FIP to accept QUALITY messages in any round or phase, and include them in the set of rebroadcat messages.

See:
 * filecoin-project/FIPs#809 (comment)
 * https://github.com/filecoin-project/go-f3/issues/624
