### PR TITLE
Update FIP-0115: document unchanged behavior for null rounds

### DIFF
--- a/FIPS/fip-0115.md
+++ b/FIPS/fip-0115.md
@@ -69,6 +69,8 @@ The base fee rises when $Premium_{P}$ exceeds $MaxAdj$, and falls otherwise.
 
 $$ BaseFee_{next} = Max(MinBaseFee, BaseFee_{curr} + Min(MaxAdj, Premium_{P} - MaxAdj)) $$
 
+As before, `ComputeNextBaseFee` is not called for null rounds, so the base fee carries over.
+
 ## Design Rationale
 
 Prices provide information signals to market participants to inform their decisions.


### PR DESCRIPTION

Reviewer @rvagg
I have verified that this behavior is not changing in any of the implementations,
but I think this detail should be documented in the FIP since it would otherwise be ambiguous.
#### Changes
* mention that null round base fee behavior is unchanged