### PR TITLE
Create fil-about-fil+-2025-10-20.md

### DIFF
--- a/FIPS/Fip-Fil+ Improvement Suggestions 2025.md
+++ b/FIPS/Fip-Fil+ Improvement Suggestions 2025.md
@@ -1,0 +1,77 @@
+
+---
+fip:  
+title: "Fil+ Improvement Suggestions 2025"
+author: "MinerTiger (@haheihou5)"
+discussions-to: 
+status: 
+type: 
+created: 2025-10-21
+
+# FRC-0108: Filecoin Snapshot Format
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the FIP.-->
+Proposals for amendments to the fil+ multiplier and DC notarization system
+针对fil+乘数 和 dc公证制度的修改意见
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+
+To address the challenges of expanding network computing capacity, along with the slow progress of the mining ecosystem and conflicts with project stakeholders, compromise measures have been implemented.
+针对全网算力增加困难，和目前矿工生态进展缓慢、与项目方产生矛盾折中措施
+
+## Change Motivation
+<!--The motivation is critical for FIPs that want to change the Filecoin protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the FIP solves. FIP submissions without sufficient motivation may be rejected outright.-->
+
+加快矿工的dc算力进度，降低矿工进入门槛，消减公证人权力
+Accelerate the mining progress of DC, lower the miner entry threshold, and reduce notary power
+
+## Specification
+<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Filecoin implementations. -->
+
+
+## Design Rationale
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
+
+## Backwards Compatibility
+<!--All FIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The FIP must explain how the author proposes to deal with these incompatibilities. FIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+
+## Test Cases
+<!--Test cases for an implementation are mandatory for FIPs that are affecting consensus changes. Other FIPs can choose to include links to test cases if applicable.-->
+
+
+## Security Considerations
+<!--All FIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. FIP submissions missing the "Security Considerations" section will be rejected. A FIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
+Regarding security, we should consider revoking notaries' authority to grant credit to fil+ multipliers outside the platform.
+安全方面应该考虑回收公证人权力，不允许在平台以外授信fil+乘数
+
+## Incentive Considerations
+<!--All FIPs must contain a section that discusses the incentive implications/considerations relative to the proposed change. Include information that might be important for incentive discussion. A discussion on how the proposed change will incentivize reliable and useful storage is required. FIP submissions missing the "Incentive Considerations" section will be rejected. An FIP cannot proceed to status "Final" without a Incentive Considerations discussion deemed sufficient by the reviewers.-->
+
+<!--All FIPs must contain a section that discusses the product implications/considerations relative to the proposed change. Include information that might be important for product discussion. A discussion on how the proposed change will enable better storage-related goods and services to be developed on Filecoin. FIP submissions missing the "Product Considerations" section will be rejected. An FIP cannot proceed to status "Final" without a Product Considerations discussion deemed sufficient by the reviewers.-->
+By reducing the fil+ multiplier to X5 or even x3, CC miners can still maintain some competitive edge without losing the incentive for authentic data. They will continue to prioritize storing genuine data while supplementing with CC data to sustain their competitiveness.
+降低fil+ 乘数到X5 甚至x3，让cc矿工依然可以拥有些许竞争资格，但又没有失去真实数据的激励，矿工依然会优先选择真实数据进行存储，以cc数据来补充以保持竞争力
+## Implementation
+<!--The implementations must be completed before any core FIP is given status "Final", but it need not be completed before the FIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
+
+1.The authority of notaries will be transferred to the DC-issued platform, which can be rebuilt or modified by referencing the data distribution platform https://console.filswan.com/ of the Filswan project, until the complete elimination of fil+. Then, the ratio of DC's computing power to CC's will be entirely determined by market forces.
+
+1 回收公证人权力至dc发放的平台，此发放平台可以参照 filswan项目的数据发放平台 https://console.filswan.com/ 来重建或修改 ，直到完全取消fil+，到时dc 的算力和cc算力比例，将完全由市场自行调整
+
+2  The ban on notaries selling or authorizing DC quotas outside the platform, coupled with miners' reluctance to purchase DC data due to cost concerns and their unwillingness to expand computing capacity because of communication costs, makes this system detrimental to the entire ecosystem.
+
+2 禁止公证人在平台外出售，或授权dc额度；矿工会因为成本问题而拒绝购买dc数据或因为沟通成本而放弃扩大算力规模，所以这个制度对整个生态我认为是有害的。
+
+3 Reduce the fil+ multiplier from X10 to X5 or even X3 to narrow the gap between cc miners, allowing them to temporarily adjust their computational power using cc sectors. This is because the cc generator and the random number generators used by some computational power notaries appear fundamentally identical.
+
+3 将 fil+ 乘数从X10 降低至X5 甚至X3，用以缩小cc矿工的差距，使得矿工也能使用cc扇区来短时间调整自己的算力，因为cc生成器，和某些出售算力的公证人使用的随机数生成器似乎本质上没有区别
+
+List out the tracking issue(s) or PR(s) that will need to be completed for this to land and become "Final".  If there isn't a tracking issue/PR yet, at least list the repo(s) that will need work.  For example, does a builtin-actors change also requires changes in a node implementation like Lotus (either for verfication purposes or to adjust for the protocol change)?  Some example repos to consider: builtin-actors, ref-fvm, rust-fil-proofs, lotus, forest, venus, curio.
+
+## TODO
+<!--A section that lists any unresolved issues or tasks that are part of the FIP proposal. Examples of these include performing benchmarking to know gas fees, validate claims made in the FIP once the final implementation is ready, etc. A FIP can only move to a “Last Call” status once all these items have been resolved.-->
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Fil+ Improvement Suggestions 2025

1.The authority of notaries will be transferred to the DC-issued platform, which can be rebuilt or modified by referencing the data distribution platform https://console.filswan.com/ of the Filswan project, until the complete elimination of fil+. Then, the ratio of DC's computing power to CC's will be entirely determined by market forces.

1 回收公证人权力至dc发放的平台，此发放平台可以参照 filswan项目的数据发放平台 https://console.filswan.com/ 来重建或修改 ，直到完全取消fil+，到时dc 的算力和cc算力比例，将完全由市场自行调整

2  The ban on notaries selling or authorizing DC quotas outside the platform, coupled with miners' reluctance to purchase DC data due to cost concerns and their unwillingness to expand computing capacity because of communication costs, makes this system detrimental to the entire ecosystem.
2 禁止公证人在平台外出售，或授权dc额度；矿工会因为成本问题而拒绝购买dc数据或因为沟通成本而放弃扩大算力规模，所以这个制度对整个生态我认为是有害的。

3 Reduce the fil+ multiplier from X10 to X5 or even X3 to narrow the gap between cc miners, allowing them to temporarily adjust their computational power using cc sectors. This is because the cc generator and the random number generators used by some computational power notaries appear fundamentally identical.

3 将 fil+ 乘数从X10 降低至X5 甚至X3，用以缩小cc矿工的差距，使得矿工也能使用cc扇区来短时间调整自己的算力，因为cc生成器，和某些出售算力的公证人使用的随机数生成器似乎本质上没有区别