### PR TITLE
FIP-0110: Shorter minimum deal duration

### DIFF
--- a/FIPS/fip-0110.md
+++ b/FIPS/fip-0110.md
@@ -1,8 +1,8 @@
 ---
-fip: "<to be assigned>"
+fip: "0110"
 title: Allow Shorter Deal Durations
 author: "Will Scott (@willscott)"
-discussions-to: 
+discussions-to: https://github.com/filecoin-project/FIPs/discussions/1205
 status: Draft
 type: Technical
 category: Core
@@ -10,7 +10,7 @@ created: 2025-10-09
 
 ---
 
-# FIP-Number: Allow Shorter Deal Durations
+# FIP-0110: Allow Shorter Deal Durations
 
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the FIP.-->


### PR DESCRIPTION
This FIP proposes to reduce the minimum sector / deal term from 6 to 1 month, to allow flexibility and more 'pay as you go' options.

Accompanying Discussion: [#1205](https://github.com/filecoin-project/FIPs/discussions/1205)