### PR TITLE
FIP: Proposal to remove ExtendSectorExpiration

### DIFF
--- a/FIPS/fip-0103.md
+++ b/FIPS/fip-0103.md
@@ -1,0 +1,76 @@
+---
+fip: "0103"
+title: Removal of the ExtendSectorExpiration method from the miner actor
+author: "Rod Vagg (@rvagg)"
+discussions-to: https://github.com/filecoin-project/FIPs/discussions/1116
+status: Draft
+type: Technical (Core)
+category: Core
+created: 2025-03-14
+spec-sections: 
+requires: FIP-0045
+replaces: N/A
+---
+
+# FIP-0103: Removal of the ExtendSectorExpiration method from the miner actor
+
+## Simple Summary
+
+This FIP proposes the removal of the `ExtendSectorExpiration` method from the miner actor as it has been superseded by the more flexible `ExtendSectorExpiration2` method, which was introduced in FIP-0045 and supports verified claims.
+
+## Abstract
+
+The `ExtendSectorExpiration` method in the miner actor was designed to allow storage providers to extend the commitment period of their sectors. However, with the introduction of `ExtendSectorExpiration2` in FIP-0045, which offers the same functionality plus additional flexibility for handling verified claims, the original method has become redundant. This proposal aims to remove the legacy `ExtendSectorExpiration` method to simplify the protocol, reduce technical debt, and streamline code pathways in the miner actor. It's important to note that sector extension functionality remains fully supported through the enhanced `ExtendSectorExpiration2` method.
+
+## Change Motivation
+
+The main motivation behind this change is to clean up builtin actors and reduce technical debt. By removing the redundant `ExtendSectorExpiration` method, we can simplify the protocol, making it more maintainable and less error-prone. The existence of two methods that serve similar purposes creates unnecessary complexity in the codebase and requires additional maintenance overhead. Since `ExtendSectorExpiration2` provides enhanced functionality including support for verified claims, there is no longer a need to maintain the original method.
+
+## Specification
+
+Implementation-wise, this change involves removing the `ExtendSectorExpiration` method from the miner actor, along with all associated helper methods that are not used by other methods, and all tests that uniquely test its functionality.
+
+## Design Rationale
+
+The decision to propose this change follows the same principle as FIP-0101, which removed the `ProveCommitAggregate` method. When newer, more flexible methods are available and in use, removing redundant legacy methods simplifies the codebase and reduces maintenance burden. 
+
+With `ExtendSectorExpiration2` fully supporting all functionality of the original method plus additional capabilities for verified claims, maintaining both methods is unnecessary and adds complexity. Efficient and clean code is prioritised over accumulated complexity that increases the potential for bugs.
+
+## Backwards Compatibility
+
+This change will not introduce any backward incompatibilities, as the `ExtendSectorExpiration2` method fully covers all the functionality previously offered by `ExtendSectorExpiration`. Storage providers have already migrated to using the newer method. The last `ExtendSectorExpiration` message recorded on-chain was on 2024-12-15 (over 3 months ago from this FIP creation), as evidenced by transaction [`bafy2bzacecmyltma2j42wai3vqymu6apmcervz3eia3oixhyyls2tdcvj7okm`](https://filfox.info/en/message/bafy2bzacecmyltma2j42wai3vqymu6apmcervz3eia3oixhyyls2tdcvj7okm). Tooling and client libraries have been updated to use `ExtendSectorExpiration2`, making this a safe removal that simplifies the API without affecting functionality.
+
+## Test Cases
+
+Test cases will need to ensure that `ExtendSectorExpiration2` method adequately covers all the functionality previously offered by `ExtendSectorExpiration` and that the system behaves normally following the removal.
+
+Care should be taken with the removal of `ExtendSectorExpiration` tests to avoid removal of tests for other parts of the system that are not covered by other test cases. In this situation, tests should be reworked to use `ExtendSectorExpiration2` to test the same functionality.
+
+## Security Considerations
+
+This FIP doesn't alter any security features of the Filecoin protocol, as it only involves the removal of a deprecated method that has been superseded by a more capable one. It may potentially reduce the attack surface area where there could be previously unknown security bugs.
+
+## Incentive Considerations
+
+Removing the `ExtendSectorExpiration` method from the miner actor does not have any direct impact on the incentive mechanisms in the Filecoin protocol. All the functionality continues to be available through `ExtendSectorExpiration2`, so there are no changes to the incentives for extending sector commitments.
+
+## Product Considerations
+
+Once the deprecated `ExtendSectorExpiration` method is removed, users and developers will experience a cleaner and less confusing system. Having a single method for extending sector expiration makes the API more consistent and easier to understand. Additionally, the simplification of code pathways in the miner actor could potentially enable further optimisations in the future.
+
+## Implementation
+
+As the implementation involves removal of a method from the current codebase, it is expected to be relatively straightforward and low-risk.
+
+No migration is necessary as the functionality remains available through the existing `ExtendSectorExpiration2` method.
+
+### Removal tasks
+
+- Remove `ExtendSectorExpiration` method from the miner actor.
+- Ensure that tests for `ExtendSectorExpiration2` effectively cover the same functionality.
+- Ensure that removal of tests previously covering `ExtendSectorExpiration` doesn't result in an overall reduction in test coverage.
+- Ensure all systems behave normally with the removal of `ExtendSectorExpiration`.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/README.md
+++ b/README.md
@@ -137,3 +137,5 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0099](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0099.md) | Delegation of Authority for F3 Parameter Setting | FRC | @Kubuxu @BigLep | Accepted |
 | [0100](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0100.md) | Removing Batch Balancer, Replacing It With a Per-sector Fee and Removing Gas-limited Constraints | FIP | irene (@irenegia), AX (@AxCortesCubero), rvagg (@rvagg), molly (@momack2), kiran (@kkarrancsu)| Accepted |
 | [0101](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0101.md) | Removal of the ProveCommitAggregate method from the miner actor | FIP | Rod Vagg (@rvagg) | Accepted |
+(@rvagg) | Draft |
+| [0103](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0103.md) | Removal of the ExtendSectorExpiration method from the miner actor | FIP | Rod Vagg (@rvagg) | Draft |


### PR DESCRIPTION
**Discussion: https://github.com/filecoin-project/FIPs/discussions/1136**

## Simple Summary

This FIP proposes the removal of the `ExtendSectorExpiration` method from the miner actor as it has been superseded by the more flexible `ExtendSectorExpiration2` method, which was introduced in FIP-0045 and supports verified claims.

## Abstract

The `ExtendSectorExpiration` method in the miner actor was designed to allow storage providers to extend the commitment period of their sectors. However, with the introduction of `ExtendSectorExpiration2` in FIP-0045, which offers the same functionality plus additional flexibility for handling verified claims, the original method has become redundant. This proposal aims to remove the legacy `ExtendSectorExpiration` method to simplify the protocol, reduce technical debt, and streamline code pathways in the miner actor. It's important to note that sector extension functionality remains fully supported through the enhanced `ExtendSectorExpiration2` method.
