### PR TITLE
FRC-0099: use jsonc code block for nicer comment display

### DIFF
--- a/FRCs/frc-0099.md
+++ b/FRCs/frc-0099.md
@@ -82,7 +82,7 @@ To streamline this process and enhance flexibility, we propose delegating the au
 <details>
 <summary>Click to expand the Dynamic Manifest Schema estimate.</summary>
 
-```jsonc
+```json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",

--- a/FRCs/frc-0099.md
+++ b/FRCs/frc-0099.md
@@ -82,7 +82,7 @@ To streamline this process and enhance flexibility, we propose delegating the au
 <details>
 <summary>Click to expand the Dynamic Manifest Schema estimate.</summary>
 
-```json
+```jsonc
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
@@ -351,7 +351,7 @@ To streamline this process and enhance flexibility, we propose delegating the au
 
 Below isn't the full ABI, but captures the key functions.  See the [implementation notes](#implementation) for links to the full ABI.
 
-```json
+```jsonc
 [
   // This will be invoked by the implementers to set the expiration as 2025-08-01T00:00:00Z
   {


### PR DESCRIPTION
Use 'jsonc' for code block to support '//' without ugly red error blocks when rendered.
