### PR TITLE
fix: add FIP-0110 to the readme-table

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,4 @@ This improvement protocol helps achieve that objective for all members of the Fi
 | [0107](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0107.md) | Implicit Messages in Block Receipts | FIP | Rod Vagg (@rvagg) | Last Call |
 | [0108](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0108.md) | Filecoin Snapshot Format | FRC | Hailong Mu (@hanabi1224) | Accepted |
 | [0109](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0109.md) | Enable smart contract notifications for Direct Data Onboarding (DDO) | FIP | Rod Vagg (@rvagg) | Final |
+| [0110](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0110.md) | Allow Shorter Deal Durations | FIP | Will Scott (@willscott) | Draft |


### PR DESCRIPTION
Add FIP-0110 to the readme-table, which was missed in https://github.com/filecoin-project/FIPs/pull/1203