### PR TITLE
FIP-0092: clarify wording in gas calculation section

### DIFF
--- a/FIPS/fip-0092.md
+++ b/FIPS/fip-0092.md
@@ -165,36 +165,69 @@ NI-PoRep is an *optional* feature that can be opt-in for those interested. The
 
 ### Gas calculations
 
-According to [FIP-0013](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0013.md#gas-calculations), for the verification of N aggregated Groth16 proofs (ie, circuits) the total gas charged is 
-- 32GiB sector: 449900*N/10 + Constant32(N)
-- 64GiB sector: 359280*N/10 + Constant64(N),
-  
-where Constant32(N) and Constant64(N) are as follows:
+According to [FIP-0013](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0013.md#gas-calculations), for the verification of `N` aggregated Groth16 proofs (ie, circuits) the total gas charged is:
 
-| Number of circuits aggregated, N      | Number of interactive PoRep proofs aggregated | Number of NI-PoRep proofs aggregated, k | Constant32(N) | Constant64(N) |
-| ----------- | ----------- | ----------- |  ----------- |  ----------- |
-| ≤ 64 = 2^6  | ≤ 6         | - | 103’994’170 | 102’581’240 |
-| ≤ 128 = 2^7 | ≤12 | 1 | 112’356’810| 110’803’030|
-| ≤ 256 = 2^8  | ≤ 25 | 2 | 122’912’610 | 120’803’700|
-| ≤ 512 = 2^9 | ≤ 51 | ≤ 4 | 137’559’930 | 134’642’130 |
-| ≤1024 = 2^10 | ≤ 102 | ≤ 8 | 162’039’100 | 157’357’890 |
-| ≤ 2048 = 2^11 | ≤ 204 | ≤ 16 | 210’960’780 | 203’017’690 |
-| ≤ 4096 = 2^12 | ≤ 409 | ≤ 32 | 318’351’180 | 304’253’590 |
-| ≤ 8192 = 2^13 | ≤ 819 | ≤ 65 | 528’274’980 | 509’880’640 |
+- 32GiB sector: `449900*N/10 + Constant32(N)` (where `N/10` approximates the number of sectors)
+- 64GiB sector: `359280*N/10 + Constant64(N)` (where `N/10` approximates the number of sectors)
 
-Since one NI-PoRep proof (128 bits of security) corresponds to aggregating 126 circuits, the gas units for the verification of one NI-PoRep proof is given by:
+> **Note on terminology**: In the formulas above, "N" refers to the number of individual Groth16 circuit proofs being verified, not the number of sectors. For regular interactive PoRep, each sector requires approximately 10 circuits. For NI-PoRep, each sector requires 126 circuits to achieve 128 bits of security. This means that for `k` sectors, `N = 10*k` for regular PoRep and `N = 126*k` for NI-PoRep.
 
-32GiB sector: 44990*126 + 112356810 = 118025550
+where `Constant32(N)` and `Constant64(N)` are as follows:
 
-64GiB sector: 35928*126 + 110803030 = 115329958 
+| Number of circuits aggregated, N<br>(snark circuits) | Number of interactive PoRep proofs aggregated<br>(≈ N/10 sectors) | Number of NI-PoRep proofs aggregated, k<br>(≈ N/126 sectors) | `Constant32(N)`<br>(gas) | `Constant64(N)`<br>(gas) |
+|:-------------:|:-----:|:----:|  ------------:|  ------------:|
+| ≤ 64 = 2^6    | ≤ 6   | -    | `103,994,170` | `102,581,240` |
+| ≤ 128 = 2^7   | ≤ 12  | 1    | `112,356,810` | `110,803,030` |
+| ≤ 256 = 2^8   | ≤ 25  | 2    | `122,912,610` | `120,803,700` |
+| ≤ 512 = 2^9   | ≤ 51  | ≤ 4  | `137,559,930` | `134,642,130` |
+| ≤ 1024 = 2^10 | ≤ 102 | ≤ 8  | `162,039,100` | `157,357,890` |
+| ≤ 2048 = 2^11 | ≤ 204 | ≤ 16 | `210,960,780` | `203,017,690` |
+| ≤ 4096 = 2^12 | ≤ 409 | ≤ 32 | `318,351,180` | `304,253,590` |
+| ≤ 8192 = 2^13 | ≤ 819 | ≤ 65 | `528,274,980` | `509,880,640` |
 
-**Aggregation**:
+#### NI-PoRep Gas Calculation
 
-The minimum number of sector NI-PoRep proofs that may be aggregated is 1, and the maximum is 65. Using the same formula as above, the gas charged for verification of k NI-PoRep proofs (128 bits) is equal to 
+Since one NI-PoRep sector (128 bits of security) requires 126 circuits (compared to 10 circuits for a regular PoRep sector), the gas units for the verification of one NI-PoRep sector is given by:
 
-32GiB sector: 44990 * 126 * k + Constant32(126 * k) 
+- 32GiB sector: `44990*126 + 112,356,810 = 118,025,550` (where `44990` is `449900/10`, the per-circuit cost)
+- 64GiB sector: `35928*126 + 110,803,030 = 115,329,958` (where `35928` is `359280/10`, the per-circuit cost)
 
-64GiB sector: 35928 * 126 * k + Constant64(126 * k) 
+#### NI-PoRep Aggregation
+
+The minimum number of sector NI-PoRep proofs that may be aggregated is 1, and the maximum is 65. For NI-PoRep, the gas charged for verification of k aggregated NI-PoRep proofs is:
+
+- For 32GiB sectors: `44990 * 126 * k + StepCost32(k)`
+- For 64GiB sectors: `35928 * 126 * k + StepCost64(k)`
+
+Where `StepCost32(k)` and StepCost64(k) follow these specific thresholds:
+
+| Number of NI-PoRep proofs (k) | `StepCost32(k)` | `StepCost64(k)` |
+|:-----------------------------:| ---------------:| ---------------:|
+| 1                             | `112,356,810`   | `110,803,030`   |
+| 2                             | `122,912,610`   | `120,803,700`   |
+| 3-4                           | `137,559,930`   | `134,642,130`   |
+| 5-8                           | `162,039,100`   | `157,357,890`   |
+| 9-16                          | `210,960,780`   | `203,017,690`   |
+| 17-32                         | `318,351,180`   | `304,253,590`   |
+| 33-65                         | `528,274,980`   | `509,880,640`   |
+
+Note that these thresholds differ from those used for regular PoRep. For example, 3 NI-PoRep proofs will use the `137,559,930` step cost, whereas 3 regular PoRep proofs would have a zero step cost.
+
+#### Examples
+
+Example 1: Gas cost for 3 aggregated 32GiB NI-PoRep proofs:
+
+```
+44990 * 126 * 3 + 137,559,930 = 16,995,960 + 137,559,930 = 154,555,890 gas
+```
+
+Example 2: Gas cost for 5 aggregated 64GiB NI-PoRep proofs:
+
+```
+35928 * 126 * 5 + 157,357,890 = 22,634,640 + 157,357,890 = 179,992,530 gas
+```
+
+#### Batch Gas Charge
 
 Usually `GasUsed * BaseFee` is burned for every message. However, for aggregated batches of proofs (for example, ProveCommitSectorsAggregate and ProveReplicaUpdates3 messages), we charge an additional proportional fee introduced in FIP0013 and updated in FIP0024. With NI-PoRep, when aggregating at most 5 sectors (i.e. k ≤ 5), the per sector gas cost is already larger than the current value (~34721049), and therefore, in this case, there is no need for any additional fee. On the other hand, when aggregating 6 or more sectors, the additional fee is needed again. In this case, the fee is computed using the current function used for interactive proofs (`PayBatchGasCharge` function, as stated in [FIP0024](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0024.md#specification)) but passing as input the number of proofs - 5.
 


### PR DESCRIPTION
NI-PoRep, already active in the network. While revisiting the gas calculations I found this particularly impenetrable when viewed from a per-sector view. This is my attempt to clear up the confusion for the future visitor who isn't as privy to the snark/circuit/proof/sector nuances involved.

[Preview rendered version of this here](https://github.com/filecoin-project/FIPs/blob/rvagg/fip-0092/gas-clarify/FIPS/fip-0092.md#gas-calculations).