### PR TITLE
FIPs: Add draft for EIP-7702 (Set Code for EOAs)

### DIFF
--- a/FIPS/fip-0111.md
+++ b/FIPS/fip-0111.md
@@ -1,5 +1,5 @@
 ---
-fip: "\<to be assigned\>"
+fip: "0111"
 title: Add Support for EIP-7702 (Set Code for EOAs) in the FEVM
 author: "Michael Seiler (@snissn), Aarav Mehta (@aaravm)"
 discussions-to: https://github.com/filecoin-project/FIPs/discussions/1143
@@ -9,7 +9,7 @@ category: Core
 created: 2025-10-30
 ---
 
-# FIP-XXXX: Add Support for EIP-7702 (Set Code for EOAs) in the FEVM
+# FIP-0111: Add Support for EIP-7702 (Set Code for EOAs) in the FEVM
 
 ## Simple Summary
 

--- a/README.md
+++ b/README.md
@@ -147,5 +147,5 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0108](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0108.md) | Filecoin Snapshot Format | FRC | Hailong Mu (@hanabi1224) | Accepted |
 | [0109](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0109.md) | Enable smart contract notifications for Direct Data Onboarding (DDO) | FIP | Rod Vagg (@rvagg) | Final |
 | [0110](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0110.md) | Allow Shorter Deal Durations | FIP | Will Scott (@willscott) | Draft |
-| [XXXX](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-draft_eip7702_eoa_set_code.md) | Add Support for EIP-7702 (Set Code for EOAs) in the FEVM | FIP | Michael Seiler (@snissn), Aarav Mehta (@aaravm) | Draft |
+| [0111](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0111.md) | Add Support for EIP-7702 (Set Code for EOAs) in the FEVM | FIP | Michael Seiler (@snissn), Aarav Mehta (@aaravm) | Draft |
 


### PR DESCRIPTION
EIP-7702 defines a new EIP-2718 transaction type (`0x04`) that includes an `authorization_list`. Each authorization is a signed tuple from an EOA (the "authority") designating a smart contract (the "delegate") to execute on its behalf.

This FIP adapts EIP-7702 to the FEVM architecture. The implementation introduces a new method, `ApplyAndCall`, in the EVM actor. This method atomically processes the authorization list—validating signatures, updating the delegation mapping, and incrementing authority nonces—and then executes the outer transaction call. The FEVM interpreter is updated to recognize these delegations: when a `CALL` targets a delegated EOA, the interpreter executes the delegate's code within the authority's context. This implementation ensures that delegation mappings and nonce increments persist even if the outer transaction call reverts, adhering to the EIP's specified atomicity model.

**Discussion:** https://github.com/filecoin-project/FIPs/discussions/1143