### PR TITLE
FIP-0100: artificially bump calibnet circulating supply up further to match mainnet

### DIFF
--- a/FIPS/fip-0100.md
+++ b/FIPS/fip-0100.md
@@ -458,13 +458,15 @@ Because this FIP uses a fixed portion of current circulating supply to calculate
 
 To address this problem, this FIP will also adjust network parameters for Calibnet to ensure that the circulating supply is a reasonable and dynamic positive number. The core problem is the initial allocation of reserve funds which appears to have been set to 900M FIL. This was likely set to ensure a total supply of 2B FIL. Unfortunately, implementations use the same `InitialFilReserved` value as mainnet, 300M FIL.
 
-Filecoin node implementations compatible with Calibnet will be required to set their `InitialFilReserved` for Calibnet (only) to `900,000,000` FIL **from the activation epoch of this FIP** (i.e. a value of `300,000,000` FIL must be used for epochs up until then, including when re-executing older tipsets). This will result in a more appropriate circulating supply calculation starting from the activation epoch of this FIP:
+The goal of Calibnet is to provide an approximation of Mainnet for testing purposes, currently the circulating supply calculation calculation makes that impossible. By setting the `InitialFilReserved` value to 900M FIL, the circulating supply calculation will become accurate for that network, but still be nearly 400M FIL lower than Mainnet. This FIP proposes to artificially inflate the circulating supply to more closely match the current mainnet conditions and be a more useful model for testing: using a value of 1,200M for `InitialFilReserved` will result in a circulating supply of 695.8M FIL, which is close to the current mainnet value.
+
+Filecoin node implementations compatible with Calibnet will be required to set their `InitialFilReserved` for Calibnet (only) to `1,200,000,000` FIL (whole) **from the activation epoch of this FIP** (i.e. a value of `300,000,000` FIL must be used for epochs up until then, including when re-executing older tipsets). This will result in a more useful circulating supply calculation value starting from the activation epoch of this FIP:
 
 | Metric                | Mainnet (FIL) | Calibnet (FIL) |
 |-----------------------|--------------:|---------------:|
-| `InitialFilReserved`  |   300,000,000 |   900,000,000  |
-| `FilReserveDisbursed` |    17,066,619 |    30,721,729  |
-| `FilCirculating`      |   686,539,216 |   386,866,636  |
+| `InitialFilReserved`  |   300,000,000 | 1,200,000,000  |
+| `FilReserveDisbursed` |    17,066,619 |   300,721,729  |
+| `FilCirculating`      |   686,539,216 |   686,866,636  |
 
 ## Design Rationale
 

--- a/FIPS/fip-0100.md
+++ b/FIPS/fip-0100.md
@@ -465,7 +465,7 @@ Filecoin node implementations compatible with Calibnet will be required to set t
 | Metric                | Mainnet (FIL) | Calibnet (FIL) |
 |-----------------------|--------------:|---------------:|
 | `InitialFilReserved`  |   300,000,000 | 1,200,000,000  |
-| `FilReserveDisbursed` |    17,066,619 |   300,721,729  |
+| `FilReserveDisbursed` |    17,066,619 |   330,721,729  |
 | `FilCirculating`      |   686,539,216 |   686,866,636  |
 
 ## Design Rationale


### PR DESCRIPTION
900M is the correct value for `InitialFilReserved` on calibration net, which is what we're trying to address to make circulating supply non-negative. But it lands us at a CS value of ~386M. This change proposes to artificially raise `InitialFilReserved` by another 300M to bring CS to ~686M which is very close to the current mainnet CS value (~686M). It is expected that these numbers will continue to diverge over time, but having them close together is useful to increase the fidelity of testing change implementations, particularly for this FIP right now.

_Coming out of some discussion in https://github.com/filecoin-project/lotus/pull/12938_