### PR TITLE
Add side-channel EC chain propagation to FIP-0086

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -334,6 +334,18 @@ type PowerTableEntry struct {
   Power BigInt
   Key BLSPublicKey
 }
+
+// PartialGossiPBFTMessage represents a GossiPBFT message with a zeroed out vote
+// value, and a precomputed MerkelizeValue of the original vote value.
+//
+// This key allows verification of the GossiPBFTMessage signature without needing
+// the specific chain tipsets represented by its Vote.Value.
+type PartialGossiPBFTMessage struct {
+  *GossiPBFTMessage
+
+  // VoteValueKey is the precomputed MerkelizeValue of the GossiPBFTMessage Payload.Value.
+  VoteValueKey []byte
+}
 ```
 
 Values for phase numbers are:
@@ -806,6 +818,77 @@ The finality certificates can be submitted (in order) to a smart contract. The s
 A smart contract will never accept a finality certificate earlier than those it has already validated. It will be safe from long-range attacks as long as it is kept reasonably up-to-date with finality decisions as F3 progresses. Like a new client, a new smart contract must be carefully initialized to ensure it follows the right certificate chain.
 
 Only one such smart contract is needed on a single blockchain execution environment, which can provide the resulting final tipset information to others.
+
+### Side-channel EC Chain Propagation
+In GPBFT protocol, each message contains at least one payload, with each payload holding a value that represents the EC chain being decided. This value makes up a large portion of the total message size with a high rate of duplicities throughout a typical instance progression. To significantly reduce the size of GPBFT messages and the bandwidth required for their propagation, a side channel is introduced to separately propagate a mapping between a chain's `MerkelizeValue` and the actual Value itself. Instead of directly propagating full GPBFT messages, a partial GPBFT message is propagated. This partial message includes all components except the EC chain value being decided, along with the `MerkelizeValue` corresponding to that chain.
+
+This approach reduces the size of GPBFT messages and allows for deduplication in EC chain value propagation. The use of `MerkelizeValue` ensures that the signature of partial messages remains verifiable without needing the actual chain being decided. Most validation processes can still be performed, except for checking the base tipset relative to the head of the previously finalized chain.
+
+Implementers need to buffer partial messages with unknown `MerkelizeValue` as well as discovered `MerkelizeValue`s with their unseen corresponding partial messages. Security recommendations include adjusting the priority of buffered data based on the progress of GPBFT to ensure timely processing and validation with a bound buffer size. This adjustment helps maintain the integrity and efficiency of the protocol while managing the propagation of EC chain values effectively.
+
+#### Partial Message Signature Verification
+
+The partial message signature verification process is the same as `GossiPBFT` message verification, except that the `MerkelizeValue` is used in place of computing it from the actual chain.
+
+#### Chain Exchange Protocol
+
+The chain exchange protocol facilitates the dissemination of EC chain values that are being decided among the participants.
+The chain exchange message format is as follows:
+
+```go
+type ChainExchangeMessage struct {
+  Instance  uint64      // ID of the GPBFT instance.
+  Chain     []ECTipset  // The vote value being decided.
+  Timestamp int64       // The timestamp at which the message was created.
+}
+```
+
+The instance ID identifies the GPBFT instance to which the chain value belongs. The chain value represents the EC chain being decided in that instance. The timestamp ensures message freshness and must be within `MaxTimestampAge` to be valid.
+
+The timestamp is adjusted to the current time, rounded down to the nearest multiple of the chain exchange `RebroadcastInterval`. This adjustment helps minimize the number of messages propagated across the network.
+
+The chain exchange protocol should ensure that the chain being decided is propagated to all participants within the $\Delta$-synchrony bound. Delays in propagation can lead to decisions defaulting to the base chain, but will not disrupt GPBFT progress since the base chain is known to all participants.
+
+Within each GPBFT instance, a chain broadcast is triggered by:
+1. **Phase Transition**: Immediately triggers a broadcast.
+2. **Periodic Rebroadcast**: Occurs every `RebroadcastInterval`.
+
+The broadcasted chain is selected based on:
+* The triggering event.
+* Previous chain broadcasts in the instance.
+
+This ensures the most informative chain is shared. Participants can infer all intermediate `MerkelizeValue`s from longer chains, making shorter chains redundant if they are prefixes of longer ones.
+
+Chain selection procedure is as follows:
+* If no prior broadcast exists, use the chain from the triggering event.
+* Otherwise, switch to the new chain only if it is not a prefix of the last broadcast chain.
+
+This logic results in the QUALITY phase proposal being broadcast until the participant is swayed.
+
+#### Partial Message Validation
+
+The validation of `PartialGossiPBFTMessage`s is the same as non-partial messages except for the following:
+* An empty `MerkelizeValue` indicates a zero-valued chain, i.e., bottom.
+* The `MerkelizeValue` is used in place of the actual chain value for signature verification.
+* The `MerkelizeValue` is used in place of the actual chain value for justification phase validation relative to Vote.
+* The `MerkelizeValue` is used in place of the actual chain value for justification signature verification.
+
+The above substitutions make it possible to partially validate the messages prior to buffering. To complete the validation upon discovering the chain that corresponds to a `MerkelizeValue`, the participant must:
+* Check that the EC Chain itself is structurally valid, e.g. order of tipset epochs, etc. 
+* Check that the EC Chain indeed corresponds to the `MerkelizeValue` in the partial message.
+* Check that the base tipset of the EC Chain being decided is the head of the previously finalized chain.
+
+Once the validation is complete, the message is passed to GPBFT.
+
+#### Buffering Recommendations
+
+Participants must buffer partial messages until the corresponding `MerkelizeValue` is identified. To prevent unbounded growth, the buffer should be bounded and prioritize messages based on GPBFT progress to ensure timely processing and validation.
+
+Buffering recommendations include:
+* Resolve partial messages with known `MerkelizeValue`s first.
+* Prioritize discovering `MerkelizeValue`s for pending partial messages.
+* Limit the number of concurrent instances buffered, considering GPBFT progress and committee lookback.
+* Implement a timeout mechanism to discard unresolved buffered partial messages after a certain period.
 
 ### Merkle Tree Format
 


### PR DESCRIPTION
Introduce a side-channel for efficient EC chain value propagation by using `MerkelizeValue` in GPBFT messages. Define the `PartialGossiPBFTMessage` structure to include precomputed `MerkelizeValue`, enabling signature verification without full chain tipsets.

Outline the chain exchange protocol and partial message validation process. Include buffering recommendations to manage partial messages and maintain protocol integrity.

See:
 * https://github.com/filecoin-project/go-f3/issues/792

Part of:
 * https://github.com/filecoin-project/go-f3/issues/838
