### PR TITLE
fix(docs): correct author field in FIP-0095 YAML frontmatter

### DIFF
--- a/FIPS/fip-0095.md
+++ b/FIPS/fip-0095.md
@@ -1,7 +1,7 @@
 ---
 fip: "0095"
 title: Add FEVM precompile to fetch beacon digest from chain history 
-author: @ZenGround0, @anorth
+author: "@ZenGround0, @anorth"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/1051
 status: Last Call
 type: Technical Core


### PR DESCRIPTION
When trying to view [FIP-0095](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0095.md), a YAML parsing error occurs in the GitHub UI due to the `@` symbols in the author field:

<img width="1148" alt="Screenshot 2024-10-01 at 08 39 52" src="https://github.com/user-attachments/assets/8e1096a2-4a92-44f9-9cf4-c314707a7a29">

This PR adds quotation marks around the author field in the YAML frontmatter, to get proper rendering of the FIP in the GitHub interface. [With this fix](https://github.com/filecoin-project/FIPs/blob/phi/fix-yaml-0095/FIPS/fip-0095.md), it now looks like:

<img width="1105" alt="Screenshot 2024-10-01 at 08 43 14" src="https://github.com/user-attachments/assets/bbc7c944-eaea-4846-97be-f300e7e5feed">
