### PR TITLE
fix(frc-0069): correct transposed padding/height bytes in 127×8 test fixture

### DIFF
--- a/FRCs/frc-0069.md
+++ b/FRCs/frc-0069.md
@@ -87,7 +87,7 @@ Given the piece CID v1 of the empty 32 GiB piece (i.e. 32 * 2^30 * 127/128 bytes
 
 Given the piece CID v1 of the empty 64 GiB piece (i.e. 64 * 2^30 * 127/128 bytes of zeros)`baga6ea4seaqomqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq` the corresponding piece mutlihash piece CID would be `bafkzcibcaap6mqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq`
 
-Take data of size 127*8 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining `127*4` bytes are 0. There is no padding so the v1 piece CID would be `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` and the v2 would be `bafkzcibcauan42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa`.
+Take data of size 127*8 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining `127*4` bytes are 0. There is no padding so the v1 piece CID would be `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` and the v2 would be `bafkzcibcaac542av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa`.
 
 Take data of size 128*4 bytes where the first where the first 127 bytes are 0, the next 127 are 1, the next 127 are 2, the next 127 are 3 and the remaining 4 bytes are 0. There is `504` bytes of padding needed and so the v1 piece CID is `baga6ea4seaqn42av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa` (notice it's the same as above) and the v2 is `bafkzcibd7abqlxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4`.
 


### PR DESCRIPTION
Test fixture in the spec is incorrectly encoded.

Digest layout is `uvarint padding | uint8 height | 32 byte root data`. For the `127*8 = 1016` byte input we end up with `padding=0`, `height=5`. The current fixture decodes as `05 00` (+root) which is `padding=5`, `height=0` (which would be a 27-byte payload).

One demo of this:

```js
import * as H from '@web3-storage/data-segment/multihash'
import * as Raw from 'multiformats/codecs/raw'
import * as Link from 'multiformats/link'

// FRC-0069 input: 127*8 bytes = 127 0s, 127 1s, 127 2s, 127 3s, 127*4 0s
const data = new Uint8Array(127 * 8)
for (let i = 127; i < 254; i++) data[i] = 1
for (let i = 254; i < 381; i++) data[i] = 2
for (let i = 381; i < 508; i++) data[i] = 3

const h = H.create(); h.write(data)
console.log(Link.create(Raw.code, h.digest()).toString())
// => bafkzcibcaac542av3szurbbscwuu3zjssvfwbpsvbjf6y3tukvlgl2nf5rha6pa
//    (not bafkzcibcauan42av...)
```

I think this hasn't been picked up for two reasons: the two primary implementations that were built around/with this spec, `go-fil-commp-hashhash` and `@web3-storage/data-segment` have their own fixtures, not overlapping with those here. Where these fixtures have been used, they haven't been used to derive the piece sizes. The 3 places on github using this fixture are all in the FOC ecosystem (Synapse, its ports, and a Solidity cross-compat test) and we've been using those reference libraries to date to _generate_ PieceCIDv2, and where we've been testing piece size extraction from CID we happened to choose 3 fixtures from here which are _correct_ and didn't encounter this bug.