### PR TITLE
Update F(E)VM FIP Status

### DIFF
--- a/FIPS/fip-0030.md
+++ b/FIPS/fip-0030.md
@@ -351,7 +351,7 @@ This approach has a few practical implications:
 
 Native user-defined actors are actors written specifically for the FVM runtime.
 Such actors will not be deployable for the time-being due to unresolved security
-considerations, but they will likely be supported eventually.
+considerations.
 
 Users can _technically_ write native user-defined actors in any programming
 language that compiles to Wasm. However, language-specific overheads (e.g.
@@ -436,8 +436,8 @@ pub struct ActorState {
 
 #### Actor deployment
 
-For the time-being, all wasm-based actors are built-in and user's cannot deploy custom
-Wasm actors to Filecoin mainnet. New wasm-based actors are deployed during network
+For the time-being, all Wasm-based actors are built-in and users cannot deploy custom
+Wasm actors to Filecoin mainnet. New Wasm-based actors are deployed during network
 upgrades.
 
 Users can deploy custom EVM-based smart contracts using FEVM (see [FIP-0054](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0054.md)).

--- a/FIPS/fip-0030.md
+++ b/FIPS/fip-0030.md
@@ -440,7 +440,7 @@ For the time-being, all wasm-based actors are built-in and user's cannot deploy 
 Wasm actors to Filecoin mainnet. New wasm-based actors are deployed during network
 upgrades.
 
-Users can deploy custom EVM-based smart contracts using FEVM (see [FIP-0054](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0042.md)).
+Users can deploy custom EVM-based smart contracts using FEVM (see [FIP-0054](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0054.md)).
 
 #### Actor message dispatch
 

--- a/FIPS/fip-0030.md
+++ b/FIPS/fip-0030.md
@@ -3,7 +3,7 @@ fip: "0030"
 title: Introducing the Filecoin Virtual Machine (FVM)
 authors: Raúl Kripalani (@raulk), Steven Allen (@stebalien)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/287
-status: Draft
+status: Final
 type: Technical Core
 category: Core
 created: 2022-01-26
@@ -94,7 +94,7 @@ FIP, and will be addressed by subsequent proposals.
 ## Abstract
 
 We specify the Filecoin Virtual Machine (FVM), an IPLD-ready Wasm-based
-execution layer capable of running arbitrary user-provided code. The FVM
+execution layer capable of running arbitrary code. The FVM
 replaces the [existing non-programmable execution layer][Specs/Legacy-VM], now
 termed _Legacy VM_.
 
@@ -284,10 +284,6 @@ The contract consists of:
    through some governance process, in order to reduce actor bytecode size (e.g.
    FVM SDKs, IPLD codecs, etc).
 
-Because this contract may change over time, user-deployed actors may specify an
-IC version at [`InitActor#InstallActor` time](#actor-deployment). The strategy
-for deprecating IC versions over time has not been yet determined.
-
 #### Syscalls
 
 Syscalls are functions made available to the actor as Wasm imports, allowing it
@@ -354,6 +350,8 @@ This approach has a few practical implications:
 ##### Native user-defined actors
 
 Native user-defined actors are actors written specifically for the FVM runtime.
+Such actors will not be deployable for the time-being due to unresolved security
+considerations, but they will likely be supported eventually.
 
 Users can _technically_ write native user-defined actors in any programming
 language that compiles to Wasm. However, language-specific overheads (e.g.
@@ -438,42 +436,11 @@ pub struct ActorState {
 
 #### Actor deployment
 
-The current `InitActor` (`f00`) will be extended with a (`InstallActor`) method
-taking a single input parameter: the actor's Wasm bytecode. As mentioned above,
-DAG representation format is to be defined. The actor's Wasm bytecode must
-specify the version of the Invocation Container the bytecode requires, inside a
-reserved exported global.
+For the time-being, all wasm-based actors are built-in and user's cannot deploy custom
+Wasm actors to Filecoin mainnet. New wasm-based actors are deployed during network
+upgrades.
 
-The state object of the `InitActor` will be extended with an `ActorRegistry`
-HAMT of `CID => ActorSpec`, where `ActorSpec` is:
-
-```rust
-/// A simple actor specification/metadata structure, to be extended with
-/// additional metadata in the future.
-struct ActorSpec {
-  /// The version of the invocation container.
-  version: int, 
-}
-```
-
-The logic of `InitActor#LoadActor` is as follows.
-
-1. Validate the Wasm bytecode.
-    - Perform syntax validation and structural validation, [as per standard](https://webassembly.github.io/spec/core/valid/index.html).
-    - No floating point instructions.
-2. Multihash the bytecode and calculate the code CID.
-3. Check if the code CID is already registered in the `ActorRegistry`.
-4. If yes, charge gas for the above operations and return the existing CID.
-5. Insert an entry in the `ActorRegistry`, binding the bytecode CID with the
-   actor spec.
-6. Return the CID, and charge the cost of the above operations, and potentially
-   a price for rent/storage.
-
-At this point, the actor can be instantiated many times through the standard
-`InitActor#Exec` method. Parameters provided will be passed through to the
-actor's constructor (currently identified by `method_number=1`). This includes
-byte streams corresponding to deployables for foreign actors (e.g. EVM
-bytecode).
+Users can deploy custom EVM-based smart contracts using FEVM (see [FIP-0054](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0042.md)).
 
 #### Actor message dispatch
 

--- a/FIPS/fip-0031.md
+++ b/FIPS/fip-0031.md
@@ -3,7 +3,7 @@ fip: "0031"
 title: Atomic switch to non-programmable FVM
 authors: Raúl Kripalani (@raulk), Steven Allen (@stebalien)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/296
-status: Draft
+status: Final
 type: Technical Core
 category: Core
 created: 2022-02-03

--- a/FIPS/fip-0032.md
+++ b/FIPS/fip-0032.md
@@ -3,7 +3,7 @@ fip: "0032"
 title: Gas accounting model adjustment for non-programmable FVM
 author: Raúl Kripalani (@raulkr), Steven Allen (@stebalien), Jakub Sztandera (@Kubuxu)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/316
-status: Draft
+status: Final
 type: Technical
 category: Core
 created: 2022-03-08

--- a/FIPS/fip-0037.md
+++ b/FIPS/fip-0037.md
@@ -3,7 +3,7 @@ fip: "0037"
 title: Gas model adjustment for for user programmability
 author: Raúl Kripalani (@raulk), Steven Allen (@stebalien)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/316
-status: Draft
+status: Withdrawn
 type: Technical
 category: Core
 created: 2022-03-09

--- a/FIPS/fip-0054.md
+++ b/FIPS/fip-0054.md
@@ -3,7 +3,7 @@ fip: "0054"
 title: Filecoin EVM runtime (FEVM)
 author: Raúl Kripalani (@raulk), Steven Allen (@stebalien)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/592
-status: Accepted
+status: Final
 type: Technical Core
 category: Core
 created: 2022-12-02

--- a/FIPS/fip-0057.md
+++ b/FIPS/fip-0057.md
@@ -3,7 +3,7 @@ fip: "0057"
 title: Update gas charging schedule and system limits for FEVM
 author: Steven Allen (@stebalien), Raúl Kripalani (@raulk), Akosh Farkash (@aakoshh), Jakub Sztandera  (@Kubuxu)
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/588
-status: Accepted
+status: Final
 type: Technical Core
 category (*only required for Standard Track): Core
 created: 2022-12-12

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0034](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0034.md) | Fix pre-commit deposit independent of sector content | FIP | @anorth, @Kubuxu | Final |
 | [0035](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0035.md) | Support actors as built-in storage market clients | FIP | @anorth | Withdrawn |
 | [0036](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0036.md) | Introducing a Sector Duration Multiple for Longer Term Sector Commitment | FIP | @AxCortesCubero, @jbenet, @misilva73, @momack2, @tmellan, @vkalghatgi, @zixuanzh | Rejected |
-| [0037](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0037.md) | Gas model adjustment for user programmability | FIP | @raulk, @stebalien | Draft |
+| [0037](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0037.md) | Gas model adjustment for user programmability | FIP | @raulk, @stebalien | Withdrawn |
 | [0038](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0038.md) | Indexer Protocol for Filecoin Content Discovery | FRC | @willscott, @gammazero, @honghaoq | Draft |
 | [0039](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0039.md) | Filecoin Message Replay Protection | FIP | @q9f | Draft |
 | [0040](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0040.md) | Boost - Filecoin Storage Deals Market Protocol | FRC | @dirkmc, @nonsense, @jacobheun, @brendalee | Draft |


### PR DESCRIPTION
1. Move FIP-0030 to Final (already marked as Final in the README). I've also updated the text to btter reflect what was actually implemented.
2. Move FIP-0031 to Final (already marked as Final in the README).
3. Move FIP-0032 to Final (already marked as Final in the README).
4. Withdraw FIP-0037 (this FIP was replaced by FIP-0054 and FIP-0057).
5. Move FIP-0054 and FIP-0057 to Final (already marked as Final in the README).