### PR TITLE
Update FIP-0112: reorder SectorStatusCode enum

### DIFF
--- a/FIPS/fip-0112.md
+++ b/FIPS/fip-0112.md
@@ -94,12 +94,12 @@ pub struct ValidateSectorStatusParams {
 
 ```rust 
 pub enum SectorStatusCode {
-    /// Sector is active (not terminated, not faulty)
-    Active,
     /// Sector is not live (terminated or never committed)
-    Dead,
+    Dead = 0,
+    /// Sector is active (not terminated, not faulty)
+    Active = 1,
 	/// Sector is currently faulty (live but not active) 
-	Faulty,
+	Faulty = 2,
 }
 ```
 


### PR DESCRIPTION

Reviewer @zenground0
This documents a pending change in builtin-actors.
I suggested this change, and it will be likely merged in https://github.com/filecoin-project/builtin-actors/pull/1720
The reason to change it is that Dead, especially Never Committed, makes sense for a default value, and we should use falsy values for defaults.
#### Changes
* reorder SectorStatusCode enum