### PR TITLE
FIP-0107: Add API Behaviour Specifications and Migration Guide

### DIFF
--- a/FIPS/fip-0107.md
+++ b/FIPS/fip-0107.md
@@ -60,7 +60,6 @@ The `MessageReceipt` structure will be modified to include both a reference to t
 
 ```go
 type MessageReceipt struct {
-    version      MessageReceiptVersion
     ExitCode     exitcode.ExitCode
     Return       []byte
     GasUsed      int64
@@ -69,6 +68,8 @@ type MessageReceipt struct {
     Message      *cid.Cid        // NEW: Reference to the executed message, nullable for backward compatibility
 }
 ```
+
+_(Note: Lotus includes a `version MessageReceiptVersion` field for internal version tracking, this is not in the encoded form but may be used during implementation of this FIP to add a third version on top of the existing original version 1 form and the version 2 form introduced with [FIP-0049](./fip-0049.md).)_
 
 Both new fields are nullable (pointers in Go, `Option`s in Rust) for backward compatibility. They are expected to be omitted for receipts prior to activation of this FIP but always be non-empty after activation of this FIP. The `EventsRoot` field was added in [FIP-0049](./fip-0049.md) and is similarly omitted prior to activation to that FIP.
 
@@ -143,6 +144,56 @@ The FVM will maintain codec information from the execution return value and this
 
 IPLD codec codes used in this field are recorded in the [multicodec table](https://github.com/multiformats/multicodec/blob/master/table.csv) either with the `ipld` or `serialization` tag.
 
+### API Behaviour
+
+To maintain backward compatibility, existing APIs will handle implicit messages as follows:
+
+#### Existing APIs - Maintaining Backward Compatibility
+
+##### Message Enumeration APIs
+
+The following APIs will exclude implicit messages when returning lists or counts:
+- `ChainGetMessagesInTipset` - returns only explicit messages
+- `ChainGetParentMessages` - returns only explicit messages
+- `ChainGetParentReceipts` - returns only receipts for explicit messages
+
+##### Ethereum-Compatible APIs
+
+All Ethereum-compatible APIs will exclude implicit messages from transaction lists and counts to maintain compatibility:
+- `eth_getBlockTransactionCountByNumber` and `eth_getBlockTransactionCountByHash` - count only explicit messages
+- `eth_getTransactionByBlockHashAndIndex` and `eth_getTransactionByBlockNumberAndIndex` - use indices based on explicit messages only (implicit messages have no index)
+- `eth_getBlockReceipts` - returns receipts for explicit messages only
+- `eth_getLogs` and filter APIs (`eth_newFilter`, `eth_getFilterLogs`, `eth_getFilterChanges`) - exclude events from implicit messages (this should be handled automatically as implicit messages currently emit only CBOR-encoded events, not Ethereum-compatible RAW events)
+
+##### Direct Query APIs
+
+APIs that accept specific message CIDs/hashes will return implicit messages when queried directly:
+- `ChainGetMessage` - returns implicit messages when queried by CID
+- `eth_getTransactionByHash` - returns implicit messages when queried by hash
+- `eth_getTransactionReceipt` - returns receipts for implicit messages when queried by hash
+
+##### Event APIs
+
+- `GetActorEventsRaw` - will return events from both explicit and implicit messages
+- `SubscribeActorEventsRaw` - will stream events from both explicit and implicit messages
+
+The `ActorEvent` type will be extended with a field to indicate implicit message origin:
+
+```go
+type ActorEvent struct {
+    // existing fields...
+    Implicit bool `json:"implicit,omitempty"` // true if event originated from an implicit message
+}
+```
+
+#### New APIs for Accessing Implicit Messages
+
+Since existing list-based APIs cannot return implicit messages without breaking compatibility, new mechanisms are needed:
+
+**Option 1 - New API**: `ChainGetAllParentReceipts` - returns all receipts including those for implicit messages. This API would return the same results as `ChainGetParentReceipts` before activation of this FIP, but would include additional receipts for implicit messages after activation.
+
+**Option 2 - v2 API**: As of the time of writing, development has begun on the Lotus v2 APIs. It is expected this will eventually lead to extension of [FRC-0104 Common Node APIs](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0104.md). This opportunity could be used to break APIs and introduce an options object that would allow optional inclusion of implicit messages. e.g. `ChainGetParentReceipts` could add a new paramter that would change the returned list to prevent filtering: `{ includeImplicits: true }`.
+
 ## Design Rationale
 
 This design was chosen to minimise disruption to existing systems while providing complete visibility into system operations.
@@ -151,6 +202,7 @@ This design was chosen to minimise disruption to existing systems while providin
 2. **Execution ordering**: Maintains consistency with current execution semantics.
 3. **Message specification**: Uses the existing Lotus implicit message format as a stable basis for all node implementations.
 4. **Gas limit approach**: Maintains existing execution patterns while clarifying that implicit messages operate outside block gas limit constraints. This ensures system operations can complete successfully regardless of user message activity or network congestion.
+5. **API compatibility**: Excludes implicit messages from most APIs by default to avoid breaking existing integrations while allowing direct access when needed.
 
 ### Storage Efficiency Assessment
 
@@ -179,7 +231,21 @@ The change to include the codec is minimal but impactful, adding just a single n
 This change introduces several backwards incompatibilities:
 
 1. **Receipt Structure Change**: The `MessageReceipt` structure modification requires updates to all code that directly accesses receipt fields; this change will take effect at the next epoch after the activation epoch of this FIP
-2. **Message/Receipt Count Mismatch**: Code assuming `length(deduped parent messages) == length(receipts)` will break and must be updated to use receipts as the canonical list of messages executed and filter out implicit messages as required
+2. **Message/Receipt Count Mismatch**: Code assuming `length(deduped parent messages) == length(receipts)` will break and must be updated to either:
+   - Use APIs that maintain the old behaviour by filtering out implicit messages
+   - Adapt to use the new `ChainGetAllParentReceipts` (or alternative v2) API when access to all receipts is needed
+
+### API Migration Guide
+
+Applications should adapt as follows:
+
+1. **For transaction enumeration**: Continue using existing APIs which will maintain backward compatibility
+2. **For complete chain analysis**:
+   - Monitor `GetActorEventsRaw` for system events (check `implicit` field)
+   - Use new `ChainGetAllParentReceipts` (or alternative v2) API when available
+   - Query implicit messages directly by CID when needed
+3. **For Ethereum compatibility**: No changes needed - existing behaviour is maintained
+4. **For receipt processing**: Update code to handle both old and new receipt formats with null checks on new fields
 
 ### Storage Impact
 
@@ -230,6 +296,32 @@ No state migration is necessary; migration exists entirely within a node impleme
 - For all epochs before this change is activated, `MessageReceipt` will not contain a link to the executed message or return data codec, `length(deduped parent messages) == length(receipts)` will be true, and implicit messages and their events will not be accessible
 - For all epochs after this change is activated, `MessageReceipt` will contain a link to the executed message and return data codec, `length(deduped parent messages) != length(receipts)` will be true, and implicit messages along with their events will be accessible (a node may choose to not persist any events after execution, as is the case today)
 
+### API Compatibility Details
+
+#### Index Stability
+
+For index-based APIs like `eth_getTransactionByBlockHashAndIndex`:
+- Indices continue to refer only to explicit messages
+- Implicit messages have no index and cannot be accessed via index-based APIs
+- This prevents index shifts that would break existing integrations
+
+#### Discovery Patterns
+
+Implicit messages can be discovered through:
+1. **Event-based discovery**: Events from `GetActorEventsRaw` include the emitter's actor ID and message CID
+2. **Receipt-based discovery**: Using `ChainGetAllParentReceipts` (or alternative v2 API) to iterate all receipts
+3. **Direct query**: If the CID is known, query directly via `ChainGetMessage`
+
+**Important**: Not all implicit messages emit events. Reward messages currently emit no events, and cron messages only emit events for specific operations (e.g., sector terminations). Applications requiring complete implicit message visibility must use receipt-based discovery.
+
+#### Recommended Integration Pattern
+
+Tools requiring implicit message processing should:
+1. Monitor `GetActorEventsRaw` for system events
+2. Use the message CID from receipts to query message details
+3. Check the `implicit` field on events to identify system-generated events
+4. Use `ChainGetAllParentReceipts` for complete message enumeration when available
+
 ## Test Cases
 
 The following test scenarios should be implemented:
@@ -248,6 +340,7 @@ The following test scenarios should be implemented:
    - Create test chain including sector termination events
    - Verify events are properly captured in receipts
    - Compare event data with expected state changes
+   - Verify `implicit` field is set correctly on events from implicit messages
 
 4. **Return data codec testing**:
    - Test different actor message returns with various codecs
@@ -262,6 +355,15 @@ The following test scenarios should be implemented:
    - Test message retrieval APIs with implicit messages present
    - Verify filtering capabilities for explicit vs implicit messages
    - Test receipt counts vs message counts across tipsets
+
+7. **API compatibility testing**:
+   - Verify `ChainGetMessagesInTipset` excludes implicit messages
+   - Verify `ChainGetParentMessages` excludes implicit messages
+   - Verify `ChainGetParentReceipts` excludes implicit message receipts
+   - Verify Ethereum APIs exclude implicit messages from counts and lists
+   - Verify direct query APIs return implicit messages when queried by CID/hash
+   - Verify `eth_getLogs` excludes events from implicit messages
+   - Test suggested `ChainGetAllParentReceipts` or v2 variant returns all receipts
 
 ## Security Considerations
 
@@ -288,6 +390,7 @@ Negative impacts from this change include:
 
 1. **Network-version Based Tipset Decoding**: Given the `MessageReceipt` changes and `length(deduped parent messages) != length(receipts)` difference, complexity is introduced in node implementations that attempt to retain compatibility across the upgrade boundary
 2. **Block Storage Increase**: The additional storage requirements, while modest in direct size, accumulate over time and include blockstore indexing overhead
+3. **API Implementation Complexity**: Implementations must filter implicit messages from various APIs to maintain backward compatibility
 
 ## Product Considerations
 
@@ -323,9 +426,11 @@ Implementation requires changes to:
    - Update validation logic for parent receipts
 
 3. **API layer**:
-   - Update message retrieval methods to handle implicit messages
-   - Add filtering options for explicit vs implicit messages
-   - Update return data handling to use codec information for proper decoding
+   - Update message retrieval methods to filter implicit messages by default
+   - Update receipt retrieval methods to filter implicit message receipts
+   - Add `implicit` field to `ActorEvent` type
+   - Implement suggested `ChainGetAllParentReceipts` API
+   - Update Ethereum APIs to maintain backward compatibility
 
 4. **FVM changes**:
    - Preserve IPLD codec information during execution
@@ -335,14 +440,6 @@ Note that FVM changes are not consensus-critical and can be performed prior to t
 
 * Lotus PR (TODO)
 * Forest PR (TODO)
-
-## Open Questions
-
-Non-consensus-critical questions that are not yet answered by this FIP but may be considered during or after implementation:
-
-* **API Behaviour**: Should implicit messages be exposed by default or require specific flags in message-fetching APIs like `ChainGetMessagesInTipset`?
-* **Ethereum API Compatibility**: How should Filecoin Ethereum-compatible APIs (`EthGetBlockTransactionCountBy*`, `EthGetTransaction*`, `EthGetBlockReceipts`) handle implicit messages? Should they be excluded to maintain compatibility or included with special identifiers?
-* **Filtering Mechanisms**: What standard filtering mechanisms should be provided to distinguish between user messages and system implicit messages?
 
 ## Copyright
 


### PR DESCRIPTION
This change addresses the open questions in FIP-0107 regarding API behaviour for implicit messages by adding comprehensive specifications for how existing APIs will handle implicit messages while maintaining backward compatibility.

There is still one slightly open question in here, suggesting either the addition of a new `ChainGetAllParentReceipts` API or a new form `ChainGetParentReceipts` on the currently under development /v2 that takes a new options parameter. We could come back and close that off once we've decided (it might depend on timing of this FIP).