### PR TITLE
Address changes to FIP 98 while in last call

### DIFF
--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -126,7 +126,7 @@ In addition to the revised termination fee formulas, a few built-in actor method
 |--------------|-------------------|-------------|
 | `miner_power` | `miner_power() -> (QAPower, RawPower)` | Returns the miner's quality-adjusted and raw power |
 | `miner_initial_pledge` | `miner_initial_pledge() -> TokenAmount` | Returns the miner's total initial pledge amount |
-| `termination_fee_percentage` | `termination_fee_percentage() -> f64` | Returns the network's termination fee percentage (8.5%) |
+| `termination_fee_percentage` | `termination_fee_percentage() -> (num u32, denom u32)` | Returns the network's termination fee percentage  (8.5%) |
 | `max_termination_fee` | `max_termination_fee(initial_pledge: TokenAmount, power: QAPower) -> TokenAmount` | Returns the maximum termination fee calculation for a given initial pledge and power amount |
 
 ## Design Rationale

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -198,7 +198,7 @@ It is important that Storage Providers are incentivized to honor their commitmen
 
 The termination fee for sectors committed a long time ago will immediately and significantly decrease, but only to match the fee:pledge ratio of new sectors. This will increase the incentive for some SPs with high-pledge sectors to terminate and re-onboard to gain more power for the same amount of pledge (but more hardware).
 
-In contrast to the current system, the termination penalty for a sector will be constant regardless of its age. Currently the termination penalty starts low and increases with age up to a max. This presents a change in the incentive structure for short-term-view SPs.
+In contrast to the current system, the termination penalty for a sector will be constant regardless of its age (after the 140 day linear ramp-up). Currently the termination penalty starts low and increases with age up to a max. This presents a change in the incentive structure for short-term-view SPs.
 
 ## Product Considerations
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -25,7 +25,7 @@ The termination fee for any given sector is calculated as a fixed percentage of 
 
 Today, it is overly sophisticated and computationally expensive to compute termination fees for miner actors. As a result, DeFi applications that leverage miner actors must make major security and/or performance sacrifices in order to operate.
 
-This FIP addresses the issue by simplifying the calculation of the miner actor termination fee. The proposed new termination fee calculation uses a "percentage of pledge" strategy - where `termination fee = initial pledge * termination penalty %`. The proposed new termination penalty % is 8.5%. There are two special cases to consider where the termination fee must be tweaked to maintain current network conditions, which are addressed in the technical specification and design rationale.
+This FIP addresses the issue by simplifying the calculation of the miner actor termination fee. The proposed new termination fee calculation uses a "percentage of pledge" strategy - where `termination fee = initial pledge * termination penalty %`. The proposed new termination penalty % is 8.5%. There are three special cases to consider where the termination fee must be tweaked to maintain current network conditions, which are addressed in the technical specification and design rationale.
 
 As a result, DeFi applications on Filecoin can operate with significantly better performance, UX, and economic security. Additionally, Filecoin economics and code implementations will be significantly simplified, as well as state bloat removed.
 
@@ -39,14 +39,13 @@ Today, it is: (1) computationally expensive, (2) economically sophisticated, and
 
 The two primary motivations to this FIP proposal are:
 
-1. Enabling a more efficient termination penalty calculation such that termination penalties can be computed (or returned by an FEVM precompile) in an FEVM runtime. This is important because it enables FEVM protocols that use Miner Actors as collateral to operate with better economic security because they can precisely estimate the value of Miner Actor collateral on-chain. 
-2. Changing the formula for calculating termination penalties to be simpler to compute. This is important because it allows both Storage Providers and FEVM actors that use Miner Actors as collateral to easily predict their economic riskiness. 
+1. Enabling a more efficient termination penalty calculation such that termination penalties can be computed (or returned by an FEVM precompile) in an FEVM runtime. This is important because it enables FEVM protocols that use Miner Actors as collateral to operate with better economic security because they can precisely estimate the value of Miner Actor collateral on-chain.
+2. Changing the formula for calculating termination penalties to be simpler to compute. This is important because it allows both Storage Providers and FEVM actors that use Miner Actors as collateral to easily predict their economic riskiness.
 
 Additionally, this FIP intends to maintain the original motivations behind termination fees:
 
 1. Create a more resilient storage network for storage clients, such that if an SP stores a client's data, the client isn't just suddenly left out to dry and their data lost.
 2. Network stability - disincentivize large power swings caused by rapid on/off-boarding of power and pledge.
-
 
 ## Specification
 
@@ -54,12 +53,12 @@ Additionally, this FIP intends to maintain the original motivations behind termi
 
 Three new constants should be created, and an existing one will be reused. Each is fixed for the whole network and configurable by future governance:
 
-| Constant | Description | Amount |
-|----------|-------------|--------|
-| `TERM_FEE_PLEDGE_MULTIPLE` | This constant will be used to compute termination fees in the base case by multiplying against initial pledge. | 0.085x initial pledge |
-| `TERM_FEE_MAX_FAULT_FEE_MULTIPLE` | This constant will be used to compute termination fees when the termination fee of a sector is less than the fault fee for the same sector. | 1.05x |
-| `TERM_FEE_MIN_PLEDGE_MULTIPLE` | This constant will ensure the termination fee for young sectors is not arbitrarily low. | 0.02x initial pledge |
-| `TERMINATION_LIFETIME_CAP` | _(Existing constant)_ This constant maintains the linear increase in termination fee for young sectors. | 140 days |
+| Constant                          | Description                                                                                                                                 | Amount                |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `TERM_FEE_PLEDGE_MULTIPLE`        | This constant will be used to compute termination fees in the base case by multiplying against initial pledge.                              | 0.085x initial pledge |
+| `TERM_FEE_MAX_FAULT_FEE_MULTIPLE` | This constant will be used to compute termination fees when the termination fee of a sector is less than the fault fee for the same sector. | 1.05x                 |
+| `TERM_FEE_MIN_PLEDGE_MULTIPLE`    | This constant will ensure the termination fee for young sectors is not arbitrarily low.                                                     | 0.02x initial pledge  |
+| `TERMINATION_LIFETIME_CAP`        | _(Existing constant)_ This constant maintains the linear increase in termination fee for young sectors.                                     | 140 days              |
 
 Refactor the [`pledge_penalty_for_termination`](https://github.com/filecoin-project/builtin-actors/blob/12d9af8a00d0909598c67e1a18dc1577e0833137/actors/miner/src/monies.rs#L179) method to:
 
@@ -93,16 +92,16 @@ termination_fee = max(base_termination_fee, minimum_fee)
 
 This ensures that:
 
-* The fee is never less than 2% of the initial pledge
-* The fee is never less than 105% of the fault fee
-* For sectors younger than 140 days, the fee scales linearly with age (subject to the bounds)
-* For sectors older than 140 days, the fee is 8.5% of the initial pledge (subject to the bounds)
+- The fee is never less than 2% of the initial pledge
+- The fee is never less than 105% of the fault fee
+- For sectors younger than 140 days, the fee scales linearly with age (subject to the bounds)
+- For sectors older than 140 days, the fee is 8.5% of the initial pledge (subject to the bounds)
 
 The complete formula in one expression is:
 
 ```
 termination fee = max(
-  MIN_TERMINATION_FEE * initial_pledge, 
+  MIN_TERMINATION_FEE * initial_pledge,
   max(
     TERM_PENALTY_PLEDGE_PERCENTAGE * initial_pledge * min(1, sector_age_days / TERMINATION_LIFETIME_CAP),
     FAULT_FEE_MULTIPLE * sector_fault_fee
@@ -127,11 +126,7 @@ In addition to the revised termination fee formulas, a few built-in actor method
 |--------------|-------------------|-------------|
 | `miner_power` | `miner_power(miner_id: ActorID) -> (QAPower, RawPower)` | Returns the miner's quality-adjusted and raw power |
 | `miner_initial_pledge` | `miner_initial_pledge(miner_id: ActorID) -> TokenAmount` | Returns the miner's total initial pledge amount |
-| `network_projection` | `network_projection(projection_period_start: ChainEpoch, projection_period_end: ChainEpoch) -> (Power, TokenAmount)` | Returns the network's projected power and reward for the given projection period |
 | `termination_fee_percentage` | `termination_fee_percentage() -> f64` | Returns the network's termination fee percentage (8.5%) |
-  
-(the below 2 methods could also be built as a FEVM native oracle contract instead of as a built-in actor method with exports to access from FEVM):
-| `single_fault_fee` | `single_fault_fee(qa_power: QAPower) -> TokenAmount` | Returns the fault fee calculation for a given amount of QA power |
 | `max_termination_fee` | `max_termination_fee(initial_pledge: TokenAmount, power: QAPower) -> TokenAmount` | Returns the maximum termination fee calculation for a given initial pledge and power amount |
 
 ## Design Rationale
@@ -142,7 +137,7 @@ There are a few different approaches one could take to accomplish the same end r
 
 1. Use a "multiple of daily rewards" approach, which computes a termination fee based on a % or multiple of expected daily rewards for a period of time based on the current block rewards
    - Problems:
-     - Less predictable - in order to estimate the collateral value of a Miner Actor, the protocol needs to be able to estimate what the future daily block reward will be for the network. If the network grows quickly and unexpectedly, this could dangerously impact a DeFi protocol as the daily block rewards may increase due to increasing baseline, thus increasing the termination penalty and decreasing the collateral value for a given Miner Actor. 
+     - Less predictable - in order to estimate the collateral value of a Miner Actor, the protocol needs to be able to estimate what the future daily block reward will be for the network. If the network grows quickly and unexpectedly, this could dangerously impact a DeFi protocol as the daily block rewards may increase due to increasing baseline, thus increasing the termination penalty and decreasing the collateral value for a given Miner Actor.
 2. Optimize data structures based on the current methodology to make an aggregate termination sector method feasible in constant time lookup
    - Problems:
      - Unsure if this is technically feasible, and if so, most likely a lot of sophistication and ugly accounting
@@ -150,10 +145,10 @@ There are a few different approaches one could take to accomplish the same end r
 
 The %-of-pledge method is:
 
- 1. simple to calculate
- 2. predictable
- 3. fixed while the sector's pledge is constant
- 4. will not decay towards zero as block rewards decline, thus more effectively protecting against churn
+1.  simple to calculate
+2.  predictable
+3.  fixed while the sector's pledge is constant
+4.  will not decay towards zero as block rewards decline, thus more effectively protecting against churn
 
 Additionally, there are two other considerations to make with respect to the design rational:
 
@@ -173,6 +168,7 @@ This FIP requires a network upgrade because it intends to change built-in actor 
 <!--Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.-->
 
 - When terminating a single sector:
+
   - Not considering fault fees, for a sector where its age >= `TERMINATION_LIFETIME_CAP`, termination fee should equal `TERM_FEE_PLEDGE_MULTIPLE * initial pledge`
   - Not considering fault fees, for a sector where its age < `TERMINATION_LIFETIME_CAP`, termination fee should equal `TERM_FEE_PLEDGE_MULTIPLE * of initial pledge * sector age in days / TERMINATION_LIFETIME_CAP`
   - Considering fault fees, for a sector with a termination fee that is less than the associated sector's fault fee, termination fee should equal `TERM_FEE_MAX_FAULT_FEE_MULTIPLE * fault fee`
@@ -192,7 +188,7 @@ The security concern with introducing this FIP is that Storage Providers will no
 3. It seems appropriate to charge an exit fee for breaking a commitment to the network, but we also do not want to charge a capture fee. Storage Providers who do not wish to use Filecoin anymore shouldn't have prohibitively high expenses for leaving the network early - ultimately for the network, burning some of this SPs tokens through sector terminations is better than 18 months of selling.
 4. As Filecoin matures, the average Storage Provider will likely be accepting paid deals in some form according to an SLA in addition to the SLA guaranteed by PoRep. These additional SLAs can/will enforce their own termination clauses, which should provide adequate motivation and verification to achieve a good experience for the average storage client.
 5. The 140 day linear termination fee increase is kept in tact to ensure no existing loan / collateral position in the Filecoin capital markets flips undercollateralized.
-6. There can be theoretical security issues when the termination fee is less than the fault fee for the same sector, however, the proposal here does not allow termination fees to drop below fault fees. 
+6. There can be theoretical security issues when the termination fee is less than the fault fee for the same sector, however, the proposal here does not allow termination fees to drop below fault fees.
 
 ## Incentive Considerations
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -196,7 +196,7 @@ The security concern with introducing this FIP is that Storage Providers will no
 
 It is important that Storage Providers are incentivized to honor their commitments to the network - this prevents major network volatility. It makes sense to maintain a disincentive for breaking commitments to the network, but this FIP doesn't change the incentive to provide useful storage to the network, it makes it somewhat easier.
 
-The termination fee for sectors committed a long time ago will immediately and significantly decrease, but only to match the fee:pledge ratio of new sectors. This will increase the incentive for some SPs with high-pledge sectors to terminate and re-onboard to gain more power for the same amount of pledge (but more hardware).
+The termination fee for sectors committed a long time ago will immediately and significantly decrease, but only to match the fee:pledge ratio of new sectors. This will increase the incentive for some SPs with high-pledge sectors to terminate and re-onboard to gain more power for the same amount of pledge (but more hardware). See [this discussion comment](https://github.com/filecoin-project/FIPs/discussions/1036#discussioncomment-10215706) for the latest data on live sector fee:pledge data from August, 2024.
 
 In contrast to the current system, the termination penalty for a sector will be constant regardless of its age (after the 140 day linear ramp-up). Currently the termination penalty starts low and increases with age up to a max. This presents a change in the incentive structure for short-term-view SPs.
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -64,16 +64,55 @@ Three new constants should be created, and an existing one will be reused. Each 
 Refactor the [`pledge_penalty_for_termination`](https://github.com/filecoin-project/builtin-actors/blob/12d9af8a00d0909598c67e1a18dc1577e0833137/actors/miner/src/monies.rs#L179) method to:
 
 1. Take the sector's `initial_pledge` `TokenAmount` as an argument
-2. Calculate a `termination_fee` value of `initial_pledge * TERM_PENALTY_PLEDGE_PERCENTAGE`
-3. If the sector's age is less than `TERMINATION_LIFETIME_CAP` days, multiply the `termination_fee` by `sector age in days / TERMINATION_LIFETIME_CAP`
-4. Compute the per sector fault fee using the method `pledge_penalty_for_continued_fault` [link](https://github.com/filecoin-project/builtin-actors/blob/8a757341d4658461e70161d1f20f9b02991e8a5f/actors/miner/src/monies.rs#L148), if the computed termination fee is less or equal to fault fee, return `FAULT_FEE_MULTIPLE * fault_fee`
-5. If `termination_fee` is less than `MIN_TERMINATION_FEE`, return `MIN_TERMINATION_FEE`
+1. Calculate the **base termination fee**:
 
-Note that the `pledge_penalty_for_continued_fault` method is not refactored in this FIP, but it must be verified to work for aggregate power numbers above the possible QA power for any single sector. For instance, an aggregate of 10 sectors' power should return the same end result as summing the `pledge_penalty_for_continued_fault` of each sector individually. This allows a caller to compute accurate maximum termination fees for any given aggregate power number (without looping through each sector).
+```
+base_termination_fee = initial_pledge * TERM_FEE_PLEDGE_MULTIPLE  // (0.085 * initial_pledge)
+```
 
-The formula written out is:
+2. Apply the **age adjustment** for young sectors:
 
-`termination fee = max(MIN_TERMINATION_FEE, max{TERM_PENALTY_PLEDGE_PERCENTAGE * initial_pledge, FAULT_FEE_MULTIPLE * sector_fault_fee} * min(1, sector_age_days / TERMINATION_LIFETIME_CAP))`
+```
+age_factor = min(1, sector_age_days / TERMINATION_LIFETIME_CAP)
+age_adjusted_fee = base_termination_fee * age_factor
+```
+
+3. Calculate the **minimum allowed fee**:
+
+```
+minimum_fee = initial_pledge * TERM_FEE_MIN_PLEDGE_MULTIPLE  // (0.02 * initial_pledge)
+```
+
+4. Calculate the **maximum allowed fee** (based on fault fee, using the [existing `pledge_penalty_for_continued_fault` method]((https://github.com/filecoin-project/builtin-actors/blob/8a757341d4658461e70161d1f20f9b02991e8a5f/actors/miner/src/monies.rs#L148))):
+
+```
+fault_fee = pledge_penalty_for_continued_fault(sector_power)
+maximum_fee = fault_fee * TERM_FEE_MAX_FAULT_FEE_MULTIPLE  // (1.05 * fault_fee)
+```
+
+5. Apply the fee bounds:
+
+```
+termination_fee = max(minimum_fee, min(age_adjusted_fee, maximum_fee))
+```
+
+This ensures that:
+
+* The fee is never less than 2% of the initial pledge
+* The fee is never more than 105% of the fault fee
+* For sectors younger than 140 days, the fee scales linearly with age
+* For sectors older than 140 days, the fee is 8.5% of the initial pledge (subject to the bounds)
+
+The complete formula in one expression is:
+
+```
+termination_fee = max(
+    initial_pledge * TERM_FEE_MIN_PLEDGE_MULTIPLE,
+    min(
+        initial_pledge * TERM_FEE_PLEDGE_MULTIPLE * min(1, sector_age_days / TERMINATION_LIFETIME_CAP),
+        fault_fee * TERM_FEE_MAX_FAULT_FEE_MULTIPLE
+    )
+)
 
 This change would immediately apply to all sectors, including historical sectors.
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -135,7 +135,7 @@ In addition to the revised termination fee formulas, a few built-in actor method
 
 There are a few different approaches one could take to accomplish the same end result:
 
-1. Use a "multiple of daily rewards" approach, which computes a termination fee based on a % or multiple of expected daily rewards for a period of time based on the current block rewards
+1. Use a "multiple of daily rewards" approach, which computes a termination fee based on a % or multiple of expected daily rewards for a period of time, based on the current block rewards
    - Problems:
      - Less predictable - in order to estimate the collateral value of a Miner Actor, the protocol needs to be able to estimate what the future daily block reward will be for the network. If the network grows quickly and unexpectedly, this could dangerously impact a DeFi protocol as the daily block rewards may increase due to increasing baseline, thus increasing the termination penalty and decreasing the collateral value for a given Miner Actor.
 2. Optimize data structures based on the current methodology to make an aggregate termination sector method feasible in constant time lookup

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -60,10 +60,10 @@ Three new constant variables should be created, each variable is fixed for the w
 Refactor the [`pledge_penalty_for_termination`](https://github.com/filecoin-project/builtin-actors/blob/12d9af8a00d0909598c67e1a18dc1577e0833137/actors/miner/src/monies.rs#L179) method to:
 
 1. Take the sector's `initial_pledge` `TokenAmount` as an argument
-2. Return `initial_pledge * TERM_PENALTY_PLEDGE_PERCENTAGE`
-3. If the sector's age is less than 140 days, multiply the result computed above (step 2) by a fraction of (`sector age in days / 140`)
-4. If the computed termination fee is less than the fault fee computed for the same sector, return `FAULT_FEE_MULTIPLE * fault_fee` 
-5. If the computed termination fee is less than `MIN_TERMINATION_FEE`, return `MIN_TERMINATION_FEE`
+2. Calculate a `termination_fee` value of `initial_pledge * TERM_PENALTY_PLEDGE_PERCENTAGE`
+3. If the sector's age is less than 140 days, multiply the `termination_fee` by `sector age in days / 140`
+4. If `termination_fee` is less than the fault fee computed for the same sector, return `FAULT_FEE_MULTIPLE * fault_fee`
+5. If `termination_fee` is less than `MIN_TERMINATION_FEE`, return `MIN_TERMINATION_FEE`
 
 The formula written out is:
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -152,7 +152,7 @@ The %-of-pledge method is:
 
 Additionally, there are two other considerations to make with respect to the design rationale:
 
-1. According to certain network participants, some Filecoin lenders provide loans to Storage Providers based on lower termination fees for sectors that are younger than 140 days old. The proposed design maintains a linear increasing termination fee over the first 140 days of the sectors life
+1. According to certain network participants, some Filecoin lenders provide loans to Storage Providers based on lower termination fees for sectors that are younger than 140 days old. The proposed design maintains a linear increasing termination fee over the first 140 days of the sector's life
 2. There are theoretical economic security issues when `termination fee < fault fee` for a sector (see [here](https://github.com/filecoin-project/FIPs/discussions/1036#discussioncomment-11984562) for more info). The proposed design ensures this security issue does not happen by forcing the termination fee to be greater than the fault fee if that edge case ever occurs.
 
 ## Backwards Compatibility

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -17,7 +17,7 @@ created: 2024-09-26
 
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the FIP.-->
 
-The termination fee for any given sector is calculated as a fixed percentage of the initial pledge held by that sector. The proposed penalty as a percentage of initial pledge is 8.5%.
+The termination fee for any given sector is calculated as a fixed percentage of the initial pledge held by that sector, except in 2 special cases. The proposed penalty as a percentage of initial pledge is 8.5%. 
 
 ## Abstract
 
@@ -25,7 +25,7 @@ The termination fee for any given sector is calculated as a fixed percentage of 
 
 Today, it is overly sophisticated and computationally expensive to compute termination fees for miner actors. As a result, DeFi applications that leverage miner actors must make major security and/or performance sacrifices in order to operate.
 
-This FIP addresses the issue by simplifying the calculation of the miner actor termination fee. The proposed new termination fee calculation uses a "percentage of pledge" strategy - where `termination fee = initial pledge * termination penalty %`. The proposed new termination penalty % is 8.5%.
+This FIP addresses the issue by simplifying the calculation of the miner actor termination fee. The proposed new termination fee calculation uses a "percentage of pledge" strategy - where `termination fee = initial pledge * termination penalty %`. The proposed new termination penalty % is 8.5%. There are two special cases to consider where the termination fee must be tweaked to maintain current network conditions, which are addressed in the technical specification and design rationale.
 
 As a result, DeFi applications on Filecoin can operate with significantly better performance, UX, and economic security. Additionally, Filecoin economics and code implementations will be significantly simplified, as well as state bloat removed.
 
@@ -52,12 +52,22 @@ Additionally, this FIP intends to maintain the original motivations behind termi
 
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Filecoin implementations. -->
 
-A new constant variable called `TERM_PENALTY_PLEDGE_PERCENTAGE` should be created, which is fixed for the whole network and configurable by future governance.
+Three new constant variables should be created, each variable is fixed for the whole network and configurable by future governance:
+1. `TERM_PENALTY_PLEDGE_PERCENTAGE` - this variable will be used to compute termination fees in the base case by multiplying against initial pledge.
+2. `FAULT_FEE_MULTIPLE` - this variable will be used to compute termination fees when the termination fee of a sector is less than the fault fee for the same sector.
+3. `MIN_TERMINATION_FEE` - this variable will ensure the termination fee for young sectors is not arbitrarily low.
 
 Refactor the [`pledge_penalty_for_termination`](https://github.com/filecoin-project/builtin-actors/blob/12d9af8a00d0909598c67e1a18dc1577e0833137/actors/miner/src/monies.rs#L179) method to:
 
 1. Take the sector's `initial_pledge` `TokenAmount` as an argument
 2. Return `initial_pledge * TERM_PENALTY_PLEDGE_PERCENTAGE`
+3. If the sector's age is less than 140 days, multiply the result computed above (step 2) by a fraction of (`sector age in days / 140`)
+4. If the computed termination fee is less than the fault fee computed for the same sector, return `FAULT_FEE_MULTIPLE * fault_fee` 
+5. If the computed termination fee is less than `MIN_TERMINATION_FEE`, return `MIN_TERMINATION_FEE`
+
+The formula written out is:
+
+`termination fee = max(MIN_TERMINATION_FEE, max{TERM_PENALTY_PLEDGE_PERCENTAGE * initial_pledge, FAULT_FEE_MULTIPLE * sector_fault_fee} * min(1, sector_age_days / 140))`
 
 This change would immediately apply to all sectors, including historical sectors.
 
@@ -70,6 +80,16 @@ The following sector info fields are used exclusively for the termination fee ca
 For all new sectors or snapped sectors, these three values are set to zero.
 
 These redundant fields can be removed from state in a future migration.
+
+In addition to the revised termination fee formulas, a few built-in actor methods needs to be created and exported so they are accessible from FEVM:
+1. Fetching a miner's QA and raw power
+2. Fetching a miner's initial pledge
+3. Fetching the network projected expected power and reward, parameterized by the projection period
+4. Fetching the termination fee constant % (8.5%)<br />
+  
+(the below 2 methods could also be built as a FEVM native oracle contract instead of as a built-in actor method with exports to access from FEVM):
+5. Fetching the single fault fee calculation, parameterized by an amount of QA power
+6. Fetching the max termination fee calculation, parameterized by an initial pledge and power amount
 
 ## Design Rationale
 
@@ -91,6 +111,11 @@ The %-of-pledge method is:
  2. predictable
  3. fixed while the sector's pledge is constant
  4. will not decay towards zero as block rewards decline, thus more effectively protecting against churn
+
+Additionally, there are two other considerations to make with respect to the design rational:
+
+1. According to certain network participants, some Filecoin lenders provide loans to Storage Providers based on lower termination fees for sectors that are younger than 140 days old. The proposed design maintains a linear increasing termination fee over the first 140 days of the sectors life
+2. There are theoretical economic security issues when `termination fee < fault fee` for a sector (see [here](https://github.com/filecoin-project/FIPs/discussions/1036#discussioncomment-11984562) for more info). The proposed design ensures this security issue does not happen by forcing the termination fee to be greater than the fault fee if that edge case ever occurs.
 
 ## Backwards Compatibility
 
@@ -117,6 +142,8 @@ The security concern with introducing this FIP is that Storage Providers will no
 2. Governance can always choose to increase the termination penalty percentage.
 3. It seems appropriate to charge an exit fee for breaking a commitment to the network, but we also do not want to charge a capture fee. Storage Providers who do not wish to use Filecoin anymore shouldn't have prohibitively high expenses for leaving the network early - ultimately for the network, burning some of this SPs tokens through sector terminations is better than 18 months of selling.
 4. As Filecoin matures, the average Storage Provider will likely be accepting paid deals in some form according to an SLA in addition to the SLA guaranteed by PoRep. These additional SLAs can/will enforce their own termination clauses, which should provide adequate motivation and verification to achieve a good experience for the average storage client.
+5. The 140 day linear termination fee increase is kept in tact to ensure no existing loan / collateral position in the Filecoin capital markets flips undercollateralized.
+6. There can be theoretical security issues when the termination fee is less than the fault fee for the same sector, however, the proposal here does not allow termination fees to drop below fault fees. 
 
 ## Incentive Considerations
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -63,55 +63,52 @@ Three new constants should be created, and an existing one will be reused. Each 
 
 Refactor the [`pledge_penalty_for_termination`](https://github.com/filecoin-project/builtin-actors/blob/12d9af8a00d0909598c67e1a18dc1577e0833137/actors/miner/src/monies.rs#L179) method to:
 
-1. Calculate the **base termination fee**:
+1. Calculate the **simple termination fee**:
 
 ```
-base_termination_fee = initial_pledge * TERM_FEE_PLEDGE_MULTIPLE  // (0.085 * initial_pledge)
+simple_termination_fee = initial_pledge * TERM_FEE_PLEDGE_MULTIPLE  // (0.085 * initial_pledge)
 ```
 
-2. Apply the **age adjustment** for young sectors:
+2. Apply the **age adjustment** for young sectors to arrive at the **base termination fee**:
 
 ```
 age_factor = min(1, sector_age_days / TERMINATION_LIFETIME_CAP)
-age_adjusted_fee = base_termination_fee * age_factor
+base_termination_fee = simple_termination_fee * age_factor
 ```
 
-3. Calculate the **minimum allowed fee**:
+3. Calculate the **minimum allowed fee** (a lower bound on the termination fee) by comparing the absolute minimum termination fee value against the fault fee. Whatever result is _larger_ sets the lower bound for the termination fee:
 
 ```
-minimum_fee = initial_pledge * TERM_FEE_MIN_PLEDGE_MULTIPLE  // (0.02 * initial_pledge)
+minimum_fee_abs = initial_pledge * TERM_FEE_MIN_PLEDGE_MULTIPLE  // (0.02 * initial_pledge)
+minimum_fee_ff = pledge_penalty_for_continued_fault(sector_power) * TERM_FEE_MAX_FAULT_FEE_MULTIPLE  // (1.05 * fault_fee)
+
+minimum_fee = max(minimum_fee_abs,minimum_fee_ff)
 ```
 
-4. Calculate the **maximum allowed fee** (based on fault fee, using the [existing `pledge_penalty_for_continued_fault` method]((https://github.com/filecoin-project/builtin-actors/blob/8a757341d4658461e70161d1f20f9b02991e8a5f/actors/miner/src/monies.rs#L148))):
+4. Apply the fee bounds:
 
 ```
-fault_fee = pledge_penalty_for_continued_fault(sector_power)
-maximum_fee = fault_fee * TERM_FEE_MAX_FAULT_FEE_MULTIPLE  // (1.05 * fault_fee)
-```
-
-5. Apply the fee bounds:
-
-```
-termination_fee = max(minimum_fee, min(age_adjusted_fee, maximum_fee))
+termination_fee = max(base_termination_fee, minimum_fee)
 ```
 
 This ensures that:
 
 * The fee is never less than 2% of the initial pledge
-* The fee is never more than 105% of the fault fee
-* For sectors younger than 140 days, the fee scales linearly with age
+* The fee is never less than 105% of the fault fee
+* For sectors younger than 140 days, the fee scales linearly with age (subject to the bounds)
 * For sectors older than 140 days, the fee is 8.5% of the initial pledge (subject to the bounds)
 
 The complete formula in one expression is:
 
 ```
-termination_fee = max(
-    initial_pledge * TERM_FEE_MIN_PLEDGE_MULTIPLE,
-    min(
-        initial_pledge * TERM_FEE_PLEDGE_MULTIPLE * min(1, sector_age_days / TERMINATION_LIFETIME_CAP),
-        fault_fee * TERM_FEE_MAX_FAULT_FEE_MULTIPLE
-    )
+termination fee = max(
+  MIN_TERMINATION_FEE * initial_pledge, 
+  max(
+    TERM_PENALTY_PLEDGE_PERCENTAGE * initial_pledge * min(1, sector_age_days / TERMINATION_LIFETIME_CAP),
+    FAULT_FEE_MULTIPLE * sector_fault_fee
+  )
 )
+```
 
 This change would immediately apply to all sectors, including historical sectors.
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -198,7 +198,7 @@ It is important that Storage Providers are incentivized to honor their commitmen
 
 The termination fee for sectors committed a long time ago will immediately and significantly decrease, but only to match the fee:pledge ratio of new sectors. This will increase the incentive for some SPs with high-pledge sectors to terminate and re-onboard to gain more power for the same amount of pledge (but more hardware).
 
-In contrast to the current system, the termination penalty for a sector will be constant regardless of its age. Currently the termination penalty starts low and increases with age up to a max. This presents is a change in the incentive structure for short-term-view SPs.
+In contrast to the current system, the termination penalty for a sector will be constant regardless of its age. Currently the termination penalty starts low and increases with age up to a max. This presents a change in the incentive structure for short-term-view SPs.
 
 ## Product Considerations
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -187,7 +187,7 @@ The security concern with introducing this FIP is that Storage Providers will no
 2. Governance can always choose to increase the termination penalty percentage.
 3. It seems appropriate to charge an exit fee for breaking a commitment to the network, but we also do not want to charge a capture fee. Storage Providers who do not wish to use Filecoin anymore shouldn't have prohibitively high expenses for leaving the network early - ultimately for the network, burning some of this SPs tokens through sector terminations is better than 18 months of selling.
 4. As Filecoin matures, the average Storage Provider will likely be accepting paid deals in some form according to an SLA in addition to the SLA guaranteed by PoRep. These additional SLAs can/will enforce their own termination clauses, which should provide adequate motivation and verification to achieve a good experience for the average storage client.
-5. The 140 day linear termination fee increase is kept in tact to ensure no existing loan / collateral position in the Filecoin capital markets flips undercollateralized.
+5. The 140 day linear termination fee increase is kept intact to ensure no existing loan / collateral position in the Filecoin capital markets flips undercollateralized.
 6. There can be theoretical security issues when the termination fee is less than the fault fee for the same sector, however, the proposal here does not allow termination fees to drop below fault fees.
 
 ## Incentive Considerations

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -17,7 +17,7 @@ created: 2024-09-26
 
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the FIP.-->
 
-The termination fee for any given sector is calculated as a fixed percentage of the initial pledge held by that sector, except in 2 special cases. The proposed penalty as a percentage of initial pledge is 8.5%. 
+The termination fee for any given sector is calculated as a fixed percentage of the initial pledge held by that sector, except in 2 special cases. The proposed penalty as a percentage of initial pledge is 8.5%.
 
 ## Abstract
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -52,13 +52,14 @@ Additionally, this FIP intends to maintain the original motivations behind termi
 
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Filecoin implementations. -->
 
-Three new constants should be created, each variable is fixed for the whole network and configurable by future governance:
-| Variable | Description | Amount |
+Three new constants should be created, and an existing one will be reused. Each is fixed for the whole network and configurable by future governance:
+
+| Constant | Description | Amount |
 |----------|-------------|--------|
-| `TERM_PENALTY_PLEDGE_PERCENTAGE` | This constant will be used to compute termination fees in the base case by multiplying against initial pledge. | 8.5% of initial pledge |
-| `FAULT_FEE_MULTIPLE` | This constant will be used to compute termination fees when the termination fee of a sector is less than the fault fee for the same sector. | 1.05x |
-| `MIN_TERMINATION_FEE` | This constant will ensure the termination fee for young sectors is not arbitrarily low. | 2% of initial pledge |
-| `TERMINATION_LIFETIME_CAP` | This constant maintains the linear increase in termination fee for young sectors. | 140 days |
+| `TERM_FEE_PLEDGE_MULTIPLE` | This constant will be used to compute termination fees in the base case by multiplying against initial pledge. | 0.085x initial pledge |
+| `TERM_FEE_MAX_FAULT_FEE_MULTIPLE` | This constant will be used to compute termination fees when the termination fee of a sector is less than the fault fee for the same sector. | 1.05x |
+| `TERM_FEE_MIN_PLEDGE_MULTIPLE` | This constant will ensure the termination fee for young sectors is not arbitrarily low. | 0.02x initial pledge |
+| `TERMINATION_LIFETIME_CAP` | _(Existing constant)_ This constant maintains the linear increase in termination fee for young sectors. | 140 days |
 
 Refactor the [`pledge_penalty_for_termination`](https://github.com/filecoin-project/builtin-actors/blob/12d9af8a00d0909598c67e1a18dc1577e0833137/actors/miner/src/monies.rs#L179) method to:
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -124,8 +124,8 @@ These redundant fields can be removed from state in a future migration.
 In addition to the revised termination fee formulas, a few built-in actor methods need to be created and exported so they are accessible from FEVM:
 | Function Name | Function Signature | Description |
 |--------------|-------------------|-------------|
-| `miner_power` | `miner_power(miner_id: ActorID) -> (QAPower, RawPower)` | Returns the miner's quality-adjusted and raw power |
-| `miner_initial_pledge` | `miner_initial_pledge(miner_id: ActorID) -> TokenAmount` | Returns the miner's total initial pledge amount |
+| `miner_power` | `miner_power() -> (QAPower, RawPower)` | Returns the miner's quality-adjusted and raw power |
+| `miner_initial_pledge` | `miner_initial_pledge() -> TokenAmount` | Returns the miner's total initial pledge amount |
 | `termination_fee_percentage` | `termination_fee_percentage() -> f64` | Returns the network's termination fee percentage (8.5%) |
 | `max_termination_fee` | `max_termination_fee(initial_pledge: TokenAmount, power: QAPower) -> TokenAmount` | Returns the maximum termination fee calculation for a given initial pledge and power amount |
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -128,14 +128,14 @@ These redundant fields can be removed from state in a future migration.
 In addition to the revised termination fee formulas, a few built-in actor methods need to be created and exported so they are accessible from FEVM:
 | Function Name | Function Signature | Description |
 |--------------|-------------------|-------------|
-| `get_miner_power` | `get_miner_power(miner_id: ActorID) -> (QAPower, RawPower)` | Returns the miner's quality-adjusted and raw power |
-| `get_miner_initial_pledge` | `get_miner_initial_pledge(miner_id: ActorID) -> TokenAmount` | Returns the miner's total initial pledge amount |
-| `get_network_projection` | `get_network_projection(projection_period_start: ChainEpoch, projection_period_end: ChainEpoch) -> (Power, TokenAmount)` | Returns the network's projected power and reward for the given projection period |
-| `get_termination_fee_percentage` | `get_termination_fee_percentage() -> f64` | Returns the network's termination fee percentage (8.5%) |
+| `miner_power` | `miner_power(miner_id: ActorID) -> (QAPower, RawPower)` | Returns the miner's quality-adjusted and raw power |
+| `miner_initial_pledge` | `miner_initial_pledge(miner_id: ActorID) -> TokenAmount` | Returns the miner's total initial pledge amount |
+| `network_projection` | `network_projection(projection_period_start: ChainEpoch, projection_period_end: ChainEpoch) -> (Power, TokenAmount)` | Returns the network's projected power and reward for the given projection period |
+| `termination_fee_percentage` | `termination_fee_percentage() -> f64` | Returns the network's termination fee percentage (8.5%) |
   
 (the below 2 methods could also be built as a FEVM native oracle contract instead of as a built-in actor method with exports to access from FEVM):
-| `get_single_fault_fee` | `get_single_fault_fee(qa_power: QAPower) -> TokenAmount` | Returns the fault fee calculation for a given amount of QA power |
-| `get_max_termination_fee` | `get_max_termination_fee(initial_pledge: TokenAmount, power: QAPower) -> TokenAmount` | Returns the maximum termination fee calculation for a given initial pledge and power amount |
+| `single_fault_fee` | `single_fault_fee(qa_power: QAPower) -> TokenAmount` | Returns the fault fee calculation for a given amount of QA power |
+| `max_termination_fee` | `max_termination_fee(initial_pledge: TokenAmount, power: QAPower) -> TokenAmount` | Returns the maximum termination fee calculation for a given initial pledge and power amount |
 
 ## Design Rationale
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -126,7 +126,6 @@ In addition to the revised termination fee formulas, a few built-in actor method
 |--------------|-------------------|-------------|
 | `miner_power` | `miner_power() -> (QAPower, RawPower)` | Returns the miner's quality-adjusted and raw power |
 | `miner_initial_pledge` | `miner_initial_pledge() -> TokenAmount` | Returns the miner's total initial pledge amount |
-| `termination_fee_percentage` | `termination_fee_percentage() -> (num u32, denom u32)` | Returns the network's termination fee percentage  (8.5%) |
 | `max_termination_fee` | `max_termination_fee(initial_pledge: TokenAmount, power: QAPower) -> TokenAmount` | Returns the maximum termination fee calculation for a given initial pledge and power amount |
 
 ## Design Rationale

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -150,7 +150,7 @@ The %-of-pledge method is:
 3.  fixed while the sector's pledge is constant
 4.  will not decay towards zero as block rewards decline, thus more effectively protecting against churn
 
-Additionally, there are two other considerations to make with respect to the design rational:
+Additionally, there are two other considerations to make with respect to the design rationale:
 
 1. According to certain network participants, some Filecoin lenders provide loans to Storage Providers based on lower termination fees for sectors that are younger than 140 days old. The proposed design maintains a linear increasing termination fee over the first 140 days of the sectors life
 2. There are theoretical economic security issues when `termination fee < fault fee` for a sector (see [here](https://github.com/filecoin-project/FIPs/discussions/1036#discussioncomment-11984562) for more info). The proposed design ensures this security issue does not happen by forcing the termination fee to be greater than the fault fee if that edge case ever occurs.

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -17,7 +17,7 @@ created: 2024-09-26
 
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the FIP.-->
 
-The termination fee for any given sector is calculated as a fixed percentage of the initial pledge held by that sector, except in 2 special cases. The proposed penalty as a percentage of initial pledge is 8.5%.
+The termination fee for any given sector is calculated as a fixed percentage of the initial pledge held by that sector, except in 3 special cases. The proposed penalty as a percentage of initial pledge is 8.5%.
 
 ## Abstract
 
@@ -52,22 +52,27 @@ Additionally, this FIP intends to maintain the original motivations behind termi
 
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Filecoin implementations. -->
 
-Three new constant variables should be created, each variable is fixed for the whole network and configurable by future governance:
-1. `TERM_PENALTY_PLEDGE_PERCENTAGE` - this variable will be used to compute termination fees in the base case by multiplying against initial pledge.
-2. `FAULT_FEE_MULTIPLE` - this variable will be used to compute termination fees when the termination fee of a sector is less than the fault fee for the same sector.
-3. `MIN_TERMINATION_FEE` - this variable will ensure the termination fee for young sectors is not arbitrarily low.
+Three new constants should be created, each variable is fixed for the whole network and configurable by future governance:
+| Variable | Description | Amount |
+|----------|-------------|--------|
+| `TERM_PENALTY_PLEDGE_PERCENTAGE` | This constant will be used to compute termination fees in the base case by multiplying against initial pledge. | 8.5% of initial pledge |
+| `FAULT_FEE_MULTIPLE` | This constant will be used to compute termination fees when the termination fee of a sector is less than the fault fee for the same sector. | 1.05x |
+| `MIN_TERMINATION_FEE` | This constant will ensure the termination fee for young sectors is not arbitrarily low. | 2% of initial pledge |
+| `TERMINATION_LIFETIME_CAP` | This constant maintains the linear increase in termination fee for young sectors. | 140 days |
 
 Refactor the [`pledge_penalty_for_termination`](https://github.com/filecoin-project/builtin-actors/blob/12d9af8a00d0909598c67e1a18dc1577e0833137/actors/miner/src/monies.rs#L179) method to:
 
 1. Take the sector's `initial_pledge` `TokenAmount` as an argument
 2. Calculate a `termination_fee` value of `initial_pledge * TERM_PENALTY_PLEDGE_PERCENTAGE`
-3. If the sector's age is less than 140 days, multiply the `termination_fee` by `sector age in days / 140`
-4. If `termination_fee` is less than the fault fee computed for the same sector, return `FAULT_FEE_MULTIPLE * fault_fee`
+3. If the sector's age is less than `TERMINATION_LIFETIME_CAP` days, multiply the `termination_fee` by `sector age in days / TERMINATION_LIFETIME_CAP`
+4. Compute the per sector fault fee using the method `pledge_penalty_for_continued_fault` [link](https://github.com/filecoin-project/builtin-actors/blob/8a757341d4658461e70161d1f20f9b02991e8a5f/actors/miner/src/monies.rs#L148), if the computed termination fee is less or equal to fault fee, return `FAULT_FEE_MULTIPLE * fault_fee`
 5. If `termination_fee` is less than `MIN_TERMINATION_FEE`, return `MIN_TERMINATION_FEE`
+
+Note that the `pledge_penalty_for_continued_fault` method is not refactored in this FIP, but it must be verified to work for aggregate power numbers above the possible QA power for any single sector. For instance, an aggregate of 10 sectors' power should return the same end result as summing the `pledge_penalty_for_continued_fault` of each sector individually. This allows a caller to compute accurate maximum termination fees for any given aggregate power number (without looping through each sector).
 
 The formula written out is:
 
-`termination fee = max(MIN_TERMINATION_FEE, max{TERM_PENALTY_PLEDGE_PERCENTAGE * initial_pledge, FAULT_FEE_MULTIPLE * sector_fault_fee} * min(1, sector_age_days / 140))`
+`termination fee = max(MIN_TERMINATION_FEE, max{TERM_PENALTY_PLEDGE_PERCENTAGE * initial_pledge, FAULT_FEE_MULTIPLE * sector_fault_fee} * min(1, sector_age_days / TERMINATION_LIFETIME_CAP))`
 
 This change would immediately apply to all sectors, including historical sectors.
 
@@ -81,15 +86,17 @@ For all new sectors or snapped sectors, these three values are set to zero.
 
 These redundant fields can be removed from state in a future migration.
 
-In addition to the revised termination fee formulas, a few built-in actor methods needs to be created and exported so they are accessible from FEVM:
-1. Fetching a miner's QA and raw power
-2. Fetching a miner's initial pledge
-3. Fetching the network projected expected power and reward, parameterized by the projection period
-4. Fetching the termination fee constant % (8.5%)<br />
+In addition to the revised termination fee formulas, a few built-in actor methods need to be created and exported so they are accessible from FEVM:
+| Function Name | Function Signature | Description |
+|--------------|-------------------|-------------|
+| `get_miner_power` | `get_miner_power(miner_id: ActorID) -> (QAPower, RawPower)` | Returns the miner's quality-adjusted and raw power |
+| `get_miner_initial_pledge` | `get_miner_initial_pledge(miner_id: ActorID) -> TokenAmount` | Returns the miner's total initial pledge amount |
+| `get_network_projection` | `get_network_projection(projection_period_start: ChainEpoch, projection_period_end: ChainEpoch) -> (Power, TokenAmount)` | Returns the network's projected power and reward for the given projection period |
+| `get_termination_fee_percentage` | `get_termination_fee_percentage() -> f64` | Returns the network's termination fee percentage (8.5%) |
   
 (the below 2 methods could also be built as a FEVM native oracle contract instead of as a built-in actor method with exports to access from FEVM):
-5. Fetching the single fault fee calculation, parameterized by an amount of QA power
-6. Fetching the max termination fee calculation, parameterized by an initial pledge and power amount
+| `get_single_fault_fee` | `get_single_fault_fee(qa_power: QAPower) -> TokenAmount` | Returns the fault fee calculation for a given amount of QA power |
+| `get_max_termination_fee` | `get_max_termination_fee(initial_pledge: TokenAmount, power: QAPower) -> TokenAmount` | Returns the maximum termination fee calculation for a given initial pledge and power amount |
 
 ## Design Rationale
 
@@ -129,8 +136,14 @@ This FIP requires a network upgrade because it intends to change built-in actor 
 
 <!--Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.-->
 
-- When terminating a single sector, the realized termination fee should equal the expected % of pledge termination fee
-- When terminating all sectors on a miner, the realized termination fee should equal the expected % of pledge termination fee
+- When terminating a single sector:
+  - Not considering fault fees, for a sector where its age >= `TERMINATION_LIFETIME_CAP`, termination fee should equal `TERM_PENALTY_PLEDGE_PERCENTAGE * initial pledge`
+  - Not considering fault fees, for a sector where its age < `TERMINATION_LIFETIME_CAP`, termination fee should equal `TERM_PENALTY_PLEDGE_PERCENTAGE * of initial pledge * sector age in days / TERMINATION_LIFETIME_CAP`
+  - Considering fault fees, for a sector with a termination fee that is less than the associated sector's fault fee, termination fee should equal `FAULT_FEE_MULTIPLE * fault fee`
+  - Given all test cases above, if the termination fee computed is less than `MIN_TERMINATION_FEE * initial pledge`, termination fee should equal `MIN_TERMINATION_FEE * initial pledge`
+
+- Additional test case for the `pledge_penalty_for_continued_fault` method:
+  - `pledge_penalty_for_continued_fault` should work for aggregate power numbers above the possible QA power for any single sector. For instance, an aggregate of 10 sectors' power should return the same end result as summing the `pledge_penalty_for_continued_fault` of each sector individually.
 
 ## Security Considerations
 

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -176,10 +176,10 @@ This FIP requires a network upgrade because it intends to change built-in actor 
 <!--Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.-->
 
 - When terminating a single sector:
-  - Not considering fault fees, for a sector where its age >= `TERMINATION_LIFETIME_CAP`, termination fee should equal `TERM_PENALTY_PLEDGE_PERCENTAGE * initial pledge`
-  - Not considering fault fees, for a sector where its age < `TERMINATION_LIFETIME_CAP`, termination fee should equal `TERM_PENALTY_PLEDGE_PERCENTAGE * of initial pledge * sector age in days / TERMINATION_LIFETIME_CAP`
-  - Considering fault fees, for a sector with a termination fee that is less than the associated sector's fault fee, termination fee should equal `FAULT_FEE_MULTIPLE * fault fee`
-  - Given all test cases above, if the termination fee computed is less than `MIN_TERMINATION_FEE * initial pledge`, termination fee should equal `MIN_TERMINATION_FEE * initial pledge`
+  - Not considering fault fees, for a sector where its age >= `TERMINATION_LIFETIME_CAP`, termination fee should equal `TERM_FEE_PLEDGE_MULTIPLE * initial pledge`
+  - Not considering fault fees, for a sector where its age < `TERMINATION_LIFETIME_CAP`, termination fee should equal `TERM_FEE_PLEDGE_MULTIPLE * of initial pledge * sector age in days / TERMINATION_LIFETIME_CAP`
+  - Considering fault fees, for a sector with a termination fee that is less than the associated sector's fault fee, termination fee should equal `TERM_FEE_MAX_FAULT_FEE_MULTIPLE * fault fee`
+  - Given all test cases above, if the termination fee computed is less than `TERM_FEE_MIN_PLEDGE_MULTIPLE * initial pledge`, termination fee should equal `TERM_FEE_MIN_PLEDGE_MULTIPLE * initial pledge`
 
 - Additional test case for the `pledge_penalty_for_continued_fault` method:
   - `pledge_penalty_for_continued_fault` should work for aggregate power numbers above the possible QA power for any single sector. For instance, an aggregate of 10 sectors' power should return the same end result as summing the `pledge_penalty_for_continued_fault` of each sector individually.

--- a/FIPS/fip-0098.md
+++ b/FIPS/fip-0098.md
@@ -63,7 +63,6 @@ Three new constants should be created, and an existing one will be reused. Each 
 
 Refactor the [`pledge_penalty_for_termination`](https://github.com/filecoin-project/builtin-actors/blob/12d9af8a00d0909598c67e1a18dc1577e0833137/actors/miner/src/monies.rs#L179) method to:
 
-1. Take the sector's `initial_pledge` `TokenAmount` as an argument
 1. Calculate the **base termination fee**:
 
 ```


### PR DESCRIPTION
Updates to FIP 98 while in last call:

- Added 3 special cases to consider when computing termination fees: when termination fee < fault fee, when a sector's age is < 140 days, and when a sector's termination fee is less than some minimum % of its initial pledge
- Added more test cases to address the special cases, as well as a test case for computing aggregate fault fees across multiple sectors
- Define new built-in actor methods to help callers (including FEVM callers by exporting built-in actor methods) to compute termination fees more easily