### PR TITLE
 Fix YAML front-matter parsing error in FIP-0100 

### DIFF
--- a/FIPS/fip-0100.md
+++ b/FIPS/fip-0100.md
@@ -1,13 +1,16 @@
 ---
 fip: "0100"
-title: Removing Batch Balancer, Replacing It With a Per-sector Fee and Removing Gas-limited Constraints
+title: "Removing Batch Balancer, Replacing It With a Per-sector Fee and Removing Gas-limited Constraints"
 author: irene (@irenegia), AX (@AxCortesCubero), rvagg (@rvagg), molly (@momack2), kiran (@kkarrancsu)
-Discussions-to: https://github.com/filecoin-project/FIPs/discussions/1092 and https://github.com/filecoin-project/FIPs/discussions/1105
- status: Final
+Discussions-to:
+  - "https://github.com/filecoin-project/FIPs/discussions/1092"
+  - "https://github.com/filecoin-project/FIPs/discussions/1105"
+status: Final
 type: Technical
 category: Core
-Created: 2025-02-04
+created: 2025-02-04
 ---
+
 
 # FIP-0100: Removing Batch Balancer, Replacing It With a Per-sector Fee and Removing Gas-limited Constraints
 

--- a/FIPS/fip-0100.md
+++ b/FIPS/fip-0100.md
@@ -11,7 +11,6 @@ category: Core
 created: 2025-02-04
 ---
 
-
 # FIP-0100: Removing Batch Balancer, Replacing It With a Per-sector Fee and Removing Gas-limited Constraints
 
 ## Simple Summary

--- a/FIPS/fip-0100.md
+++ b/FIPS/fip-0100.md
@@ -2,7 +2,7 @@
 fip: "0100"
 title: "Removing Batch Balancer, Replacing It With a Per-sector Fee and Removing Gas-limited Constraints"
 author: irene (@irenegia), AX (@AxCortesCubero), rvagg (@rvagg), molly (@momack2), kiran (@kkarrancsu)
-Discussions-to:
+discussions-to:
   - "https://github.com/filecoin-project/FIPs/discussions/1092"
   - "https://github.com/filecoin-project/FIPs/discussions/1105"
 status: Final


### PR DESCRIPTION
Fix YAML front-matter parsing error in FIP-0100 (https://github.com/asamuj/FIPs/blob/master/FIPS/fip-0100.md) by correcting the `Discussions-to` field formatting.
