### PR TITLE
FIP: Removal of the ProveReplicaUpdates method from the miner actor

### DIFF
--- a/FIPS/fip-0106.md
+++ b/FIPS/fip-0106.md
@@ -1,5 +1,5 @@
 ---
-fip: "XXXX"
+fip: "0106"
 title: Removal of the ProveReplicaUpdates method from the miner actor
 author: "Rod Vagg (@rvagg)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/1151
@@ -12,7 +12,7 @@ requires: FIP-0019
 replaces: N/A
 ---
 
-# FIP-XXXX: Removal of the ProveReplicaUpdates method from the miner actor
+# FIP-0106: Removal of the ProveReplicaUpdates method from the miner actor
 
 ## Simple Summary
 

--- a/FIPS/fip-remove-provereplicaupdates.md
+++ b/FIPS/fip-remove-provereplicaupdates.md
@@ -1,0 +1,77 @@
+---
+fip: "XXXX"
+title: Removal of the ProveReplicaUpdates method from the miner actor
+author: "Rod Vagg (@rvagg)"
+discussions-to: https://github.com/filecoin-project/FIPs/discussions/1151
+status: Draft
+type: Technical (Core)
+category: Core
+created: 2025-05-20
+spec-sections: 
+requires: FIP-0019
+replaces: N/A
+---
+
+# FIP-XXXX: Removal of the ProveReplicaUpdates method from the miner actor
+
+## Simple Summary
+
+This FIP proposes the removal of the `ProveReplicaUpdates` method (Method 27) from the miner actor as it has been superseded by the more flexible `ProveReplicaUpdates3` method, which offers the same functionality in a more effective manner.
+
+## Abstract
+
+The `ProveReplicaUpdates` method in the miner actor was originally introduced by [FIP-0019 (Snap Deals)](./fip-0019.md) to allow storage providers to update sealed sectors with new data without re-sealing. However, with the introduction of `ProveReplicaUpdates3`, which offers the same functionality with greater flexibility and efficiency, the original method has become redundant. This proposal aims to remove the legacy `ProveReplicaUpdates` method to simplify the protocol, reduce technical debt, and streamline code pathways in the miner actor. It's important to note that Snap Deals functionality remains fully supported through the enhanced `ProveReplicaUpdates3` method.
+
+## Change Motivation
+
+The main motivation behind this change is to clean up builtin actors and reduce technical debt. By removing the redundant `ProveReplicaUpdates` method, we can simplify the protocol, making it more maintainable and less error-prone. The existence of two methods that serve similar purposes creates unnecessary complexity in the codebase and requires additional maintenance overhead. Since `ProveReplicaUpdates3` provides enhanced functionality and is already the only method actively used for Snap Deals operations, there is no longer a need to maintain the original method.
+
+## Specification
+
+Implementation-wise, this change involves removing the `ProveReplicaUpdates` method (Method 27) from the miner actor, along with all associated helper methods that are not used by other methods, and all tests that uniquely test its functionality. This includes removing the entire implementation of `prove_replica_updates` and its supporting code that isn't shared with other methods.
+
+## Design Rationale
+
+The decision to propose this change follows the same principle as [FIP-0101](./fip-0101.md) and [FIP-0103](./fip-0103.md), which removed other unused methods from the miner actor. When newer, more flexible methods are available and in use, removing redundant legacy methods simplifies the codebase and reduces maintenance burden.
+
+With `ProveReplicaUpdates3` fully supporting all functionality of the original method plus additional capabilities, maintaining both methods is unnecessary and adds complexity. Efficient and clean code is prioritised over accumulated complexity that increases the potential for bugs.
+
+## Backwards Compatibility
+
+This change will not introduce any backward incompatibilities, as the `ProveReplicaUpdates3` method fully covers all the functionality previously offered by `ProveReplicaUpdates`. Storage providers have already migrated to using the newer method, as evidenced by the lack of on-chain usage of the original method for at least six months. Tooling and client libraries have been updated to use `ProveReplicaUpdates3`, making this a safe removal that simplifies the API without affecting functionality.
+
+## Test Cases
+
+Test cases will need to ensure that `ProveReplicaUpdates3` method adequately covers all the functionality previously offered by `ProveReplicaUpdates` and that the system behaves normally following the removal.
+
+Care should be taken with the removal of `ProveReplicaUpdates` tests to avoid removal of tests for other parts of the system that are not covered by other test cases. In this situation, tests should be reworked to use `ProveReplicaUpdates3` to test the same functionality.
+
+## Security Considerations
+
+This FIP doesn't alter any security features of the Filecoin protocol, as it only involves the removal of a deprecated method that has been superseded by a more capable one. It may potentially reduce the attack surface area where there could be previously unknown security bugs.
+
+## Incentive Considerations
+
+Removing the `ProveReplicaUpdates` method from the miner actor does not have any direct impact on the incentive mechanisms in the Filecoin protocol. All the functionality continues to be available through `ProveReplicaUpdates3`, so there are no changes to the incentives for updating sector data via Snap Deals.
+
+## Product Considerations
+
+Once the deprecated `ProveReplicaUpdates` method is removed, users and developers will experience a cleaner and slightly less confusing system. Having a single method for Snap Deals makes the API more consistent and easier to understand. Additionally, the simplification of code pathways in the miner actor could potentially enable further optimisations in the future.
+
+## Implementation
+
+As the implementation involves removal of a method from the current codebase, it is expected to be relatively straightforward and low-risk.
+
+No migration is necessary as the functionality remains available through the existing `ProveReplicaUpdates3` method.
+
+### Removal tasks
+
+- Remove `ProveReplicaUpdates` method from the miner actor.
+- Remove any helper methods or functions that were used exclusively by `ProveReplicaUpdates`.
+- Ensure that tests for `ProveReplicaUpdates3` effectively cover the same functionality.
+- Ensure that removal of tests previously covering `ProveReplicaUpdates` doesn't result in an overall reduction in test coverage.
+- Ensure all systems behave normally with the removal of `ProveReplicaUpdates`.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/README.md
+++ b/README.md
@@ -139,4 +139,4 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0101](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0101.md) | Removal of the ProveCommitAggregate method from the miner actor | FIP | Rod Vagg (@rvagg) | Accepted |
 | [0102](./FRCs/frc-0102.md) | Wallet-Signing Envelope for Arbitrary Messages | FRC | "Hugo Dias (@hugomrdias), Bumblefudge (@bumblefudge)" | Draft |
 | [0103](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0103.md) | Removal of the ExtendSectorExpiration method from the miner actor | FIP | Rod Vagg (@rvagg) | Draft |
-| [XXXX](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-remove-provereplicaupdates.md) | Removal of the ProveReplicaUpdates method from the miner actor | FIP | Rod Vagg (@rvagg) | Draft |
+| [0106](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0106.md) | Removal of the ProveReplicaUpdates method from the miner actor | FIP | Rod Vagg (@rvagg) | Draft |

--- a/README.md
+++ b/README.md
@@ -139,3 +139,4 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0101](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0101.md) | Removal of the ProveCommitAggregate method from the miner actor | FIP | Rod Vagg (@rvagg) | Accepted |
 | [0102](./FRCs/frc-0102.md) | Wallet-Signing Envelope for Arbitrary Messages | FRC | "Hugo Dias (@hugomrdias), Bumblefudge (@bumblefudge)" | Draft |
 | [0103](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0103.md) | Removal of the ExtendSectorExpiration method from the miner actor | FIP | Rod Vagg (@rvagg) | Draft |
+| [XXXX](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-remove-provereplicaupdates.md) | Removal of the ProveReplicaUpdates method from the miner actor | FIP | Rod Vagg (@rvagg) | Draft |


### PR DESCRIPTION
This PR introduces a new FIP proposing the removal of the `ProveReplicaUpdates` method (Method 27) from the miner actor.

The method has been effectively superseded by `ProveReplicaUpdates3`, which provides the same Snap Deals functionality with greater flexibility. On-chain analysis shows no active usage of this method for at least six months, with storage providers having fully migrated to the newer method.

This follows the same pattern as [FIP-0101](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0101.md) and [FIP-0103](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0103.md), which removed other deprecated methods. The change will reduce technical debt and simplify the protocol without impacting functionality.

**Discussion thread: https://github.com/filecoin-project/FIPs/discussions/1151**