### PR TITLE
docs: add FIP-0064 to README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0061](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0061.md) | WindowPoSt Grindability Fix | FIP | @cryptonemo @Kubuxu @DrPeterVanNostrand @Nicola @porcuquine @vmx @arajasek| Final |
 | [0062](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0062.md) | Fallback Method Handler for the Multisig Actor | FIP | Dimitris Vyzovitis (@vyzo), Raúl Kripalani (@raulk)| Final |
 | [0063](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0063.md) | Switching to new Drand mainnet network | FIP | @yiannisbot, @CluEleSsUK, @AnomalRoil, @nikkolasg, @willscott | Final |
-| [0064](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0064.md) | Add Parameters to Base Fee Mechanism | FIP | @guy.goren | Draft |
+| [0064](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0064.md) | Add Parameters to Base Fee Mechanism | FIP | @guy-goren | Draft |
 | [0065](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0065.md) | Ignore built-in market locked balance in circulating supply calculation | FIP | @anorth | Final |
 | [0066](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0066.md) | Piece Retrieval Gateway | FRC | @willscott, @dirkmc | Draft |
 | [0067](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0067.md) | PoRep Security Policy & Replacement Sealing Enforcement | FIP | @Kubuxu, @anorth, @irenegia, @lucaniz | Accepted |


### PR DESCRIPTION
This PR adds FIP-0064 "Add Parameters to Base Fee Mechanism" to the FIPs table in the README.md file, as it was missing.