### PR TITLE
Update fip statuses for nv27 upgrade completion

### DIFF
--- a/FIPS/fip-0077.md
+++ b/FIPS/fip-0077.md
@@ -3,7 +3,7 @@ fip: "0077"
 title: Add Cost Opportunity For New Miner Creation
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/780
 author: "Zac <@remakeZK>"
-status: Accepted
+status: Final
 type: Technical
 category: Core
 created: 2023-08-21

--- a/FIPS/fip-0101.md
+++ b/FIPS/fip-0101.md
@@ -3,7 +3,7 @@ fip: "0101"
 title: Removal of the ProveCommitAggregate method from the miner actor
 author: "Rod Vagg (@rvagg)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/1116
-status: Accepted
+status: Final
 type: Technical (Core)
 category: Core
 created: 2025-02-05

--- a/FIPS/fip-0103.md
+++ b/FIPS/fip-0103.md
@@ -3,7 +3,7 @@ fip: "0103"
 title: Removal of the ExtendSectorExpiration method from the miner actor
 author: "Rod Vagg (@rvagg)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/1116
-status: Accepted
+status: Final
 review-period-end: 2025-07-14
 type: Technical (Core)
 category: Core

--- a/FIPS/fip-0105.md
+++ b/FIPS/fip-0105.md
@@ -3,7 +3,7 @@ fip: "0105"
 title: BLS12-381 Precompiles for FEVM (EIP-2537)
 author: "Aarav Mehta (@aaravm), Michael Seiler (@snissn)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/1135
-status: Accepted
+status: Final
 type: Technical
 category: Core
 created: 2025-04-11

--- a/FIPS/fip-0106.md
+++ b/FIPS/fip-0106.md
@@ -3,7 +3,7 @@ fip: "0106"
 title: Removal of the ProveReplicaUpdates method from the miner actor
 author: "Rod Vagg (@rvagg)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/1151
-status: Accepted
+status: Final
 review-period-end: 2025-07-14
 type: Technical (Core)
 category: Core

--- a/FIPS/fip-0109.md
+++ b/FIPS/fip-0109.md
@@ -3,7 +3,7 @@ fip: "0109"
 title: Enable smart contract notifications for Direct Data Onboarding (DDO)
 author: "Rod Vagg (@rvagg)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/1181
-status: Accepted
+status: Final
 review-period-end: 2025-08-29
 type: Technical
 category: Core

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0074](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0074.md) | Remove cron-based automatic deal settlement | FIP | @anorth, @alexytsu| Final |
 | [0075](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0075.md) | Improvements to the FVM randomness syscalls | FIP | @arajasek, @Stebalien | Final |
 | [0076](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0076.md) | Direct data onboarding | FIP | @anorth, @zenground0 | Final |
-| [0077](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0077.md) | Add Cost Opportunity For New Miner Creation | FIP | Zac (@remakeZK), Mike Li (@hunjixin)| Accepted |
+| [0077](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0077.md) | Add Cost Opportunity For New Miner Creation | FIP | Zac (@remakeZK), Mike Li (@hunjixin)| Final |
 | [0078](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0078.md) | Remove Restrictions on the Minting of Datacap | FIP | Fatman13 (@Fatman13), flyworker (@flyworker), stuberman (@stuberman), Eliovp (@Eliovp), dcasem (@dcasem), and The-Wayvy (@The-Wayvy)| Draft |
 | [0079](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0079.md) | Add BLS Aggregate Signatures to FVM | FIP | Jake (@drpetervannostrand) | Final |
 | [0080](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0080.md) | Phasing Out Fil+ and Restoring Deal Quality Multiplier to 1x | FIP | @Fatman13, @ArthurWang1255, @stuberman, @Eliovp, @dcasem, @The-Wayvy | Draft |
@@ -137,12 +137,12 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0098](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0098.md) | Simplify termination fee calculation to a fixed percentage of initial pledge | FIP | Jonathan Schwartz (@Schwartz10), Alex North (@anorth), Jim Pick (@jimpick) | Final |
 | [0099](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0099.md) | Delegation of Authority for F3 Parameter Setting | FRC | @Kubuxu @BigLep | Final |
 | [0100](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0100.md) | Removing Batch Balancer, Replacing It With a Per-sector Fee and Removing Gas-limited Constraints | FIP | irene (@irenegia), AX (@AxCortesCubero), rvagg (@rvagg), molly (@momack2), kiran (@kkarrancsu)| Final |
-| [0101](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0101.md) | Removal of the ProveCommitAggregate method from the miner actor | FIP | Rod Vagg (@rvagg) | Accepted |
+| [0101](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0101.md) | Removal of the ProveCommitAggregate method from the miner actor | FIP | Rod Vagg (@rvagg) | Final |
 | [0102](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0102.md) | Wallet-Signing Envelope for Arbitrary Messages | FRC | "Hugo Dias (@hugomrdias), Bumblefudge (@bumblefudge)" | Draft |
-| [0103](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0103.md) | Removal of the ExtendSectorExpiration method from the miner actor | FIP | Rod Vagg (@rvagg) | Accepted |
+| [0103](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0103.md) | Removal of the ExtendSectorExpiration method from the miner actor | FIP | Rod Vagg (@rvagg) | Final |
 | [0104](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0104.md) | Common Node API | FRC | David Ansermino (@ansermino), Aatif Syed (@aatifsyed), Alexey Krasnoperov (@AlexeyKrasnoperov) | Draft |
-| [0105](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0105.md) | Add Support for EIP-2537 (BLS12-381 Precompiles) in the FEVM | FIP | Aarav Mehta (@aaravm), Michael Seiler (@snissn) | Accepted |
-| [0106](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0106.md) | Removal of the ProveReplicaUpdates method from the miner actor | FIP | Rod Vagg (@rvagg) | Accepted |
+| [0105](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0105.md) | Add Support for EIP-2537 (BLS12-381 Precompiles) in the FEVM | FIP | Aarav Mehta (@aaravm), Michael Seiler (@snissn) | Final |
+| [0106](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0106.md) | Removal of the ProveReplicaUpdates method from the miner actor | FIP | Rod Vagg (@rvagg) | Final |
 | [0107](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0107.md) | Implicit Messages in Block Receipts | FIP | Rod Vagg (@rvagg) | Last Call |
 | [0108](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0108.md) | Filecoin Snapshot Format | FRC | Hailong Mu (@hanabi1224) | Accepted |
-| [0109](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0109.md) | Enable smart contract notifications for Direct Data Onboarding (DDO) | FIP | Rod Vagg (@rvagg) | Accepted |
+| [0109](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0109.md) | Enable smart contract notifications for Direct Data Onboarding (DDO) | FIP | Rod Vagg (@rvagg) | Final |


### PR DESCRIPTION
This is a PR to update the statuses of all FIPs that were implemented as part of NV27 upgrade. 