### PR TITLE
chore: update FIP0097 status to Accepted

### DIFF
--- a/FIPS/fip-0097.md
+++ b/FIPS/fip-0097.md
@@ -3,7 +3,7 @@ fip: "0097"
 title: Add Support for EIP-1153 (Transient Storage) in the FEVM  
 author: Michael Seiler (@snissn), Steven Allen (@stebalien)  
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/855
-status: Last Call
+status: Accepted
 type: Technical  
 category: Core  
 created: 2024-11-19  

--- a/README.md
+++ b/README.md
@@ -132,5 +132,5 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0094](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0094.md) | Add Support for EIP-5656 (MCOPY Opcode) in the FEVM | FIP | Michael Seiler (@snissn), Raúl Kripalani (@raulk), Steven Allen (@stebalien) | Final |
 | [0095](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0095.md) | Add FEVM precompile to fetch beacon digest from chain history | FIP | @ZenGround0, Alex North (@anorth) | Final |
 | [0096](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0096.md) | Convert fundraising remainder address(es) to keyless account actor(s) | FIP | @Fatman13 | Draft |
-| [0097](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0097.md) | Add Support for EIP-1153 (Transient Storage) in the FEVM | FIP | Michael Seiler (@snissn), Steven Allen (@stebalien) | Last Call |
+| [0097](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0097.md) | Add Support for EIP-1153 (Transient Storage) in the FEVM | FIP | Michael Seiler (@snissn), Steven Allen (@stebalien) | Accepted |
 | [0098](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0098.md) | Simplify termination fee calculation to a fixed percentage of initial pledge | FIP | Jonathan Schwartz (@Schwartz10), Alex North (@anorth), Jim Pick (@jimpick) | Draft |


### PR DESCRIPTION
As per message by @luckyparadise [here](https://filecoinproject.slack.com/archives/C01EU76LPCJ/p1736174473228969). FIP0097 has passed out of Last Call and is now accepted.

This PR reflects that change.