### PR TITLE
fip-0107: GasLimit=0 for canonical implicit msgs

### DIFF
--- a/FIPS/fip-0107.md
+++ b/FIPS/fip-0107.md
@@ -117,9 +117,9 @@ The `GasLimit` value is part of the canonical encoded message and is not subject
 
 **Cron Message Execution**: Cron operations have inherently variable and potentially extensive computational requirements. Cron execution encompasses critical network maintenance functions including deadline processing, early sector terminations, proof fee accounting, fault fee processing, vesting schedule management, and pledge adjustments. The computational cost of these operations varies significantly based on network state, particularly the number of sectors requiring processing and the complexity of state transitions occurring at epoch boundaries.
 
-To manage these variable costs, protocol development has consistently prioritised efficiency improvements and cost reduction strategies. Where feasible, operations have been relocated from cron execution to userspace, as demonstrated in [FIP-0084](./fip-0084.md), which removed computationally expensive sector activations from the cron actor. Despite these optimisation efforts, the unpredictable nature of network state changes necessitates substantial gas headroom to ensure system-critical operations complete successfully under all network conditions.
+To manage these variable costs, protocol development has consistently prioritised efficiency improvements and cost reduction strategies. Where feasible, operations have been relocated from cron execution to userspace, as demonstrated in [FIP-0084](./fip-0084.md), which removed computationally expensive sector activations from the cron actor. Despite these optimisation efforts, the unpredictable nature of network state changes necessitates substantial execution headroom to ensure system-critical operations complete successfully under all network conditions.
 
-In practice, actual gas consumption during cron execution typically remains well below this generous limit, reflecting both the effectiveness of ongoing optimisation efforts and the conservative approach taken to guarantee system reliability.
+In practice, actual gas consumption during cron execution typically remains well below the available implicit execution allowance, reflecting both the effectiveness of ongoing optimisation efforts and the conservative approach taken to guarantee system reliability.
 
 ### Message Execution Order
 
@@ -212,7 +212,7 @@ This design was chosen to minimise disruption to existing systems while providin
 
 1. **Receipt linking**: Allows events to be properly associated with their originating messages rather than indirectly via the de-duplicated across-block list generated from parent blocks and allows us to insert implicit messages without needing to list them in a new block field.
 2. **Execution ordering**: Maintains consistency with current execution semantics.
-3. **Message specification**: Uses the existing Lotus implicit message format as a stable basis for all node implementations.
+3. **Message specification**: Defines a stable canonical implicit message format for all node implementations, including a zero `GasLimit` sentinel for system implicit messages without an explicit encoded execution bound.
 4. **Gas limit approach**: Maintains existing execution patterns while clarifying that implicit messages operate outside block gas limit constraints. The encoded `GasLimit` value is part of the canonical message form exposed by this FIP; zero is used as a sentinel for system implicit messages without an explicit encoded execution bound. Any future change to give these messages an enforceable execution bound would be a separate protocol change.
 5. **API compatibility**: Excludes implicit messages from most APIs by default to avoid breaking existing integrations while providing a clear path forward with v2 APIs for accessing implicit messages.
 

--- a/FIPS/fip-0107.md
+++ b/FIPS/fip-0107.md
@@ -75,7 +75,7 @@ Both new fields are nullable (pointers in Go, `Option`s in Rust) for backward co
 
 ### Implicit Message Definitions
 
-Implicit messages must be encoded consistently to produce stable CIDs across all Filecoin nodes. The following definitions, currently used by Filecoin's reference implementation (Lotus) will be used:
+Implicit messages must be encoded consistently to produce stable CIDs across all Filecoin nodes. The following definitions will be used as the canonical encoded form exposed by this FIP. Implementations should take care to expose the canonical message values, not any executor-internal mutation of the message object.
 
 #### Reward Messages
 
@@ -87,7 +87,7 @@ rewardMessage := &types.Message{
    Value:      0,
    GasFeeCap:  0,
    GasPremium: 0,
-   GasLimit:   1 << 30,                         // 1_073_741_824
+   GasLimit:   0,
    Method:     reward.Methods.AwardBlockReward, // 2
    Params:     params,                          // reward params for this miner/block
 }
@@ -103,19 +103,19 @@ cronMessage := &types.Message{
    Value:      0,
    GasFeeCap:  0,
    GasPremium: 0,
-   GasLimit:   buildconstants.BlockGasLimit * 10000, // 100 Trillion
-   Method:     cron.Methods.EpochTick,               // 2
+   GasLimit:   0,
+   Method:     cron.Methods.EpochTick,          // 2
    Params:     nil,
 }
 ```
 
 #### Gas Limit Rationale
 
-These gas limits serve as execution bounds for the individual messages and are not subject to block-level gas constraints. Unlike user messages, implicit messages do not contribute to or get limited by the block gas limit (`buildconstants.BlockGasLimit`). The gas limits specified in the message structure serve as the maximum gas that can be consumed during execution of that specific message. If gas accounting during message execution exceeds the message's gas limit, the message execution fails.
+The `GasLimit` value is part of the canonical encoded message and is not subject to block-level gas constraints. Unlike user messages, implicit messages do not contribute to or get limited by the block gas limit (`buildconstants.BlockGasLimit`). A zero gas limit is used here as a canonical sentinel indicating that these system implicit messages do not carry an explicit per-message execution bound in their encoded form. This FIP does not change implicit-message gas accounting or introduce a new failure condition based on this field.
 
-**Reward Message Gas Allocation**: The gas limit of approximately 1.07 billion provides substantial headroom for reward operations, which have predictable and bounded computational costs. Reward message execution involves adjusting the miner's vesting schedule with new rewards, unlocking any vested amounts in the process, and attempting to repay any existing fee debt. These operations have relatively consistent resource requirements with minimal variation across different execution contexts.
+**Reward Message Execution**: Reward operations have predictable and bounded computational costs. Reward message execution involves adjusting the miner's vesting schedule with new rewards, unlocking any vested amounts in the process, and attempting to repay any existing fee debt. These operations have relatively consistent resource requirements with minimal variation across different execution contexts.
 
-**Cron Message Gas Allocation**: The exceptionally high gas limit of 100 trillion addresses the inherently variable and potentially extensive computational requirements of cron operations. Cron execution encompasses critical network maintenance functions including deadline processing, early sector terminations, proof fee accounting, fault fee processing, vesting schedule management, and pledge adjustments. The computational cost of these operations varies significantly based on network state, particularly the number of sectors requiring processing and the complexity of state transitions occurring at epoch boundaries.
+**Cron Message Execution**: Cron operations have inherently variable and potentially extensive computational requirements. Cron execution encompasses critical network maintenance functions including deadline processing, early sector terminations, proof fee accounting, fault fee processing, vesting schedule management, and pledge adjustments. The computational cost of these operations varies significantly based on network state, particularly the number of sectors requiring processing and the complexity of state transitions occurring at epoch boundaries.
 
 To manage these variable costs, protocol development has consistently prioritised efficiency improvements and cost reduction strategies. Where feasible, operations have been relocated from cron execution to userspace, as demonstrated in [FIP-0084](./fip-0084.md), which removed computationally expensive sector activations from the cron actor. Despite these optimisation efforts, the unpredictable nature of network state changes necessitates substantial gas headroom to ensure system-critical operations complete successfully under all network conditions.
 
@@ -213,7 +213,7 @@ This design was chosen to minimise disruption to existing systems while providin
 1. **Receipt linking**: Allows events to be properly associated with their originating messages rather than indirectly via the de-duplicated across-block list generated from parent blocks and allows us to insert implicit messages without needing to list them in a new block field.
 2. **Execution ordering**: Maintains consistency with current execution semantics.
 3. **Message specification**: Uses the existing Lotus implicit message format as a stable basis for all node implementations.
-4. **Gas limit approach**: Maintains existing execution patterns while clarifying that implicit messages operate outside block gas limit constraints. This ensures system operations can complete successfully regardless of user message activity or network congestion.
+4. **Gas limit approach**: Maintains existing execution patterns while clarifying that implicit messages operate outside block gas limit constraints. The encoded `GasLimit` value is part of the canonical message form exposed by this FIP; zero is used as a sentinel for system implicit messages without an explicit encoded execution bound. Any future change to give these messages an enforceable execution bound would be a separate protocol change.
 5. **API compatibility**: Excludes implicit messages from most APIs by default to avoid breaking existing integrations while providing a clear path forward with v2 APIs for accessing implicit messages.
 
 ### Storage Efficiency Assessment


### PR DESCRIPTION
The current numbers encoded in the original form of this FIP come out of Lotus' construction of the messages. But internally Lotus overwrites those values before execution anyway. So I'm taking this opportunity to just zero them out in their canonical form for the purpose of making deterministic CIDs. It's effectively "uncapped".

Ref: https://github.com/filecoin-project/lotus/blob/25a03f58bff5491f047b5c16eedad2d434f33158/chain/vm/fvm.go#L484
