### PR TITLE
Update FIP-0115: latex markdown fixes

### DIFF
--- a/FIPS/fip-0115.md
+++ b/FIPS/fip-0115.md
@@ -148,7 +148,7 @@ The method `GasEstimateGasPremium` MAY recommend premiums by simulating the memp
 3. Build a sorted gas premium distribution from the current mempool.
 4. Scale the above-base-fee portion of the distribution by the fraction of the epoch remaining, to model incoming transactions.
 5. Let $Premium_k =$ the $k$-th percentile premium of the top $BlockGasLimit$ gas.
-6. Set `result` to $\min($`result`$, Premium_k)$.
+6. Set `result` to $\min(result, Premium_k)$.
 7. If `nblocksincl` $< 2$, return `result`.
 8. Otherwise, decrement `nblocksincl`, simulate block selection by removing a random subset of top transactions and recalculating $BaseFee$, then repeat from step 4 with a full epoch remaining.
 
@@ -160,6 +160,7 @@ Of course, inclusion within any number of epochs cannot be guaranteed.
 
 This method considers `maxqueueblks` and `msg` and suggests a `MaxFeePerGas` for the `msg`.
 This method SHOULD return the sum of the premium and the worst case base fee after `maxqueueblks` epochs.
+
 $$ FeeCap(maxqueueblks, msg) = Premium_{msg} + BaseFee_{curr} * (1 + R)^{Max(1, maxqueueblks)} $$
 
 #### `eth_gasPrice`


### PR DESCRIPTION

Reviewer @rvagg
I noticed some issues with the rendering of some of the LaTeX.
While these looked fine in my local pandoc, they don't render correctly on Github.
I experimented a bit, and these are the fixes.
#### Changes
* don't break up min()
* extra newline before formula block