### PR TITLE
Update recommendations on F3 rebroadcast timeout increments

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -432,7 +432,7 @@ GossiPBFT(instance, inputChain, baseChain, committee) → decision, certificate:
 01:  round ← 0
 02:  proposal ← inputChain  // Chain that the participant locally believes should be decided.
 03:  timeout ← 2*Δ
-04:  timeout_rebroadcast ← timeout + 1 // Any value larger than timeout, at implementation discretion.
+04:  timeout_rebroadcast ← timeout + 1 // Any value larger than the initial timeout, at implementation discretion.
 05:  value ← proposal // Used to communicate the voted value to others (proposal or 丄)
 06:  evidence ← nil   // Used to communicate evidence for the voted value
 07:  C ← {baseChain}
@@ -565,11 +565,15 @@ The reBroadcast function broadcasts and remembers a message. It then sets a time
 87:        }
            // Increase and trigger timeout_rebroadcast again.
            // The amount to increase is at the discretion of the participant.
-88:        timeout_rebroadcast = timeout_rebroadcast + 1
+88:        timeout_rebroadcast = timeout_rebroadcast + 1 // Arbitrary increment
 89:        trigger(timeout_rebroadcast) 
 ```
 
-A participant may skip to a subsequent round upon receiving sufficient messages to demonstrate that a strong quorum of other participants have reached that round.
+The `timeout_rebroadcast` value is incremented arbitrarily on lines 51 and 88. Implementations have discretion in choosing the increment size, which should balance two competing concerns: the increment must be large enough to allow rebroadcast message propagation without creating excessive network traffic, yet small enough to enable participants to quickly re-enter the main processing loop when progress becomes possible.
+
+Continuing to rebroadcast messages independently of phase timeouts becomes critical at higher rounds. Since phase timeouts increase exponentially with round number (line 50), relying solely on phase timeout expiry for rebroadcasting would create extended periods of network inactivity. This could trap participants in a state where they cannot make progress due to insufficient network state propagation, as they would wait through increasingly long timeout periods before attempting to rebroadcast essential messages.
+
+A participant may skip to a subsequent round upon receiving sufficient messages to demonstrate that a strong quorum of other participants has reached that round.
 
 In order to avoid unbounded accumulation of state, some messages from some future rounds are immediately dropped.
 
@@ -853,7 +857,7 @@ Within each GPBFT instance, a chain broadcast is triggered by:
 1. **Phase Transition**: Immediately triggers a broadcast.
 2. **Periodic Rebroadcast**: Occurs every `RebroadcastInterval`.
 
-The broadcasted chain is selected based on:
+The broadcast chain is selected based on:
 * The triggering event.
 * Previous chain broadcasts in the instance.
 


### PR DESCRIPTION
After the F3 activation on mainnet the network experienced a lack of progress at an instance that ultimately entered more than 20 rounds.

What we observed was that there were extended periods of total radio silence in the network where none of the participants were exchanging messages. This was caused by two things:
 1. the FIP defines lack of progress as no change in instance, round or phase, and
 2. the rebroadcast timeout is always incremented relative to phase timeout.

The increase in rounds increased the phase timeout exponentially, and rebroadcast never triggered until the phase timeout expired.

Update the FIP to:
 * adjust advice on arbitrary rebroadcast timeout increment
 * rebroadcast independent of phase timeout at high rounds

The changes made here specifically avoid updating the pseudocode to keep it abstract. Because, the rebroadcast interval is not a consensus-critical process and is largely at the discretion of implementers.

For reference, the go-f3 implementation of this FIP has opted to:
* await phase rebroadcast for the first 3 rounds before rebroadcasting any messages.
* beyond 3 rounds rebroadcast with exponential backoff without waiting for phase timeout to expire.
* cap the maximum exponential backoff for rebroadcast

See:
* https://github.com/filecoin-project/go-f3/issues/983
* https://github.com/filecoin-project/go-f3/pull/1003

Fixes: https://github.com/filecoin-project/go-f3/issues/1009
