### PR TITLE
FIP-0109: Enable smart contract notifications for Direct Data Onboarding (DDO)

### DIFF
--- a/FIPS/fip-0109.md
+++ b/FIPS/fip-0109.md
@@ -1,5 +1,5 @@
 ---
-fip: "XXXX"
+fip: "0109"
 title: Enable smart contract notifications for Direct Data Onboarding (DDO)
 author: "Rod Vagg (@rvagg)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/1181
@@ -10,7 +10,7 @@ created: 2025-02-05
 requires: "FIP-0076"
 ---
 
-# FIP-XXXX: Enable smart contract notifications for Direct Data Onboarding (DDO)
+# FIP-0109: Enable smart contract notifications for Direct Data Onboarding (DDO)
 
 ## Simple Summary
 

--- a/FIPS/fip-unlock-sector-notifications.md
+++ b/FIPS/fip-unlock-sector-notifications.md
@@ -1,0 +1,178 @@
+---
+fip: "XXXX"
+title: Unlock sector content notifications to arbitrary actors
+author: "Rod Vagg (@rvagg)"
+discussions-to: "<create a discussion link and add it here>"
+status: Draft
+type: Technical
+category: Core
+created: 2025-02-05
+requires: "FIP-0076"
+---
+
+# FIP-XXXX: Unlock sector content notifications to arbitrary actors
+
+## Simple Summary
+Remove the restriction that limits _sector content change_ notifications to only the storage market actor (f05), allowing any actor designed to handle the [FRC-42](../FRCs/frc-0042.md) `SectorContentChanged` method to receive notifications when data is onboarded to sectors.
+
+## Abstract
+[FIP-0076](./fip-0076.md) introduced Direct Data Onboarding (DDO) with a notification system that allows actors to be notified when data is committed to sectors. However, these notifications are currently restricted to only the built-in storage market actor (f05). This FIP proposes removing this restriction, enabling any actor designed to handle the FRC-42 `SectorContentChanged` method to receive notifications, thereby enabling new data-driven applications on Filecoin, such as custom marketplaces, data DAOs, and data verification services.
+
+## Change Motivation
+The current restriction of notifications to only the storage market actor limits the potential applications that can be built on top of Filecoin's data onboarding system. By unlocking notifications to arbitrary actors:
+
+1. Smart contracts can directly track when their data is committed to sectors
+2. Custom marketplaces can implement their own deal activation logic
+3. Data DAOs can monitor and react to data commitments in real-time
+4. Applications can implement complex data availability and verification schemes
+5. New types of data-driven DeFi applications become possible
+
+This change continues the evolution of Filecoin toward being a more dynamic and programmable storage network.
+
+## Specification
+
+### Storage Miner Actor Changes
+
+Remove [the check](https://github.com/filecoin-project/builtin-actors/blob/5aad41bfa29d8eab78f91eb5c82a03466c6062d2/actors/miner/src/notifications.rs#L62-L69) in the `notify_data_consumers` function in the miner actor that restricts notifications to only the storage market actor. Specifically, remove this code block:
+
+```rust
+// Reject notifications to any actor other than the built-in market.
+if notifee != STORAGE_MARKET_ACTOR_ADDR {
+    if require_success {
+        return Err(
+            actor_error!(illegal_argument; "disallowed notification receiver: {}", notifee),
+        );
+    }
+    continue;
+}
+```
+
+The notification system will continue to operate as before, but without this restriction.
+
+### Notification Success Control
+
+Storage providers have control over whether notification failures should abort the sector commitment process through the `require_notification_success` boolean field in parameters for both:
+
+* `ProveCommitSectors3`: For new sector commitments
+* `ProveReplicaUpdates3`: For sector data updates
+
+When set to `true`, any notification failure will cause the entire operation to fail. When `false`, failure will be silent and the remainder of the operation will proceed. This allows storage providers to decide how strictly they want to enforce notification delivery for different use-cases.
+
+### Example Solidity Contract Interface
+
+Smart contracts wishing to receive sector content notifications must implement this interface:
+
+```solidity
+// SPDX-License-Identifier: MIT
+interface ISectorContentReceiver {
+    struct PieceChange {
+        bytes data;     // CID of the piece
+        uint size;      // Size of the piece
+        bytes payload;  // Custom payload sent with notification
+    }
+    
+    struct SectorChange {
+        uint64 sector;                  // Sector number
+        int64 minimumCommitmentEpoch;   // Minimum epoch until which data is committed
+        PieceChange[] added;            // Pieces added to the sector
+    }
+    
+    struct SectorReturn {
+        bool[] added;   // Success/failure for each piece
+    }
+
+    // Function selector: 0x868e10c4
+    function handle_filecoin_method(
+        uint64 method,
+        uint64 codec,
+        bytes calldata params
+    ) external returns (uint32 exitCode, uint64 codec, bytes memory returnData);
+}
+```
+
+When data is committed to a sector and this contract is specified as a notification receiver, the `handle_filecoin_method` function will be called with:
+- `method`: The FRC-42 method number for `SectorContentChanged` (2034386435)
+- `codec`: 0x51 (CBOR codec)
+- `params`: CBOR-encoded `SectorContentChangedParams`
+
+The contract must decode the parameters and respond with:
+- `exitCode`: 0 for success
+- `codec`: 0x51 (CBOR codec) 
+- `returnData`: CBOR-encoded `SectorContentChangedReturn`
+
+See [FIP-0076.md](./fip-0076.md) for the full specification of the `SectorContentChanged` method.
+
+## Design Rationale
+The original restriction was put in place as a security precaution to prevent potential issues with untrusted code, particularly:
+
+1. Out-of-gas conditions in notification receivers that could cause entire sector commitment operations to fail
+2. The lack of recovery mechanisms when notifications fail
+3. The potential for malicious actors to deliberately cause sector activation failures
+
+However, this FIP proposes that these risks can be managed because:
+
+1. Storage providers have full control over which actors receive notifications
+2. The `require_notification_success` flag allows storage providers to choose whether notification failures should abort operations
+3. Gas limits and other FVM protections provide basic safety boundaries
+4. The notification system is already designed to be "untrusted" - the miner actor does not rely on notification results for critical operations
+5. Smart contracts receiving notifications can only read the data, not modify sector state
+
+## Backwards Compatibility
+This change is backwards compatible:
+- Existing sector commitments continue working as before
+- The storage market actor continues receiving notifications unchanged
+- No state migration is required
+
+## Test Cases
+To be provided with implementation.
+
+## Security Considerations
+1. **Out-of-gas Protection**: When `require_notification_success=true`, any notification failure, including out-of-gas conditions, will cause the entire sector activation process to fail (including the case of batching sectors, where all sectors will fail to activate). Storage providers must carefully consider this when:
+   - Choosing notification receivers
+   - Setting gas limits
+   - Deciding whether to use `require_notification_success=true`
+
+2. **Notification Failure Handling**:
+   - With `require_notification_success=true`: No retry mechanism exists - any failure will abort message processing
+   - With `require_notification_success=false`: Failures are ignored and message processing continues
+
+3. **Storage Provider Controls**:
+   - Only storage providers can specify notification receivers
+   - Storage providers can test notification receivers before deployment
+   - The `require_notification_success` flag provides some flexibility in handling failures
+
+4. **Other Considerations**:
+   - Malicious notification receivers cannot affect sector commitment when `require_notification_success=false`
+   - Gas limits protect against infinite loops or excessive computation
+   - The read-only nature of notifications prevents state manipulation
+
+## Incentive Considerations
+This change creates new opportunities for economic models around data onboarding while preserving existing incentives:
+- Marketplaces can implement custom deal activation logic
+- Data DAOs can create incentive systems for specific data types
+- Applications can implement proofs of data availability
+
+## Product Considerations
+This change enables several new product categories:
+
+1. Custom Storage Markets
+   - Implement specialised deal matching and activation
+   - Create niche markets for specific data types
+
+2. Data Verification Services
+   - Track and verify data availability
+   - Implement custom data quality metrics
+
+3. Data DAOs
+   - Coordinate decentralised data storage
+   - Implement governance around data storage
+
+4. DeFi Applications
+   - Create financial products based on data storage
+   - Implement data-backed tokens
+
+## Implementation
+To be completed.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/FIPS/fip-unlock-sector-notifications.md
+++ b/FIPS/fip-unlock-sector-notifications.md
@@ -1,8 +1,8 @@
 ---
 fip: "XXXX"
-title: Unlock sector content notifications to arbitrary actors
+title: Enable smart contract notifications for Direct Data Onboarding (DDO)
 author: "Rod Vagg (@rvagg)"
-discussions-to: "<create a discussion link and add it here>"
+discussions-to: https://github.com/filecoin-project/FIPs/discussions/1181
 status: Draft
 type: Technical
 category: Core
@@ -10,15 +10,18 @@ created: 2025-02-05
 requires: "FIP-0076"
 ---
 
-# FIP-XXXX: Unlock sector content notifications to arbitrary actors
+# FIP-XXXX: Enable smart contract notifications for Direct Data Onboarding (DDO)
 
 ## Simple Summary
+
 Remove the restriction that limits _sector content change_ notifications to only the storage market actor (f05), allowing any actor designed to handle the [FRC-42](../FRCs/frc-0042.md) `SectorContentChanged` method to receive notifications when data is onboarded to sectors.
 
 ## Abstract
-[FIP-0076](./fip-0076.md) introduced Direct Data Onboarding (DDO) with a notification system that allows actors to be notified when data is committed to sectors. However, these notifications are currently restricted to only the built-in storage market actor (f05). This FIP proposes removing this restriction, enabling any actor designed to handle the FRC-42 `SectorContentChanged` method to receive notifications, thereby enabling new data-driven applications on Filecoin, such as custom marketplaces, data DAOs, and data verification services.
+
+[FIP-0076](./fip-0076.md) introduced Direct Data Onboarding (DDO) with a notification system that allows actors to be notified when data is committed to sectors. However, these notifications are currently restricted to only the built-in storage market actor (f05). This FIP proposes removing this restriction, enabling any actor designed to handle the [FRC-42](../FRCs/frc-0042.md) `SectorContentChanged` method to receive notifications. This change enables new data-driven applications on Filecoin, such as custom marketplaces, data DAOs, and data verification services, advancing Filecoin toward becoming a comprehensive marketplace of storage services.
 
 ## Change Motivation
+
 The current restriction of notifications to only the storage market actor limits the potential applications that can be built on top of Filecoin's data onboarding system. By unlocking notifications to arbitrary actors:
 
 1. Smart contracts can directly track when their data is committed to sectors
@@ -27,7 +30,7 @@ The current restriction of notifications to only the storage market actor limits
 4. Applications can implement complex data availability and verification schemes
 5. New types of data-driven DeFi applications become possible
 
-This change continues the evolution of Filecoin toward being a more dynamic and programmable storage network.
+This change continues the evolution of Filecoin toward being a more dynamic and programmable storage network, enabling integration between sealed storage and other on-chain primitives like Proof of Data Possession (PDP).
 
 ## Specification
 
@@ -49,6 +52,26 @@ if notifee != STORAGE_MARKET_ACTOR_ADDR {
 
 The notification system will continue to operate as before, but without this restriction.
 
+### Notification Grouping and Delivery
+
+The miner actor optimises notification delivery by grouping all notifications destined for the same actor into a single message. When processing `ProveCommitSectors3` or `ProveReplicaUpdates3`, the miner actor performs the following grouping:
+
+All sectors that contain pieces specifying the same notification receiver are collected as a group. It then sends a single `SectorContentChanged` message to each unique receiver containing all relevant sectors, with each sector including its complete piece manifest.
+
+This grouping mechanism significantly reduces gas costs compared to sending individual notifications per sector. Storage providers can further optimise costs by minimising the number of distinct notification receivers within a single prove-commit or replica-update operation.
+
+The piece manifest included in each sector notification is particularly important for smart contract applications. Contracts will typically focus on pieces rather than sectors. Each piece in the manifest includes its CID, size, and any custom payload specified during sector commitment. This granular information enables contracts to identify and process only the pieces relevant to their business logic, such as verifying that specific data has been committed, tracking storage of particular datasets, or activating deals for individual pieces within a sector.
+
+Each piece in the activation manifest can specify multiple notification receivers. This provides flexibility for complex multi-party arrangements where different actors need to be notified about the same piece commitment. However, this flexibility also introduces gas consumption risks, as each additional notifee requires a separate method invocation. Storage providers must carefully consider the gas implications when allowing multiple notifees per piece, especially when combined with large batch operations.
+
+### Notification Payloads
+
+The payload field in each notification provides a flexible mechanism for passing application-specific data to receiving actors. This arbitrary bytes field is scoped to a specific notifee rather than being tied to the piece itself, allowing different receivers to get different contextual information about the same piece commitment.
+
+Use cases for the payload field may include deal identifiers linking the piece to off-chain or on-chain agreements, payment references for automated settlement systems, authorisation tokens or signatures validating the storage request, metadata about processing requirements or data handling instructions, and governance references for DAO-controlled storage operations. The flexibility of this field enables rich application-specific behaviours while maintaining protocol-level simplicity. Standardisation of the payload field may be pursued in a future FRC.
+
+Smart contracts receiving notifications can efficiently filter the piece manifest to identify their data of interest, avoiding the need to process information about unrelated pieces sharing the same sector. This design supports efficient multi-client sectors where different pieces may be relevant to different applications or clients.
+
 ### Notification Success Control
 
 Storage providers have control over whether notification failures should abort the sector commitment process through the `require_notification_success` boolean field in parameters for both:
@@ -56,29 +79,102 @@ Storage providers have control over whether notification failures should abort t
 * `ProveCommitSectors3`: For new sector commitments
 * `ProveReplicaUpdates3`: For sector data updates
 
-When set to `true`, any notification failure will cause the entire operation to fail. When `false`, failure will be silent and the remainder of the operation will proceed. This allows storage providers to decide how strictly they want to enforce notification delivery for different use-cases.
+When set to `true`, any notification failure indicated by the receiving actor will cause the entire operation to fail. When `false`, notification failures are ignored and the remainder of the operation will proceed. This flag specifically controls how the miner actor responds to the success/failure indicators returned by notification receivers, not gas-related failures which would cause the entire transaction to revert regardless of this setting.
+
+### Notification Data Structures
+
+Smart contracts receiving sector content notifications will receive parameters encoded as CBOR in tuple form. The notification contains comprehensive information about sectors and their piece manifests, structured as follows:
+
+```rust
+// Root structure for sector content change notifications
+pub struct SectorContentChangedParams {
+    // Distinct sectors with changed content
+    pub sectors: Vec<SectorChanges>,
+}
+
+// Description of changes to one sector's content
+pub struct SectorChanges {
+    // Identifier of sector being updated
+    pub sector: SectorNumber,
+    // Minimum epoch until which the data is committed to the sector
+    // Note the sector may later be extended without necessarily another notification
+    pub minimum_commitment_epoch: ChainEpoch,
+    // Information about pieces added to (or retained in) the sector
+    // This may be only a subset of sector content
+    // Inclusion here does not mean the piece was definitely absent previously
+    // Exclusion here does not mean a piece has been removed since a prior notification
+    pub added: Vec<PieceChange>,
+}
+
+// Description of a piece of data committed to a sector
+pub struct PieceChange {
+    pub data: Cid,
+    pub size: PaddedPieceSize,
+    // A receiver-specific identifier
+    // E.g. an encoded deal ID which the provider claims this piece satisfies
+    pub payload: RawBytes,
+}
+```
+
+Tuple form CBOR, means that struct fields are serialized as arrays rather than maps, with fields appearing in the order defined above.
+
+The `minimum_commitment_epoch` field indicates the minimum duration for which the data is intended to remain in the sector. Storage providers may extend sectors beyond this epoch without triggering additional notifications. Smart contracts should account for this when implementing time-based logic.
+
+The `added` field contains pieces relevant to the notification receiver. This may represent a subset of the total sector content, as other pieces may have different or no notification receivers. The semantics are important: inclusion of a piece does not guarantee it is newly added (it may have been present previously), and exclusion does not indicate removal. These semantics accommodate replica updates where existing pieces may be re-notified to contracts.
+
+The `payload` field in each piece provides receiver-specific context. Storage providers encode application-specific data in this field, such as deal identifiers, authorization tokens, or processing instructions relevant to the receiving contract. The interpretation of this payload is entirely determined by the agreement between the storage provider and the receiving contract.
+
+### Notification Response Format
+
+Contracts receiving notifications must return a properly structured response indicating whether they accept or reject each piece notification. The response must match the exact structure of the notification request, with one acceptance indicator per piece per sector, in the same order as received. These structures must be encoded as CBOR in tuple form:
+
+```rust
+// For each sector notified, return acceptance for each piece.
+pub struct SectorContentChangedReturn {
+    pub sectors: Vec<SectorReturn>,
+}
+
+pub struct SectorReturn {
+    pub added: Vec<PieceReturn>,
+}
+
+pub struct PieceReturn {
+    pub accepted: bool,
+}
+```
+
+The `accepted` field indicates whether the receiver successfully processed and accepts the piece notification. When `require_notification_success` is true, any `accepted: false` response will cause the entire sector commitment operation to abort. This mechanism allows contracts to enforce business logic requirements at the point of sector commitment.
 
 ### Example Solidity Contract Interface
 
-Smart contracts wishing to receive sector content notifications must implement this interface:
+Smart contracts that wish to receive sector content notifications must implement the `handle_filecoin_method` function with appropriate security measures. The critical security requirement is verifying that the caller is a legitimate miner actor. Due to the fundamental constraints of Filecoin's architecture, miner actors cannot execute arbitrary method calls on other actors. They can only invoke `SectorContentChanged` through the strictly controlled execution paths of `ProveCommitSectors3` or `ProveReplicaUpdates3`, and only after successful proof verification. Therefore, confirming that the caller is a registered miner actor provides sufficient assurance that the notification represents a genuine sector commitment.
+
+The following example demonstrates the recommended implementation pattern for secure notification handling:
 
 ```solidity
 // SPDX-License-Identifier: MIT
-interface ISectorContentReceiver {
-    struct PieceChange {
-        bytes data;     // CID of the piece
-        uint size;      // Size of the piece
-        bytes payload;  // Custom payload sent with notification
+pragma solidity ^0.8.17;
+
+import { PowerTypes } from "filecoin-solidity/v0.8/types/PowerTypes.sol";
+import { PowerAPI } from "filecoin-solidity/v0.8/PowerAPI.sol";
+
+contract SectorContentReceiver {
+
+    // Verify the caller is a registered miner actor
+    modifier onlyMinerActor() {
+        require(isMinerActor(msg.sender), "Caller must be a miner actor");
+        _;
     }
-    
-    struct SectorChange {
-        uint64 sector;                  // Sector number
-        int64 minimumCommitmentEpoch;   // Minimum epoch until which data is committed
-        PieceChange[] added;            // Pieces added to the sector
-    }
-    
-    struct SectorReturn {
-        bool[] added;   // Success/failure for each piece
+
+    function isMinerActor(address caller) internal view returns (bool) {
+        try PowerAPI.minerPower(caller) returns (PowerTypes.MinerPowerReturn memory result) {
+            // If the call succeeds, the address is a registered miner
+            // Additional validation could check if the miner has non-zero power
+            return true;
+        } catch {
+            // If the call fails, the address is not a registered miner
+            return false;
+        }
     }
 
     // Function selector: 0x868e10c4
@@ -86,93 +182,110 @@ interface ISectorContentReceiver {
         uint64 method,
         uint64 codec,
         bytes calldata params
-    ) external returns (uint32 exitCode, uint64 codec, bytes memory returnData);
+    ) external onlyMinerActor returns (uint32 exitCode, uint64 codec, bytes memory returnData) {
+        // Verify this is the SectorContentChanged method
+        require(method == 2034386435, "Invalid method");
+        require(codec == 0x51, "Invalid codec"); // CBOR
+
+        // Decode CBOR params into SectorContentChangedParams
+        // Process notifications according to contract's business logic
+        // Build SectorContentChangedReturn with acceptance status for each piece
+
+        // Return success with CBOR-encoded response
+        exitCode = 0;
+        codec = 0x51;
+        returnData = /* CBOR-encoded SectorContentChangedReturn */;
+    }
 }
 ```
 
-When data is committed to a sector and this contract is specified as a notification receiver, the `handle_filecoin_method` function will be called with:
-- `method`: The FRC-42 method number for `SectorContentChanged` (2034386435)
-- `codec`: 0x51 (CBOR codec)
-- `params`: CBOR-encoded `SectorContentChangedParams`
+Contracts receiving notifications need to decode the CBOR-encoded parameters containing sector and piece information, process the notifications according to their specific requirements, and return a properly formatted CBOR-encoded response indicating acceptance or rejection of each piece notification. The response structure must exactly match the notification structure, with one `accepted` boolean per piece per sector.
 
-The contract must decode the parameters and respond with:
-- `exitCode`: 0 for success
-- `codec`: 0x51 (CBOR codec) 
-- `returnData`: CBOR-encoded `SectorContentChangedReturn`
-
-See [FIP-0076.md](./fip-0076.md) for the full specification of the `SectorContentChanged` method.
+**Note on Tooling**: The filecoin-solidity library currently does not include pre-built utilities for handling `SectorContentChanged` notifications. Future updates to the library should include type definitions and helper functions to simplify the implementation of notification receivers, including CBOR encoding/decoding utilities for the notification parameters and response structures, type-safe representations of the sector content change data structures, and example implementations demonstrating common notification handling patterns.
 
 ## Design Rationale
-The original restriction was put in place as a security precaution to prevent potential issues with untrusted code, particularly:
 
-1. Out-of-gas conditions in notification receivers that could cause entire sector commitment operations to fail
-2. The lack of recovery mechanisms when notifications fail
-3. The potential for malicious actors to deliberately cause sector activation failures
+The original restriction was put in place as a security precaution to prevent potential issues with untrusted code, particularly concerns about notification receivers disrupting sector commitments, the lack of recovery mechanisms when notifications fail, and the potential for malicious actors to deliberately cause sector activation failures.
 
-However, this FIP proposes that these risks can be managed because:
+However, this FIP proposes that these risks can be managed because storage providers have full control over which actors receive notifications, the `require_notification_success` flag allows storage providers to choose whether notification failures should abort operations, gas limits and other FVM protections provide basic safety boundaries, the notification system is already designed to be "untrusted" - the miner actor does not rely on notification results for critical operations, and smart contracts receiving notifications can only read the data, not modify sector state.
 
-1. Storage providers have full control over which actors receive notifications
-2. The `require_notification_success` flag allows storage providers to choose whether notification failures should abort operations
-3. Gas limits and other FVM protections provide basic safety boundaries
-4. The notification system is already designed to be "untrusted" - the miner actor does not rely on notification results for critical operations
-5. Smart contracts receiving notifications can only read the data, not modify sector state
+Despite these mitigations, the risk of gas exhaustion remains. Computationally expensive smart contract operations could still cause sector commitments or updates to abort when gas limits are exceeded. Storage providers must therefore carefully vet notification receiver contracts before use, as they bear full responsibility for managing this operational risk. This places the burden of due diligence squarely on storage providers, who must balance the benefits of smart contract integration against the potential for gas-related failures.
+
+### Alternatives Considered
+
+Several alternative approaches were evaluated before settling on the push-based notification mechanism:
+
+**Pull-based Sector Status Method**: A `SectorStatus` builtin method exposed to smart contracts is [under consideration for future development](https://github.com/filecoin-project/FIPs/discussions/1108). This would allow contracts to query the status of any sector, including whether it has been onboarded, terminated (early or on-time), faulted, or its expected expiry time and verified data size. However, this approach requires contracts to be actively invoked to check sector status, limiting its utility for reactive applications. While this method may complement the notification system in the future, it does not address the immediate need for contracts to be notified upon data commitment.
+
+**Off-chain Watcher Services**: An alternative approach involves off-chain services that monitor sector lifecycle events and submit transactions to smart contracts when relevant events occur. While technically feasible, this approach introduces trust assumptions as contracts cannot independently verify the authenticity of such notifications. Additionally, it creates operational complexity and potential points of failure outside the protocol.
+
+**Verified Registry Integration**: As pioneered in the Eastore project by Shashank Trivedi, smart contracts can query the verified registry to check sector status for verified deals. This approach leverages existing on-chain infrastructure but is limited to verified deals only and requires pull-based queries similar to the sector status method. It cannot support unverified data or provide immediate notifications upon sector activation.
+
+The push-based notification system provides immediate, trustless notifications to smart contracts without requiring external infrastructure or limiting functionality to specific deal types. However, it does not cover the entire lifecycle of a sector, so is insufficient by itself to provide all needed functionality for smart contract storage markets.
 
 ## Backwards Compatibility
-This change is backwards compatible:
-- Existing sector commitments continue working as before
-- The storage market actor continues receiving notifications unchanged
-- No state migration is required
+
+This change is backwards compatible. Existing sector commitments continue working as before, the storage market actor continues receiving notifications unchanged, and no state migration is required.
 
 ## Test Cases
+
 To be provided with implementation.
 
 ## Security Considerations
-1. **Out-of-gas Protection**: When `require_notification_success=true`, any notification failure, including out-of-gas conditions, will cause the entire sector activation process to fail (including the case of batching sectors, where all sectors will fail to activate). Storage providers must carefully consider this when:
-   - Choosing notification receivers
-   - Setting gas limits
-   - Deciding whether to use `require_notification_success=true`
 
-2. **Notification Failure Handling**:
-   - With `require_notification_success=true`: No retry mechanism exists - any failure will abort message processing
-   - With `require_notification_success=false`: Failures are ignored and message processing continues
+### Notification Authenticity Verification
 
-3. **Storage Provider Controls**:
-   - Only storage providers can specify notification receivers
-   - Storage providers can test notification receivers before deployment
-   - The `require_notification_success` flag provides some flexibility in handling failures
+The security of the notification system relies on the immutability and correctness of the miner actor code. Storage providers control their miner actors through a limited interface that prevents arbitrary method calls or state modifications. The `SectorContentChanged` method can only be invoked by the miner actor itself during the execution of sector activation methods, after all proofs have been verified and state changes committed.
 
-4. **Other Considerations**:
-   - Malicious notification receivers cannot affect sector commitment when `require_notification_success=false`
-   - Gas limits protect against infinite loops or excessive computation
-   - The read-only nature of notifications prevents state manipulation
+When smart contracts receive `SectorContentChanged` notifications, they must verify the authenticity of the caller to ensure the notification represents a genuine sector commitment. The security model relies on the fact that miner actors can only invoke `SectorContentChanged` as part of the `ProveCommitSectors3` or `ProveReplicaUpdates3` execution paths, after successful proof verification.
+
+**Recommended Verification Pattern**: Smart contracts should verify that the calling address is a registered miner actor by querying the power actor's `MinerPowerExported` method (method number 36284446). This checks whether the caller exists in the power table, confirming it is a legitimate miner actor.
+
+**Insecure Patterns to Avoid**: Contracts must NOT rely on address format checks alone (such as verifying addresses starting with `0xff000000000000000...` for f0 addresses). Such checks are vulnerable to exploitation through built-in actors that can execute arbitrary calls from f0 addresses.
+
+### Operational Security Considerations
+
+**Gas Consumption**: The notification system introduces several vectors for gas consumption that compound multiplicatively. Each notification receiver requires a separate method invocation, and when combined with multiple pieces per sector and multiple sectors per batch, the total gas consumption can escalate rapidly. For example, a batch of 100 sectors, each containing 10 pieces with 2 distinct notifees per piece, where all notifee addresses are unique, would result in 2,000 separate (immediate) contract invocations within a single transaction.
+
+Beyond the sheer number of invocations, the gas consumption of receiving contracts themselves presents an additional risk. While simple contracts might only consume minimal gas for recording notifications, more complex contracts performing extensive validation, state updates, or triggering additional contract calls could consume substantial gas per notification. This consumption is difficult to predict without thorough testing, as it depends entirely on the receiving contract's implementation.
+
+Storage providers should therefore conduct gas profiling before committing to notification arrangements. This includes not only estimating the base cost of multiple invocations but also understanding the gas consumption patterns of specific receiving contracts under various load conditions. Providers should establish gas consumption thresholds and may need to limit batch sizes or the number of notifees per operation to maintain predictable costs. The compounding nature of these factors means that what appears manageable at small scale can become prohibitively expensive in production scenarios with larger batches or more complex notification requirements.
+
+**Notification Failure Handling**: The `require_notification_success` flag controls how the miner actor responds to the success/failure indicators returned by notification receivers. With `require_notification_success=true`, any receiver returning `accepted: false` will abort the entire operation. With `require_notification_success=false`, such failures are ignored and sector commitment proceeds. This flag does not affect gas-related failures, which would cause the entire transaction to revert regardless of this setting.
+
+**Storage Provider Controls**: Only storage providers can specify notification receivers. Storage providers can test notification receivers before deployment. The `require_notification_success` flag provides flexibility in handling failures based on business requirements.
+
+**Other Considerations**: The `require_notification_success` flag only controls whether the miner actor responds to explicit failure signals from notification receivers. It does not protect against gas exhaustion attacks. A malicious or poorly designed notification receiver can still cause entire sector commitment transactions to fail by consuming excessive gas, regardless of this flag's setting. While gas limits provide an upper bound on computation, they cannot prevent a contract from consuming all available gas within that limit, which would cause the entire transaction to revert.
+
+The read-only nature of notifications does provide important security guarantees by preventing any manipulation of the miner actor's state or sector metadata. Notification receivers cannot modify sector commitments, change deal information, or alter any aspect of the proven storage. However, this isolation does not extend to gas consumption, which remains a shared resource across the entire transaction.
+
+Storage providers must therefore treat all notification receivers as potentially hostile from a gas consumption perspective. Even contracts that appear benign during testing may behave differently under various conditions or after upgrades. The combination of these factors means that notification receivers represent a significant operational risk that must be actively managed through careful vetting, testing, and monitoring of gas consumption patterns.
 
 ## Incentive Considerations
-This change creates new opportunities for economic models around data onboarding while preserving existing incentives:
-- Marketplaces can implement custom deal activation logic
-- Data DAOs can create incentive systems for specific data types
-- Applications can implement proofs of data availability
+
+This change creates new opportunities for economic models around data onboarding while preserving existing incentives. Marketplaces can implement custom deal activation logic, data DAOs can create incentive systems for specific data types, and applications can implement proofs of data availability.
+
+The notification grouping mechanism creates an incentive for storage providers to consolidate their interactions with specific smart contracts. By batching sectors that notify the same contract within a single prove-commit operation, storage providers can reduce their gas costs while maintaining the same functionality.
 
 ## Product Considerations
-This change enables several new product categories:
 
-1. Custom Storage Markets
-   - Implement specialised deal matching and activation
-   - Create niche markets for specific data types
+This change enables several new product categories and advances Filecoin's evolution toward a comprehensive marketplace of storage services:
 
-2. Data Verification Services
-   - Track and verify data availability
-   - Implement custom data quality metrics
+**Integration with Proof of Data Possession**: By connecting PoRep sectors directly with smart contracts, this proposal creates a foundation for integrating sealed storage with Proof of Data Possession (PDP) systems currently implemented entirely within smart contracts. This integration enables smart contracts to offer differentiated storage services based on both sealed and unsealed proofs.
 
-3. Data DAOs
-   - Coordinate decentralised data storage
-   - Implement governance around data storage
+**Marketplace of Services**: The notification system enables smart contracts to act as service providers offering various storage products built on Filecoin's storage primitives. These services can range from basic storage with custom payment terms to complex offerings combining storage with computation, retrieval guarantees, or data availability proofs. This marketplace model extends beyond storage to potentially include other verifiable services.
 
-4. DeFi Applications
-   - Create financial products based on data storage
-   - Implement data-backed tokens
+**Enhanced Payment Activity**: By enabling direct integration between storage commitments and smart contracts, this proposal facilitates increased on-chain payment activity. Smart contracts can implement sophisticated payment schemes, including streaming payments, milestone-based releases, and conditional payments based on storage performance metrics.
+
+**Market Expansion**: The ability for smart contracts to receive storage notifications opens new markets for storage providers. Custom marketplaces can target specific verticals with tailored requirements, payment methods, and service level agreements, allowing storage providers to diversify their client base and revenue streams.
+
+Specific applications enabled include custom storage markets that implement specialised deal matching and activation logic, data verification services that track and verify data availability, data DAOs that coordinate decentralised data storage with governance mechanisms, and DeFi applications that create financial products based on data storage commitments.
 
 ## Implementation
-To be completed.
+
+* builtin-actors: https://github.com/filecoin-project/builtin-actors/pull/1689
+* Lotus integration tests: TODO
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/README.md
+++ b/README.md
@@ -144,3 +144,4 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0106](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0106.md) | Removal of the ProveReplicaUpdates method from the miner actor | FIP | Rod Vagg (@rvagg) | Last Call |
 | [0107](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0107.md) | Implicit Messages in Block Receipts | FIP | Rod Vagg (@rvagg) | Last Call |
 | [0108](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0108.md) | Filecoin Snapshot Format | FRC | Hailong Mu (@hanabi1224) | Draft |
+| [0109](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0109.md) | Enable smart contract notifications for Direct Data Onboarding (DDO) | FIP | Rod Vagg (@rvagg) | Draft |


### PR DESCRIPTION
This FIP removes the restriction that currently limits Direct Data Onboarding (DDO) sector content notifications to only the built-in storage market actor (f05). By enabling any smart contract to receive these notifications when data is committed to sectors, this proposal unlocks new possibilities for custom marketplaces, data DAOs, and other data-driven applications on Filecoin. The change maintains security through storage provider controls while acknowledging the operational responsibility for managing gas consumption risks when interacting with untrusted contracts.

**Discussion: https://github.com/filecoin-project/FIPs/discussions/1181**