### PR TITLE
Add quality phase timeout multiplier for improved proposal propagation

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -418,7 +418,7 @@ GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
 // Committee is implicitly used to calculate quora.
 
 01:  round ← 0
-02:  proposal ← inputChain  // CHain that the participant locally believes should be decided.
+02:  proposal ← inputChain  // Chain that the participant locally believes should be decided.
 03:  timeout ← 2*Δ
 04:  timeout_rebroadcast ← timeout + 1 // Any value larger than timeout, at implementation discretion.
 05:  value ← proposal // Used to communicate the voted value to others (proposal or 丄)
@@ -430,10 +430,13 @@ GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
 10:  while (phase != DECIDE)  {
        // QUALTIY
 11:    if (round = 0)
-12:      BEBroadcast <QUALITY, value>; trigger (timeout)
+         // The timeout for QUALITY may set to be longer than the other phases using a 
+         // multiplier. This is to increase the chances of collecting a strong quorum 
+         // of QUALITY messages and reduce potential hindrance on successive phases. 
+12:      BEBroadcast <QUALITY, value>; trigger (timeout * quality_timeout_multiplier)
 13:      phase ← QUALITY
 14:      collect a clean set M of valid QUALITY messages from this instance 
-           until HasStrongQuorum(proposal, M) OR timeout expires
+           until HasStrongQuorum(proposal, M) OR timeout * quality_timeout_multiplier expires
 15:      C ← C ∪ {prefix : IsPrefix(prefix,proposal) and HasStrongQuorum(prefix,M)}
 16:      proposal ← longest prefix ∈ C  // At least baseChain, or something longer
 17:      value ← proposal
@@ -687,6 +690,7 @@ The synchronization of participants within an instance is achieved with a timeou
 
 As an optimization, participants may finish a phase once its execution is determined by the received messages, without waiting for the timeout. For example, if a participant receives QUALITY messages from all participants, it can proceed to the next phase without waiting for the timeout. More generally, if the remaining valid messages to be received cannot change the execution of the phase, regardless of the values contained in the messages, then a participant may continue to the next phase.
 
+In the `QUALITY` phase, a $\Delta$ multiplier is applied to facilitate better propagation of proposals from all honest participants at the start of a GPBFT instance. This adjustment is because inadequate or delayed proposal propagation during this phase can significantly increase the likelihood of requiring additional rounds, thereby raising the chances of defaulting to the base decision. This issue is exacerbated in large networks with intermittent connectivity or message delivery throttling, leading to longer finalization times, which are undesirable.
 
 ### Synchronization of Participants across Instances
 


### PR DESCRIPTION
To aid QUALITY proposal propagation, introduce a QUALITY-phase delta multiplier that increases the timeout for this phase only. This is to reduce the adverse effects of poor QUALITY proposal propagation, which include the need for additional rounds and higher likelihood of a decision on base.

The rationale above is observed and documented as part of mainnet passive testing in nv24, where longer delta resulted in higher progress velocity and fewer non-base decisions.

See:
 * https://github.com/filecoin-project/go-f3/issues/785

Part of:
 * https://github.com/filecoin-project/go-f3/issues/838
