### PR TITLE
FIP-0100: Add VestingFunds optimisation details

### DIFF
--- a/FIPS/fip-0100.md
+++ b/FIPS/fip-0100.md
@@ -246,11 +246,89 @@ Sectors that were onboarded prior to the activation of this FIP, and therefore d
 | **Faults** | No change | No change | Update if sectors move between queues | No direct impact on fee calculation |
 | **Early terminations** | N/A (sector removed) | Reduce by terminated sector's `daily_fee` | N/A (sector removed) | Applies to both automatic and manual terminations |
 
+### Optimization of `VestingFunds`
+
+The `VestingFunds` data structure, associated with the miner actor's state, is currently implemented as a single, large array of vesting tuples: `(ChainEpoch, TokenAmount)`. Each tuple specifies the amount of tokens to be unlocked at a specific epoch. Vesting epochs are quantized, meaning that vesting occurs at regular intervals, but not necessarily every epoch or even every deadline. This array can become very large, leading to inefficiencies when it needs to be updated. These updates occur when new vesting block rewards are added, when tokens vest and are unlocked, and when locked rewards are used to cover fee debts arising from penalties.
+
+The introduction of a daily fee, paid using the fee debt mechanism, increases the frequency with which the `VestingFunds` data structure is mutated. To mitigate the performance impact of these frequent mutations, this FIP introduces an optimization to the storage of `VestingFunds`. The goal is to make the common operation of drawing funds from the _next_ vesting epoch more efficient, avoiding unnecessary reads and writes to the large `VestingFunds` array.
+
+**Existing state representation**
+
+```rust
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct State {
+    // ... existing fields
+
+    /// VestingFunds (Vesting Funds schedule for the miner).
+    pub vesting_funds: Cid,
+
+    // ... existing fields
+}
+
+/// Represents the vesting table state for the miner.
+/// It is a slice of (VestingEpoch, VestingAmount).
+/// The slice will always be sorted by the VestingEpoch.
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct VestingFunds {
+    pub funds: Vec<VestingFund>,
+}
+
+// Represents miner funds that will vest at the given epoch.
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct VestingFund {
+    pub epoch: ChainEpoch,
+    pub amount: TokenAmount,
+}
+```
+
+**New state representation**
+
+```rust
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct State {
+    // ... existing fields
+
+    /// VestingFunds (Vesting Funds schedule for the miner).
+    pub vesting_funds: Option<VestingFunds>,
+
+    // ... existing fields
+}
+
+/// Represents the vesting table state for the miner. It's composed of a `head` (stored inline) and
+/// a tail (referenced by CID).
+#[derive(Serialize_tuple, Deserialize_tuple)]
+struct VestingFunds {
+    // The "next" batch of vesting funds.
+    head: VestingFund,
+    // The rest of the vesting funds, if any.
+    tail: Cid, // Vec<VestingFund>
+}
+
+// Represents miner funds that will vest at the given epoch.
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct VestingFund {
+    pub epoch: ChainEpoch,
+    pub amount: TokenAmount,
+}
+```
+
+The new algorithm for managing VestingFunds operates as follows:
+
+  * The `vesting_funds` field in a miner actor can be `null`. This indicates that there are no remaining funds to vest. If `vesting_funds` is `null`, any attempt to draw from unvested funds or to unlock locked vested funds will yield no tokens. This field will be `null` for all new miners and for miners with no remaining unvested tokens. It's important to note that it is possible to have unlocked, but not unvested, tokens in `VestingFunds`. These tokens are typically unlocked during mutation of `VestingFunds`, such as during balance withdrawal attempts.
+  * The vesting of new rewards will continue to follow the existing schedule, spread across 180 days, with vesting occurring once per day. The vesting schedule is quantized to a precision of 12 hours, so vesting may occur twice per day for a miner, depending on when rewards are received.
+  * The *next* batch of funds to vest is always stored directly within the miner actor's state, in the first element of the `vesting_funds` field, as a `(ChainEpoch, TokenAmount)` tuple. This is referred to as the *"head"*.
+  * All subsequent batches of funds to vest are stored in a separate block, as a list of `(ChainEpoch, TokenAmount)` tuples. This is referred to as the *"tail"*. The "tail" is referenced by a CID.
+  * During unlocking, if the epoch specified in the "head" has passed, the funds in the "head" are moved to the miner's unlocked balance. The first block in the "tail" is then removed and promoted to become the new "head". This process requires modifying both the miner's root state block and the `VestingFunds` "tail" block.
+  * When extracting funds to cover fee debt (penalties or the new daily fee), the system first attempts to draw the required funds solely from the "head". If the "head" contains sufficient funds, only the miner's root state block needs to be updated. If the "head" does not contain enough funds, it is emptied, and the "tail" is then depleted until the required amount is obtained.
+  * The "head" tuple may represent a zero value if fee debt reduces the balance to zero. This situation will be resolved either during normal vesting or during future fee extraction.
+
 ### Migration
 
 At activation of this FIP, a new schema for the `Deadline` block type will be introduced, adding two new fields: `live_power: PowerPair` and `daily_fee: TokenAmount`. A migration will be performed on all deadlines, across all miner actors. As the majority of deadlines referenced on chain are _the_ empty `Deadline` block, a CID for this singleton block may be used to speed up migration where the CID for the previous form's `Deadline` block is encountered. All `daily_fee` values will be set to zero at migration and the `live_power` will be calculated as a sum of the `live_power` in each of the `Partition`s assigned to the `Deadline`.
 
 No migration is necessary for `SectorOnChainInfo` or `ExpirationSet` as the lazy migration strategy is employed.
+
+The miner actor state root block for all miners will be migrated to accommodate the new `VestingFunds` structure. Where a miner has an empty existing `VestingFunds` list, the `vesting_funds` field will be set to `null`. Otherwise, the `vesting_funds` field will be updated to a new format `VestingFunds` object, with the `head` field set to the first element of the existing `VestingFunds` list and the `tail` field set to a CID referencing the remaining elements of the list (which may be a zero-element block if there are no funds beyond the head). It is possible that the new `head` will represent an already-vested epoch, however this will be resolved during the next update to the `VestingFunds` structure by the miner actor.
 
 ### Special handling for Calibration network
 

--- a/FIPS/fip-0100.md
+++ b/FIPS/fip-0100.md
@@ -248,9 +248,13 @@ Sectors that were onboarded prior to the activation of this FIP, and therefore d
 
 ### Optimization of `VestingFunds`
 
-The `VestingFunds` data structure, associated with the miner actor's state, is currently implemented as a single, large array of vesting tuples: `(ChainEpoch, TokenAmount)`. Each tuple specifies the amount of tokens to be unlocked at a specific epoch. Vesting epochs are quantized, meaning that vesting occurs at regular intervals, but not necessarily every epoch or even every deadline. This array can become very large, leading to inefficiencies when it needs to be updated. These updates occur when new vesting block rewards are added, when tokens vest and are unlocked, and when locked rewards are used to cover fee debts arising from penalties.
+The `VestingFunds` data structure, associated with the miner actor's state, is currently implemented as a single, very large array of vesting tuples: `(ChainEpoch, TokenAmount)` (almost always 360 tuples per miner actor). Each tuple specifies the amount of tokens to be unlocked at a specific epoch. An average `VestingFunds` IPLD block occupies 5.5 KiB of space.
 
-The introduction of a daily fee, paid using the fee debt mechanism, increases the frequency with which the `VestingFunds` data structure is mutated. To mitigate the performance impact of these frequent mutations, this FIP introduces an optimization to the storage of `VestingFunds`. The goal is to make the common operation of drawing funds from the _next_ vesting epoch more efficient, avoiding unnecessary reads and writes to the large `VestingFunds` array.
+Vesting epochs are quantized, meaning that vesting occurs at regular intervals, but not necessarily every epoch or even every deadline. Updating this data structure too often can lead to excessive amounts of state churn, taxing node operators and adding to (the already large) archival state weight. These updates occur when new vesting block rewards are added, when tokens vest and are unlocked, and when locked rewards are used to cover fee debts arising from penalties.
+
+The introduction of a daily fee, paid using the fee debt mechanism, increases the frequency with which the `VestingFunds` data structure is mutated, causing it to be updated every deadline (48 times per day, for each miner actor with fees to deduct). Without mitigating the cost of this mutation, it is estimated that the current Filecoin state tree would add up to an additional 435 MiB of IPLD block churn per day.
+
+To mitigate the performance impact of these frequent mutations, this FIP introduces an optimization to the storage of `VestingFunds`. The goal is to make the common operation of drawing funds from the _next_ vesting epoch more efficient, avoiding unnecessary reads and writes to the large `VestingFunds` array.
 
 **Existing state representation**
 


### PR DESCRIPTION
This is an addition to https://github.com/filecoin-project/FIPs/pull/1124 that's large enough and different enough in nature that it should be reviewed separately. It doesn't impact the fee mechanism, it's an internal detail for the miner actor, but it needs to be documented as a change in state representation, mutation and how we perform a migration.

Details being finalised in https://github.com/filecoin-project/FIPs/pull/1124.