### PR TITLE
fix(fip-55): f410 binary encoding

### DIFF
--- a/FIPS/fip-0055.md
+++ b/FIPS/fip-0055.md
@@ -127,7 +127,7 @@ The subaddress is the literal Ethereum address in binary form.
 # Ethereum address in Filecoin as an f4 address
 #
 
-0x04 || 0x10 || <binary Ethereum address>
+0x04 || 0x0a || <binary Ethereum address>
 |       |       |
 A       B       C
 


### PR DESCRIPTION
Yes this FIP is final but it has a minor mistake worth fixing.

The `0x` prefix signals hexadecimal. This portion of the address binary is 10 in decimal which is 0x0a. The current FIP says 0x10 which is incorrect. I lost some time debugging this today.