### PR TITLE
Move FIP-0100 to Last Call

### DIFF
--- a/FIPS/fip-0100.md
+++ b/FIPS/fip-0100.md
@@ -3,7 +3,7 @@ fip: "0100"
 title: Removing Batch Balancer, Replacing It With a Per-sector Fee and Removing Gas-limited Constraints
 author: irene (@irenegia), AX (@AxCortesCubero), rvagg (@rvagg), molly (@momack2), kiran (@kkarrancsu)
 Discussions-to: https://github.com/filecoin-project/FIPs/discussions/1092 and https://github.com/filecoin-project/FIPs/discussions/1105
-status: Draft
+status: Last Call
 type: Technical
 category: Core
 Created: 2025-02-04


### PR DESCRIPTION
This is a proposal to move FIP-0100 to last call in order to make the nv25 finalization and code freeze timeline. 
Last call would last for the normal 2-week period from Feb 14-Feb 28th.