### PR TITLE
Note the use of justification to infer messages in F3

### DIFF
--- a/FIPS/fip-0086.md
+++ b/FIPS/fip-0086.md
@@ -418,6 +418,14 @@ A [merkle tree](#merkle-tree-format) is built from these encoded `ECTipset` valu
       ```
     * Returns a tuple $\langle participants, aggSig \rangle$ where $participants$ are all participants such that $m.sender ∈ M'$ (in some compact/compressed representation, i.e. a bitmask with optional run-length encoding) and $aggSig$ is an aggregate signature (BLS) across all of those participants on $(m.i||m.T||m.r||m.v)$ for some $m ∈ M'$.
 
+#### Inferring Messages from Justifications
+
+Vote justifications serve as compact evidence that a strong quorum of nodes has sent identical messages for a specific phase and value. When a participant receives a justification but has not yet received the underlying messages it represents, the participant can treat that justification as equivalent to having received those messages directly. This optimization enables nodes to make faster progress toward consensus without waiting for majority network state propagation or relying on message re-broadcasts.
+
+This inference mechanism is particularly valuable in two phases:
+
+1. During the PREPARE phase, nodes can use PREPARE justifications found in COMMIT messages (same round), PREPARE messages (next round), or CONVERGE messages (next round) to immediately satisfy their PREPARE phase requirements and advance. 
+2. Similarly, during the COMMIT phase, nodes can use COMMIT to 丄 justifications found in CONVERGE messages (next round) or PREPARE messages (next round) to immediately satisfy their COMMIT to 丄 phase requirements.
 
 #### GossiPBFT pseudocode (main algorithm)
 


### PR DESCRIPTION
Update the FIP to state that collecting all the messages in practice is not strictly required as long as there exists a justification as evidence of their existence.

* Originally captured in: https://github.com/filecoin-project/go-f3/issues/342
* Implemented in: https://github.com/filecoin-project/go-f3/pull/1024
