### PR TITLE
FIP-0118: specify f02 mechanics: pull settlement, queue, validation

### DIFF
--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -1149,12 +1149,19 @@ goes.
 ##### 2.4.6 Stream lifecycle: removal, re-pointing, tombstones
 
 `RemoveStream` and `SetDistribution` first settle the current period
-exactly as `SetShares` does: each recipient's earned-but-unclaimed
-amount is banked as payable under the outgoing shares. On removal
-those balances move to a **tombstone** for the stream's id, so claims
-stay addressable after removal: `Claim` pays from the tombstone, rows
-delete as they are claimed, and a drained tombstone deletes entirely,
-so nothing about a removed stream is permanent. `RemoveStream` admission
+exactly as `SetShares` does. Earned-but-unclaimed balances remain
+`payable` on a map or writer change and move to a tombstone for the
+stream id on removal. `Claim` pays and deletes rows; a drained tombstone
+deletes.
+
+Surviving balances are capped at `2 * MAX_RECIPIENTS = 128` payable rows
+per live stream and `MAX_TOMBSTONE_ROWS = 256` rows across tombstones.
+`SetShares` rejects a fold whose resulting `payable` table exceeds the
+per-stream cap. A hostile designated writer can therefore fill only its
+own stream's table; a global cap would let one stream block another's
+`SetShares`. Because `Claim` is permissionless and accepts
+`MAX_RECIPIENTS` wallets, a blocked writer can drain one full share map's
+stale rows in one call and retry. `RemoveStream` admission
 requires existing tombstone payable rows plus one
 `max(MAX_RECIPIENTS, |payable ∪ shares|)` reservation for each pending
 removal, including the candidate, to be at most `MAX_TOMBSTONE_ROWS`.
@@ -1162,8 +1169,7 @@ For each removal, `|payable ∪ shares|` counts the distinct recipient IDs
 in that target stream's two tables; an ID present in both counts once. Any
 `SetShares` while a removal is pending recomputes every reservation from
 the post-fold `payable ∪ shares` and rejects the change if the aggregate
-exceeds the cap. Removal revalidates at application. Each successful
-`Claim` immediately frees capacity by deleting paid rows. A removed
+exceeds the cap. Removal revalidates at application. A removed
 stream's weight reverts to the burn residual until reallocated. Id
 non-reuse after the tombstone is gone is SWA discipline (f02 still rejects any
 duplicate it can see); violating it risks event-history ambiguity
@@ -1394,20 +1400,20 @@ outcomes require replay or state comparison.
 
 **`MAX_STREAMS = 8`, `MAX_RECIPIENTS = 64`,
 `MAX_TOMBSTONE_ROWS = 256`,
-`MAX_PENDING_WRITES = 3 * MAX_STREAMS + 2 = 26`.** `MAX_STREAMS`
+`MAX_PENDING_WRITES = 26`.** `MAX_STREAMS`
 includes Consensus. `MAX_RECIPIENTS` bounds each share map and
 `Claim.wallets`; `MAX_TOMBSTONE_ROWS` caps payable rows across all
-tombstones. The queue bound is its exact slot space: three per-stream
-operations and two schedule-wide operations.
+tombstones. The imposed queue bound, sized for all per-stream operations
+across a full stream table plus two schedule-wide slots, is enforced as a
+cap by an explicit length check rather than derived from slot space.
 
-These bounds limit configured award and mutation work. Live-stream
-payable rows have no aggregate bound and drain through `Claim`. At the
-tombstone cap, operators remove until reserved capacity is full, drain
-rows through permissionless `Claim`, then continue. The shared cap also
-couples governance tiers: each pending removal reserves at least 64 rows,
-so at most four can be in flight, and the lower-tier SRA writer can reduce
-that concurrency by growing recipient unions; it cannot block removals,
-which serialize under the drainage cadence above. Raising a limit requires
+These bounds limit configured award and mutation work. Payable rows drain
+through `Claim`. At the tombstone cap, operators remove until reserved
+capacity is full, drain rows through permissionless `Claim`, then continue.
+The shared cap also couples governance tiers: each pending removal reserves
+at least 64 rows, so at most four can be in flight. The lower-tier SRA
+writer can reduce that concurrency by growing recipient unions but cannot
+block removals, which serialize under the drainage cadence above. Raising
 a future FIP and network upgrade that also reshapes the affected structures
 for the new scale.
 
@@ -1695,7 +1701,7 @@ VOL_TARGET_ENTRY = 3_500  // USD. First gate (10% -> 15%); calibrated to current
                           // Filecoin Pay actuals, at FIL = $1
 VOL_TARGET_RATIO = 2.7    // per-step escalation; back-loads the volume requirement
 
-// Back-loaded escalation: every 5pp step demands ~2.7x the previous volume;
+// Back-loaded escalation: every 5pp step demands ~2.7x the previous target;
 // preserves a low entry barrier while tightening the terminal requirement.
 // Frozen schedule (USD): 3.5K, 9.4K, 25.5K, 68.9K, 186K, 502K, 1.36M, 3.66M
 // for gates 10->15 through 45->50. Fixed at FIP time.
@@ -2242,9 +2248,10 @@ The implementation test suite MUST cover at least:
     types, including explicit failure rollback and implicit best effort;
 
   - stream registration and distribution changes, share-map validation
-    and immediate binding, period folds and dust, positional claims and
-    send rollback, full explicit-stream decommissioning, removal around
-    pending gate writes, repeated awards with no explicit stream,
+    and immediate binding, payable-cap rejection and claim relief, period
+    folds and dust, positional claims and send rollback, full explicit-stream
+    decommissioning, removal around pending gate writes, repeated awards with
+    no explicit stream,
     consensus-stream removal, and stream-ID reuse only after its
     tombstone drains;
 
@@ -2412,11 +2419,11 @@ changes to leader election or finality.
     reward at all and permits a validating timelocked repair, so no
     party gains by inducing one. Otherwise each allocation is floored
     and the exact residual burns, conserving `BR` atto-exactly.
-    `MAX_STREAMS` bounds allocation work and `MAX_RECIPIENTS` bounds each
-    share map. The low-balance cap derives outstanding liability from
-    the stream block already decoded for weights; historical payable and
-    tombstone rows have no aggregate protocol bound and are drained
-    through permissionless claims. Recipient sends occur only in
+    `MAX_STREAMS` bounds allocation work, `MAX_RECIPIENTS` bounds each
+    share map, and Section 2.4.6 bounds surviving balances. The low-balance
+    cap derives outstanding liability from the stream block already
+    decoded for weights; those balances drain through permissionless
+    claims. Recipient sends occur only in
     `Claim`, where failure reverts the call without stalling an award.
 
   - **Compromised Orchestrator wallet.** An Orchestrator address holds

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -855,7 +855,7 @@ w0(e) = 1 - Σ_{i>=1} ComputeWeight(W_i, e)  // residual over all streams; never
 ##### 2.4.2 State
 
 The pre-upgrade f02 state is an 11-field tuple; this migration produces
-the 14-field tuple below. Per-block counters, accruals, and epochs remain
+the 15-field tuple below. Per-block counters, accruals, and epochs remain
 inline. Stream configuration, recipient accounting, tombstones, and the
 queue live behind one CID, read every award for weights and liabilities
 but rewritten only by stream mutations or a due transition.
@@ -868,6 +868,7 @@ but rewritten only by stream mutations or a due transition.
 | `total_explicit_minted` | New counter: cumulative accrual across all `EXPLICIT` streams. |
 | `accrued[id]` | New, one per `EXPLICIT` stream: the current period's gross accrual. |
 | `swa_timelock_epochs` | New: the SWA timelock in epochs (`SWA_TIMELOCK`), set per network by the migration and never written afterwards. Mainnet: 7 days; test networks may set it shorter. |
+| `swa_actor` | New: the SWA address in ID form, set by the activation migration, with no setter. |
 | `streams_root` | New CID: the stream list, the tombstones and the pending-write queue. |
 
 The retired fields become the code constants
@@ -920,7 +921,8 @@ struct State {
     total_explicit_minted: TokenAmount,     // 11 new
     accrued: Vec<StreamAccrual>,            // 12 new
     swa_timelock_epochs: ChainEpoch,        // 13 new; migration-set only
-    streams_root: Cid,                      // 14 new
+    swa_actor: Address,                     // 14 new; migration-set only
+    streams_root: Cid,                      // 15 new
 }
 
 struct StreamAccrual { id: u64, amount: TokenAmount }
@@ -1302,6 +1304,13 @@ contracts. Existing methods keep their numbers and signatures.
 | `SetShares(id, map)` | the stream's designated writer | immediate |
 | `Claim(id, wallets[])` | anyone | immediate |
 
+SWA caller checks compare the caller's f0 ID address exactly with
+`swa_actor`; Init assigns actor IDs per network, so no portable code
+constant exists and the deployed address is migration configuration.
+There is no setter: replacing the SWA still requires a FIP and network
+upgrade, the compromised-tier backstop in Section 4. The SRA needs no
+equivalent root field because each stream names its designated writer.
+
 `SetWeightRecords` and `StepWeightRecords` are payload-identical; they are
 separate methods so that cancellability is a static per-operation
 rule. The SWA's gate path (`QuarterlyGateCheck`) calls
@@ -1418,11 +1427,10 @@ with no scheduled write needed (Section 3.1.1). The service stream
 starts with the single-Orchestrator share map (one wallet, `share = 1`)
 and the SRA as designated writer. The migration also renames position
 9, drops positions 10 and 11 (their values continue as the code
-constants of Section 2.4.2 on every network), zeroes the new
-counters, and sets `swa_timelock_epochs`: the only place it is ever
-written.
-The migration resolves every bootstrap writer and recipient to an ID
-address before persistence.
+constants of Section 2.4.2 on every network), zeroes the new counters,
+and sets `swa_timelock_epochs` and `swa_actor`: the only place either is
+ever written. It resolves `swa_actor`, every bootstrap writer and every
+recipient to ID form before persistence.
 
 #### 2.5 Supply accounting
 

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -115,10 +115,10 @@ streams are as follows. The weight w1 ramps down from 95% to 50% over
 roughly 9 quarters. During the first quarter (the bootstrap phase),
 `w2 = 1 − w1` so no w0 share is scheduled and w2 reaches 10% by the
 end of the quarter. From Q2 onward, w2 steps up by 5 percentage
-points per quarter,
-capped at the ceiling `1 − w1`, and only when on-chain aggregated Filecoin
-Pay Volume (FPV) clears its target for the quarter. The SWA is governed
-by **SWA Governance** (see Section 4).
+points per quarter, never exceeding the ceiling `1 − w1`, and only
+when on-chain aggregated Filecoin Pay Volume (FPV) clears the current
+gate's target. The SWA is governed by **SWA Governance** (see Section
+4).
 
 The **Service Rewards Actor (SRA)** is the new governed contract
 that computes how the service stream is divided among Service
@@ -515,7 +515,7 @@ Once per quarter, off the per-epoch path:
         publicly recomputable value before the window closes; if it
         does not, the zero value safely depresses the gate.
 
-    4.  `SubmitShares(Q)` and `QuarterlyGateCheck(Q)` become callable only
+    4.  `SubmitShares` and `QuarterlyGateCheck` become callable only
         after the window closes and read only bound values, with
         `AggregatedFPV(Q)` the sum of bound values. There is no
         retroactive clawback: a misreport discovered after binding is
@@ -563,8 +563,9 @@ Once per quarter, off the per-epoch path:
     produce diverging numbers.
 
 4.  **Weights and shares updates.** `QuarterlyGateCheck` compares the
-    USD-denominated `AggregatedFPV(Q)` against the quarter's fixed USD
-    target (Section 3.1.1). If it passes, the SWA raises w2 via
+    USD-denominated `AggregatedFPV(Q)` against the current gate's fixed
+    USD target, indexed by gates passed rather than by the quarter
+    number (Section 3.1.1). If it passes, the SWA raises w2 via
     `StepWeightRecords` (Section 2.4.9), the uncancellable gate write.
     `SplitRule` sets each Orchestrator's
     share in proportion to its USD-denominated `FPV_i(Q)`, using the
@@ -576,6 +577,14 @@ Once per quarter, off the per-epoch path:
     computations: they are omitted from the submitted share map
     (shares in the map must be positive, Section 2.4.4) and their FPV
     does not enter `AggregatedFPV(Q)` (Section 3.2).
+
+    Quarter 1 runs this full pipeline with one exception: no gate
+    check. Posting, verification, binding and `SubmitShares(1)` proceed
+    as in any other quarter, and the first quarter's report is
+    required even though it gates nothing: the Orchestrator posts on
+    chain and the bound values set the shares. Only `QuarterlyGateCheck`
+    is skipped, because the bootstrap ramp performs the 5% to 10% move
+    ungated (Section 3.1.1).
 
 #### 2.3 FPV definitions
 
@@ -1155,10 +1164,17 @@ decrease's headroom, or a write targeting a stream whose registration
 was canceled. A well-formed due write that fails validation at
 application is discarded, with an event, and processing continues;
 the award path never fails on a queued write, and there is no
-fallback weight vector. The SWA should still pre-validate before
-submitting, and the queued records are public during the objection
-window so anyone can recompute the breakpoints, but f02's queue-time
-check is authoritative for admission.
+fallback weight vector. A discarded `StepWeightRecords` self-heals:
+gate writes are absolute levels derived from the SWA's step counter
+(Section 3.1.1), so the next passing gate restores the full correct
+level, w2 sitting one level low until then. The final step is the
+exception: `steps` is terminal, no later gate exists, and repair is
+a discretionary write (the counter already correct, no `steps`
+adjustment needed). The SWA
+should still pre-validate before submitting, and the queued records
+are public during the objection window so anyone can recompute the
+breakpoints, but f02's queue-time check is authoritative for
+admission.
 
 ##### 2.4.9 Methods and bounds
 
@@ -1175,7 +1191,6 @@ contracts. Existing methods keep their numbers and signatures.
 | `CancelPending(id, op)` | SWA | immediate |
 | `SetShares(id, map)` | the stream's designated writer | immediate |
 | `Claim(id, wallets[])` | anyone | immediate |
-| `GetState()` | anyone | read-only |
 
 `SetWeightRecords` and `StepWeightRecords` are payload-identical; they are
 separate methods so that cancellability is a static per-operation
@@ -1189,22 +1204,6 @@ exceed `MAX_STREAMS`, the recipient count within `MAX_RECIPIENTS`,
 `activation_epoch >= current_epoch + swa_timelock_epochs`, and the
 distribution is one of the two supported forms; the stream pays
 nothing until its `activation_epoch`.
-
-`GetState` returns the logical state as one tuple:
-
-```
-[ total_minted_reward, total_burn_minted, total_service_minted,
-  service_accrued[], next_transition_epoch, swa_timelock_epochs,
-  streams[], tombstones[], pending_writes[] ]
-```
-
-the state schema above with `streams_root` dereferenced and
-due-but-unapplied writes projected in memory, so reads stay
-read-only; the next mutating call or award performs the real
-application. Its callers are contracts, so the return
-shape stays small and fixed. Claimable amounts need no dedicated read
-method: `Claim` returns `amounts[]` and an all-zero batch writes
-nothing, so a read-only invocation of `Claim` is the query.
 
 Parameter and return tuples, under the encoding rules of Section 2.4.2
 and reusing its component types. Registration supplies only the
@@ -1347,12 +1346,15 @@ particular
     governance-settable via `SetGateParams`, which govern how the next
     service weight record is computed once per quarter; the Weight records
     themselves live in f02 (Section 2.4); the SWA only writes them. It
-    also holds its gate progress: the count of executed gate steps,
-    the last w2 level it wrote, and the last executed quarter
-    (enforcing at most one gate step per quarter). The step counter
-    is authoritative for gate position: it indexes the target
-    schedule directly, unaffected by a write still queued in f02 or
-    by the `1 − w1` ceiling clamping w2 off the 5pp grid.
+    also holds its gate progress as explicit state: `steps`, the count
+    of gate steps executed, and `last_checked_quarter`, the last
+    quarter consumed by a check (the sequential once-per-quarter
+    latch, Section 3.1.1). Quarter numbering and window state are the
+    SRA's (Section 3.1.1); the SWA keeps no copy of the quarter
+    boundaries and asks the SRA whether a quarter's volumes are
+    bound. The step counter is authoritative for gate
+    position: it indexes the target schedule directly and determines
+    the next w2 level.
     It also holds the two SWA Safe addresses (Section 4.2) and
     the addresses it is wired to: f02 and the SRA (read for
     `AggregatedFPV`). Pending f02 writes are queued and held in f02
@@ -1361,10 +1363,12 @@ particular
     a SWA-internal timelock of the same duration, cancellable by
     either Safe. Its methods:
 
-      - **`QuarterlyGateCheck(Q)`.** The mechanism entry point;
-        permissionless. Requires that quarter Q has ended, that
-        `AggregatedFPV(Q)` is bound (its verification window has
-        closed), and that no step has yet executed for Q. Its read of
+      - **`QuarterlyGateCheck()`.** The mechanism entry point;
+        permissionless. Operates on the next unchecked quarter,
+        `Q = last_checked_quarter + 1` (the sequential latch, Section
+        3.1.1), and is callable only once quarter Q's verification
+        window has closed, so `AggregatedFPV(Q)` is bound (the posting
+        period always closes first, Section 2.2). Its read of
         `AggregatedFPV(Q)` triggers the SRA’s `FinalizeConversion(Q)` if
         it has not yet run (Section 2.2). Runs the gate rule of
         Section 3.1.1 and, when the gate passes, writes the new w2
@@ -1386,9 +1390,10 @@ particular
 
       - **`SetGateParams(params)`.** Discretionary; requires the
         approval of both SWA Safes and a published FIP. Updates the
-        gate parameters; held in the SWA-internal timelock and
-        cancellable by either Safe. The gate rule itself is code and
-        cannot be changed by a parameter write.
+        gate parameters, the step counter `steps` included; held in
+        the SWA-internal timelock and cancellable by either Safe. The
+        gate rule itself is code and cannot be changed by a parameter
+        write.
 
 ##### 3.1.1 The volume gate mechanism
 
@@ -1413,24 +1418,33 @@ quarter.
 **Steady state (Q2 onward).** The ramp rate is 5pp per quarter, so w2
 reaches `W2_BASE` (10%) exactly at the Q1 boundary, where the
 record clamps at its cap. No end-of-quarter write is needed to exit the
-bootstrap: the clamp does it. From then on, w2 is a step function: when a
+bootstrap: the clamp does it. The move from 5% to `W2_BASE` is therefore
+ungated: no gate check runs for Q1 (`last_checked_quarter` initializes
+to 1), and the first `QuarterlyGateCheck` evaluates quarter 2's bound
+volume, after Q2's verification window has closed.
+From then on, w2 is a step function: when a
 gate passes, `QuarterlyGateCheck` replaces the record with a constant
 one at the new level,
 `{ v_start: new_w2, slope: 0, floor = cap = new_w2 }`, via
 `StepWeightRecords` under `SWA_TIMELOCK`; when a gate fails, the
-record is untouched and w2 holds. Burn resumes automatically from the Q1
-boundary: w1 keeps ramping down while w2 holds at its gate-set level,
-and the residual is burned.
+record is untouched and w2 holds. Scheduled burn resumes
+automatically from the Q1 boundary: w1 keeps ramping down while w2
+holds at its gate-set level, and the residual is burned.
 
-**`QuarterlyGateCheck`**, run once per quarter from Q2 onward:
+**`QuarterlyGateCheck`**, callable once per quarter, in quarter order,
+the first check evaluating quarter 2:
 
 ```
-// SWA state: steps = gate steps executed so far; w2_level = the level
-// the last gate write set (W2_BASE before any step). Tracking both
-// locally keeps the gate self-contained: steps indexes the target
-// schedule directly, unaffected by a write still queued in f02 or by
-// the 1 - w1 ceiling clamping w2 off the 5pp grid.
-func QuarterlyGateCheck(Q uint64):
+// SWA state: steps = gate steps executed so far, indexing the target
+// schedule directly; last_checked_quarter = the last quarter consumed
+// by a check, initialized to 1 (the ungated bootstrap quarter).
+func QuarterlyGateCheck():
+    // Sequential once-per-quarter latch: quarters are checked in
+    // order and each quarter's bound volume is evaluated exactly once
+    Q = last_checked_quarter + 1
+    require verification window for Q has closed  // AggregatedFPV(Q) is bound
+    require steps < (W2_CAP - W2_BASE) / W2_STEP  // 8 gates; done once w2 rests at W2_CAP
+
     // 1. Read aggregated volume for the quarter just ended, posted to the SRA
     //    (see FPV definitions in Section 2)
     measured = AggregatedFPV(Q)
@@ -1440,18 +1454,74 @@ func QuarterlyGateCheck(Q uint64):
 
     // 3. Gate decision
     if measured >= target:
-        new_w2 = min(w2_level + W2_STEP, 1 - w1)      // w1 evaluated from f02 state
-        f02.StepWeightRecords({ w2: constant record at new_w2 })  // uncancellable; f02 re-derives w0
-        steps += 1; w2_level = new_w2
-    // else: gate fails, w2 unchanged
+        steps += 1
+        new_w2 = W2_BASE + steps * W2_STEP  // always on the 5pp grid
+        f02.StepWeightRecords({ w2: { v_start: new_w2, slope: 0, floor: new_w2, cap: new_w2 } })
+        // uncancellable (Section 2.4.7); f02 re-derives w0
+    // else: gate fails; steps, and so the target, are unchanged
+    last_checked_quarter = Q  // pass or fail, quarter Q is consumed
 ```
+
+**One gate at a time.** A quarter's bound volume clears at most one
+gate. When a gate fails, `steps` holds, so w2 and the target both hold;
+the ceiling `1 − w1` keeps ramping away and the widening residual is
+burned. There is no catch-up: no later quarter can clear more than its
+own single gate, and the only way forward is passing the
+still-standing gate with a later quarter's volume, one step per
+quarter. The latch makes replay-based catch-up impossible: a passed
+quarter cannot be re-checked, so its volume can never be run against
+the next target for a second step.
+
+**Late cranks self-heal.** Nothing requires the check for quarter Q to
+run during quarter Q+1. If nobody invokes it until later, it still
+evaluates quarter Q's bound volume, and the check for quarter Q+1
+becomes callable immediately after. Two steps landing in quick
+succession this way is each gate being cleared by its own quarter's
+volume, not catch-up: the latch counts quarters checked, not calendar
+time.
+
+**Gate write rejection.** If f02's queue-time schedule validation
+(Section 2.4.8) rejects the gate write, the whole `QuarterlyGateCheck`
+call reverts, `steps` and `last_checked_quarter` do not advance, and
+the gate is re-attemptable in a later quarter (on this FIP's schedule
+the rejection can occur only after a discretionary change to w1's
+schedule, applied or pending). w2 takes values only on the 5pp grid
+`W2_BASE + steps * W2_STEP`; partial steps do not exist.
+
+**The counter is the authority.** Gate position lives in `steps`; the
+w2 record is derived from it as `W2_BASE + steps * W2_STEP`. Any
+discretionary write that changes the w2 record MUST be accompanied,
+in the same governance action, by the matching `steps` adjustment via
+`SetGateParams`, and the two changes MUST take effect at the same
+epoch (the SWA schedules the `SetGateParams` application to the f02
+write's effective epoch). Record and counter otherwise diverge: a
+lowered record with a stale counter makes the next passing gate skip
+levels, and a gate check firing between two unaligned effective
+epochs acts on a mismatched pair. The terminal check reads the
+counter, so it is not permanent: lowering `steps` through
+`SetGateParams` reopens the gate.
+
+**Quarter boundaries.** The SRA is the sole authority on quarter
+numbering and window state; the SWA holds no boundary state and does
+no window arithmetic. `QuarterlyGateCheck` operates on
+`Q = last_checked_quarter + 1` and is callable once the SRA reports
+quarter Q's volumes bound (verification window closed, values final);
+the check then reads `AggregatedFPV(Q)` from the same contract, so the
+volume and its finality come from one place. The boundaries
+themselves are as defined in Section 2.2: consecutive
+`EPOCHS_PER_QUARTER`-epoch windows counted from the activation epoch,
+maintained in the SRA.
 
 **`ComputeTarget` (volume target).** The gate compares USD-denominated
 volume directly against a fixed schedule:
 **`AggregatedFPV(Q) ≥ ComputeTarget(steps)`**, where `steps` counts
 the gate step-ups already executed.
 It sets how much on-chain volume the service economy must generate to
-unlock the next w2 step-up.
+unlock the next w2 step-up. The ladder is step-indexed, not
+time-indexed: the target depends only on how many gates have passed,
+never on which quarter it is, so a missed gate leaves the next
+quarter's target exactly where it was, and the target escalates by
+`VOL_TARGET_RATIO` only when a gate passes.
 
 ```
 W2_STEP    = 0.05  // quarterly increment (5pp) when volume targets are cleared
@@ -1468,7 +1538,8 @@ VOL_TARGET_RATIO = 2.7    // per-step escalation; back-loads the volume requirem
 // for gates 10->15 through 45->50. Fixed at FIP time.
 
 func ComputeTarget(steps) -> USD:
-    steps = clamp(steps, 0, (W2_CAP - W2_BASE) / W2_STEP - 1)  // bound within [0, 7]: 8 gates, indices 0-7
+    // steps is within [0, 7] here: 8 gates, guarded by the terminal
+    // check in QuarterlyGateCheck
     return VOL_TARGET_ENTRY * VOL_TARGET_RATIO ^ steps
 ```
 
@@ -1484,7 +1555,10 @@ divided among Orchestrators. In particular,
 
   - The SRA holds the registry (the (payer, operator) to Orchestrator
     bindings and each Orchestrator’s status, active or frozen), the
-    posted volumes `FPV_i(Q)` with their verification-window state, the
+    posted volumes `FPV_i(Q)` with their verification-window state
+    (also served to the SWA, which reads quarter and window state
+    from the SRA alongside `AggregatedFPV`, Section 3.1.1), the
+    last quarter whose share map was submitted, the
     two Registry Safe addresses (Section 4.2), and the queue of
     pending governance changes under `SRA_CANCEL_HOLD`; the hold and
     verification-window durations are parameters set in the
@@ -1556,11 +1630,16 @@ divided among Orchestrators. In particular,
         `QuarterlyGateCheck`’s read and by `SubmitShares` when not
         already run.
 
-      - **`SubmitShares(Q)`.** Permissionless once every `FPV_i(Q)` for
-        the quarter is bound. Triggers `FinalizeConversion(Q)` if it has
-        not yet run, then computes each Orchestrator’s share via
-        `SplitRule` over the stored USD values (Section 2.2) and writes
-        the wallet-to-share map into f02 via `SetShares`. Orchestrators
+      - **`SubmitShares()`.** Permissionless. Operates on the latest
+        quarter whose volumes are bound, so an older quarter's
+        shares can never overwrite a newer quarter's; if submissions
+        lag by more than a quarter, the skipped quarters' maps are
+        superseded and are never submitted late. Reverts when that
+        quarter's map has already been submitted. Triggers
+        `FinalizeConversion(Q)` for that quarter if it has not yet run,
+        then computes each Orchestrator’s share via `SplitRule` over
+        the stored USD values (Section 2.2) and writes the
+        wallet-to-share map into f02 via `SetShares`. Orchestrators
         frozen at the close of the posting period are excluded:
         omitted from the submitted map, with their FPV not entering
         `AggregatedFPV(Q)`.
@@ -1976,7 +2055,9 @@ The implementation test suite MUST cover at least:
     existing claims and in-flight activation messages;
 
   - `ComputeWeight` clamping and rounding, the Q1 w1/w2 bootstrap,
-    gate pass and failure transitions, the exact-residual burn, and
+    gate pass and failure transitions, the sequential gate latch
+    (quarter ordering, late cranks, and the atomic revert on an f02
+    rejection, Section 3.1.1), the exact-residual burn, and
     atto-exact conservation of the full block reward while gas rewards
     and penalties retain their existing treatment;
 
@@ -2041,15 +2122,20 @@ changes to leader election or finality.
     indirect path is not bounded by share validation alone: the gate
     reads `AggregatedFPV` from SRA state, so a compromised SRA could
     report inflated volume to force a w2 step-up. That step is still
-    bounded (≤ `W2_STEP` per quarter, capped at `1 − w1`), held by
+    bounded (one `W2_STEP` per quarter under the gate latch, with
+    f02's queue-time validation keeping the weights within `Σ ≤ 1`,
+    Sections 2.4.8 and 3.1.1), held by
     `SWA_TIMELOCK`, and visible during that hold, though not cancellable
     since gate steps are mechanism-executed (Section 4.3) and the posted
     FPV is itself held by the verification window and correctable
     against recomputation (Section 2.2). Unlike the share misallocation,
     which is confined to one quarter, a wrongly executed step is
     standing: the gate only moves w2 up, so reversing it takes a
-    discretionary, FIP-backed SWA write lowering the w2 record (Section
-    4.2).
+    discretionary, FIP-backed SWA write lowering the w2 record,
+    paired in the same governance action with the matching `steps`
+    adjustment via `SetGateParams`, taking effect at the same epoch
+    (Section 3.1.1), so the counter keeps its authority over gate
+    position (Section 4.2).
 
   - **Sustainability of consensus mining.** The initial ceiling (1 −
     w1 = 5%) is not expected to materially threaten L1-PoRep SP

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -988,50 +988,88 @@ callers do not.
 ```
 AwardBlockReward(miner, penalty, gas_reward, win_count):
     require balance >= gas_reward
+    load the streams block            // absent block or store error aborts
+    computed_BR = this_epoch_reward * win_count / 5
+    if the block is undecodable, or its stream, tombstone or queue
+       structure is invalid:
+        no_award()
     if current explicit liability is uncomputable:
-        pay gas_reward and apply penalty as today; return without state change
+        award_without_service()
     projection = project valid due writes and cancellation-stranded drops
     fold_dust = projection's fold dust
     liability =
         Σ projected live (accrued - Σ claimed_period + Σ payable)
         + Σ projected tombstone payable
-    if liability is uncomputable
-       or balance < gas_reward + liability + fold_dust:
-        pay gas_reward and apply penalty as today; return without state change
-    commit projection
-    computed_BR = this_epoch_reward * win_count / 5
+    if liability is uncomputable:
+        award_without_service()
+    if balance <= gas_reward + liability + fold_dust:
+        no_award()
     BR = min(computed_BR, balance - gas_reward - liability - fold_dust)
     evaluated = ComputeWeight for every active stream
-    weights_valid =
-        every record satisfies 0 <= floor <= v_start <= cap <= DENOM
+    if any record violates 0 <= floor <= v_start <= cap <= DENOM
+       or Σ evaluated > DENOM:
+        no_award()
+    commit projection
     miner_reward = 0
     paid = 0
-    if not weights_valid or Σ evaluated > DENOM:
-        // Defensive: queue and application validation enforce both conditions.
-        implicit_weight =
-            min(Σ evaluated weights of IMPLICIT streams, DENOM)
-        miner_reward = floor(implicit_weight * BR / DENOM)
-        paid = miner_reward                       // Section 2.4.8
-    else:
-        for each active stream s:                 // in list order
-            portion = floor(evaluated[s] * BR / DENOM)
-            if s.distribution is IMPLICIT:
-                miner_reward += portion
-            else:
-                accrued[s.id] += portion
-                total_explicit_minted += portion
-            paid += portion
+    for each active stream s:                     // in list order
+        portion = floor(evaluated[s] * BR / DENOM)
+        if s.distribution is IMPLICIT:
+            miner_reward += portion
+        else:
+            accrued[s.id] += portion
+            total_explicit_minted += portion
+        paid += portion
     burn = BR - paid
     send(f099, burn + fold_dust); total_burn_minted += burn
     total_minted_reward += BR
     pay miner_reward + gas_reward to winning miner; penalties as today
+
+no_award():
+    pay gas_reward and apply penalty as today; return without state change
+
+award_without_service():          // stored state, never the projection
+    ceiling = min(STORAGE_MINING_ALLOCATION - total_minted_reward,
+                  balance - gas_reward)
+    evaluated = ComputeWeight for every active stream
+    if ceiling <= 0
+       or any record violates 0 <= floor <= v_start <= cap <= DENOM
+       or Σ evaluated > DENOM:
+        no_award()
+    BR = min(computed_BR, ceiling)
+    miner_reward = Σ over IMPLICIT s of floor(evaluated[s] * BR / DENOM)
+    burn = BR - miner_reward
+    send(f099, burn); total_burn_minted += burn
+    total_minted_reward += BR
+    pay miner_reward + gas_reward to winning miner; penalties as today
 ```
 
-Due writes and drops are projected, not committed, until current and
-projected liabilities are computable and the reserve check passes. An
-uncomputable liability or shortfall pays only `gas_reward`, applies the
-penalty as today, and commits no projection, accrual, burn, or issuance
-counter; the next award retries from stored state.
+Due writes and drops are projected, not committed: the projection commits
+only once its liability is computable, the reserve check passes and the
+weights validate.
+
+`no_award` mints nothing: the block reward is not issued at all, no
+counter moves, the miner receives only the fresh gas reward, the penalty
+applies as today, and the next award retries from stored state.
+
+`award_without_service` is the response when the weights are sound but
+the accounting rows are not. The miner receives the real `IMPLICIT` share
+of a reserve-independent ceiling, the remainder burns, nothing accrues to
+`EXPLICIT` streams, and only `total_minted_reward` and `total_burn_minted`
+move. `STORAGE_MINING_ALLOCATION` is the nominal storage-mining
+allocation of 1,100,000,000 FIL credited to f02 at genesis, and it
+substitutes for the liability that cannot be computed: for any history,
+`balance - gas_reward - liability` is `STORAGE_MINING_ALLOCATION -
+total_minted_reward` plus whatever f02 holds above its genesis credit, so
+the ceiling never exceeds what the exact reserve check would allow.
+That margin is zero by construction, which makes it a requirement: f02's
+genesis credit MUST be at least `STORAGE_MINING_ALLOCATION`.
+
+A block missing from the store, or a store error, aborts. The award never
+aborts on a deterministic state fault, since every node reads the same
+bytes and reaches the same verdict; a node-local fault carries no such
+guarantee, and degrading on one would let two nodes commit different
+states from the same input.
 
 Clients MUST deposit each block's message tips into f02 before invoking
 `AwardBlockReward` for that block and MUST pass exactly their sum as
@@ -1215,8 +1253,8 @@ on the canceled entry: a weight increase that needed a canceled
 decrease's headroom, or a write targeting a stream whose registration
 was canceled. A well-formed due write that fails validation at
 application is discarded, with an event, and processing continues;
-the award path never fails on a queued write, and there is no
-fallback weight vector. A discarded `StepWeightRecords` self-heals:
+the award path never fails on a queued write. A discarded
+`StepWeightRecords` self-heals:
 gate writes are absolute levels derived from the SWA's step counter
 (Section 3.1.1), so the next passing gate restores the full correct
 level, w2 sitting one level low until then. The final step is the
@@ -1236,20 +1274,17 @@ cancellation, and `SetShares` remain available; due writes apply only
 when their result passes full validation. New writes are rejected except a
 timelocked `SetWeightRecords` batch whose projected application restores
 valid records and a valid future schedule without stranding an admitted
-write.
+write. Awards pay nothing until that repair lands (Section 2.4.3).
 
-For either weight failure, `AwardBlockReward` caps the sum of evaluated
-`IMPLICIT` weights at `DENOM`, pays that bounded allocation, accrues no
-`EXPLICIT` allocation, and burns the exact remainder. This defensive
-branch cannot over-issue or construct a negative burn.
-`total_minted_reward` and `total_burn_minted` increase by `BR` and the
-remainder; `total_explicit_minted` is unchanged. Undecodable or malformed
-non-weight state remains illegal. Inconsistent accounting aborts `Claim`,
-`SetShares`, and governance mutations; `AwardBlockReward` instead uses
-the accounting-failure behavior in Section 2.4.3.
+Repairability stops at decodability. Undecodable state cannot be
+repaired in band at all, because every explicit method aborts at load
+before it can propose anything; only a network upgrade carrying a
+migration recovers it.
 
-These are fail-closed responses to inconsistent or corrupted state, not
-alternative allocation modes.
+Inconsistent accounting aborts `Claim`, `SetShares`, and governance
+mutations; `AwardBlockReward` instead degrades as Section 2.4.3
+specifies. These are fail-closed responses to inconsistent or corrupted
+state, not alternative allocation modes.
 
 ##### 2.4.9 Methods and bounds
 
@@ -2178,9 +2213,9 @@ The implementation test suite MUST cover at least:
     gate pass and failure transitions, the sequential gate latch
     (quarter ordering, late cranks, and atomic revert on f02 rejection),
     exact-residual burn, atto-exact reward conservation, unchanged gas
-    and penalty treatment, bounded `IMPLICIT` allocation with no explicit
-    accrual when a weight record is malformed or evaluated weights exceed
-    `DENOM`, and timelocked repair of both;
+    and penalty treatment, no reward minted and no counter moved when a
+    weight record is malformed or evaluated weights exceed `DENOM`, and
+    timelocked repair of both;
 
   - authorization, slot occupancy, projected-schedule validation, queue
     ordering, activation and exact-slot cancellation, dependent-write
@@ -2195,9 +2230,11 @@ The implementation test suite MUST cover at least:
     tombstone drains;
 
   - monotone issuance counters, the derived explicit-stream reserve,
-    unchanged `FilMined`, and accounting-failure or reserve-shortfall
-    awards that return only `gas_reward` with the existing penalty and
-    change no state;
+    unchanged `FilMined`, reserve-shortfall awards that return only
+    `gas_reward` with the existing penalty and change no state,
+    accounting-failure awards that pay the `IMPLICIT` share of the
+    allocation ceiling and burn the remainder without accruing, an
+    exhausted ceiling, and an aborting store fault;
 
   - FPV calculation for admitted stablecoin and FIL settlements,
     pricing-print boundaries, reporting and correction windows,
@@ -2348,9 +2385,9 @@ changes to leader election or finality.
   - **Consensus-path safety of the split.** The per-block split makes no
     FEVM or recipient call. Queue admission rejects a projected epoch
     with `Σ w_i > 1`, and cancellation-stranded writes drop before
-    allocation. An otherwise well-formed persisted violation pays only
-    the implicit allocation, burns the remainder, and permits a
-    validating timelocked repair. Otherwise each allocation is floored
+    allocation. An otherwise well-formed persisted violation mints no
+    reward at all and permits a validating timelocked repair, so no
+    party gains by inducing one. Otherwise each allocation is floored
     and the exact residual burns, conserving `BR` atto-exactly.
     `MAX_STREAMS` bounds allocation work and `MAX_RECIPIENTS` bounds each
     share map. The low-balance cap derives outstanding liability from

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -855,7 +855,7 @@ w0(e) = 1 - Σ_{i>=1} ComputeWeight(W_i, e)  // residual over all streams; never
 ##### 2.4.2 State
 
 The pre-upgrade f02 state is an 11-field tuple; this migration produces
-the 15-field tuple below. Per-block counters, accruals, and epochs remain
+the 14-field tuple below. Per-block counters, accruals, and epochs remain
 inline. Stream configuration, recipient accounting, tombstones, and the
 queue live behind one CID, read every award for weights and liabilities
 but rewritten only by stream mutations or a due transition.
@@ -867,7 +867,6 @@ but rewritten only by stream mutations or a due transition.
 | `total_burn_minted` | New counter: cumulative w0 residual, accrued at award. |
 | `total_explicit_minted` | New counter: cumulative accrual across all `EXPLICIT` streams. |
 | `accrued[id]` | New, one per `EXPLICIT` stream: the current period's gross accrual. |
-| `next_transition_epoch` | New: the earliest effective epoch over the pending writes; recomputed on queue, apply and cancel; -1 (`EPOCH_UNDEFINED`) when the queue is empty. It lets the per-block path skip queue projection, cloning, and a CID rewrite when no write is due. |
 | `swa_timelock_epochs` | New: the SWA timelock in epochs (`SWA_TIMELOCK`), set per network by the migration and never written afterwards. Mainnet: 7 days; test networks may set it shorter. |
 | `streams_root` | New CID: the stream list, the tombstones and the pending-write queue. |
 
@@ -893,11 +892,14 @@ Encoding follows Filecoin's canonical IPLD conventions:
 
   - each Rust struct below is a DAG-CBOR tuple, encoded as an array in
     field order; logical maps use ordered entry arrays, not CBOR maps;
-  - `TokenAmount`, other big integers, `FilterEstimate`, and `Address`
-    use their standard chain encodings, with stored addresses normalized
-    to ID form;
-  - `Option<T>` is null or `T`, and `PendingWriteOp` is its displayed
-    unsigned integer discriminant; and
+  - `TokenAmount`, `Spacetime`, and other big integers are byte strings:
+    one sign byte (`00` non-negative, `01` negative), then big-endian
+    magnitude, empty for zero; `FilterEstimate` is a pair of such integers;
+  - `Address` is Filecoin address bytes in ID form: protocol byte `00`,
+    then the LEB128 actor ID; stored addresses are normalized to this form;
+  - `Option<T>` is null or `T`; `PendingWriteOp` is its displayed unsigned
+    integer discriminant; `RawBytes` is a CBOR byte string wrapping a
+    separately encoded operation payload tuple;
   - `accrued`, `streams`, and `tombstones` have unique ascending stream
     IDs; recipient tables have unique ascending recipient IDs; and
     `pending_writes` is ordered by effective epoch, preserving admission
@@ -917,9 +919,8 @@ struct State {
     total_burn_minted: TokenAmount,         // 10 new
     total_explicit_minted: TokenAmount,     // 11 new
     accrued: Vec<StreamAccrual>,            // 12 new
-    next_transition_epoch: ChainEpoch,      // 13 new; -1 when queue empty
-    swa_timelock_epochs: ChainEpoch,        // 14 new; migration-set only
-    streams_root: Cid,                      // 15 new
+    swa_timelock_epochs: ChainEpoch,        // 13 new; migration-set only
+    streams_root: Cid,                      // 14 new
 }
 
 struct StreamAccrual { id: u64, amount: TokenAmount }
@@ -928,7 +929,7 @@ struct StreamAccrual { id: u64, amount: TokenAmount }
 struct StreamsState {
     streams: Vec<Stream>,
     tombstones: Vec<Tombstone>,
-    pending_writes: Vec<PendingWrite>,      // effective epoch, then queue position
+    pending_writes: Vec<PendingWrite>,
 }
 
 struct Stream {
@@ -960,14 +961,14 @@ struct Tombstone { id: u64, payable: Vec<RecipientAmount> }
 struct PendingWrite {
     id: Option<u64>,                        // None for schedule-wide ops
     op: PendingWriteOp,
-    payload: RawBytes,                      // the op's payload tuple, below
+    payload: RawBytes, // operation tuple wrapped as a CBOR byte string
     effective_epoch: ChainEpoch,
 }
 
 enum PendingWriteOp { // encoded as the displayed integer
     SetWeightRecords = 0,   // payload: [ [ [id, WeightRecord], .. ] ]
     StepWeightRecords = 1,  // payload as SetWeightRecords; uncancellable
-    RegisterStream = 2,     // payload: [ WeightRecord, Option<DistributionInit> ]
+    RegisterStream = 2,     // payload: [WeightRecord, Option<DistributionInit>]
     RemoveStream = 3,       // payload: [] (empty tuple)
     SetDistribution = 4,    // payload: [ Address ]
 }
@@ -986,20 +987,29 @@ callers do not.
 
 ```
 AwardBlockReward(miner, penalty, gas_reward, win_count):
-    fold_dust = apply due queued writes if any (Section 2.4.7)
+    require balance >= gas_reward
+    if current explicit liability is uncomputable:
+        pay gas_reward and apply penalty as today; return without state change
+    projection = project valid due writes and cancellation-stranded drops
+    fold_dust = projection's fold dust
     liability =
-        Σ live (accrued - Σ claimed_period + Σ payable)
-        + Σ tombstone payable
+        Σ projected live (accrued - Σ claimed_period + Σ payable)
+        + Σ projected tombstone payable
+    if liability is uncomputable
+       or balance < gas_reward + liability + fold_dust:
+        pay gas_reward and apply penalty as today; return without state change
+    commit projection
     computed_BR = this_epoch_reward * win_count / 5
-    require balance >= gas_reward + liability + fold_dust
     BR = min(computed_BR, balance - gas_reward - liability - fold_dust)
     evaluated = ComputeWeight for every active stream
-    weights_valid = every record satisfies 0 <= floor <= v_start <= cap <= DENOM
+    weights_valid =
+        every record satisfies 0 <= floor <= v_start <= cap <= DENOM
     miner_reward = 0
     paid = 0
     if not weights_valid or Σ evaluated > DENOM:
         // Defensive: queue and application validation enforce both conditions.
-        implicit_weight = min(Σ evaluated weights of IMPLICIT streams, DENOM)
+        implicit_weight =
+            min(Σ evaluated weights of IMPLICIT streams, DENOM)
         miner_reward = floor(implicit_weight * BR / DENOM)
         paid = miner_reward                       // Section 2.4.8
     else:
@@ -1014,16 +1024,28 @@ AwardBlockReward(miner, penalty, gas_reward, win_count):
     burn = BR - paid
     send(f099, burn + fold_dust); total_burn_minted += burn
     total_minted_reward += BR
-    pay miner_reward + gas_reward to the winning miner, penalties as today
+    pay miner_reward + gas_reward to winning miner; penalties as today
 ```
 
-`liability` is computed after due writes apply. Rounding dust produced
-by those writes is no longer owed to recipients but has not yet been
-burned, so `fold_dust` is excluded from `BR` separately and sent to
-f099 with the residual burn.
-Burning the exact residual conserves `BR` atto-exactly despite
-per-stream floors. Gas rewards and existing miner-send failure handling
-are unchanged; the allocation path calls no FEVM contract or recipient.
+Due writes and drops are projected, not committed, until current and
+projected liabilities are computable and the reserve check passes. An
+uncomputable liability or shortfall pays only `gas_reward`, applies the
+penalty as today, and commits no projection, accrual, burn, or issuance
+counter; the next award retries from stored state.
+
+Clients MUST deposit each block's message tips into f02 before invoking
+`AwardBlockReward` for that block and MUST pass exactly their sum as
+`gas_reward`. Thus `gas_reward` is fresh balance: a reserve shortfall
+proves the pre-tip balance was already underfunded, and returning those
+tips cannot consume previously sound reserve. `balance < gas_reward`
+is an invariant failure.
+
+After projection commits, its fold dust is no longer owed to recipients
+but has not yet been burned, so it is excluded from `BR` and sent to
+f099 with the residual. Burning the exact residual conserves `BR`
+atto-exactly despite per-stream floors. Gas rewards and existing
+miner-send failure handling are unchanged; the allocation path calls
+no FEVM contract or recipient.
 
 ##### 2.4.4 SetShares and the period fold
 
@@ -1059,10 +1081,11 @@ claims. The residue is rounding dust only, because shares sum to
 exactly one, and it burns without touching either counter:
 `total_explicit_minted` already counted it at accrual, so the
 decomposition attributes dust to explicit-stream issuance and the
-derived miner residual stays exact; f099's receipts exceed `total_burn_minted`
-by cumulative dust. A recipient that does not resolve to an ID address
-rejects the whole call: a backstop against typos and stranded funds,
-with the SRA validating recipients at registration.
+derived miner residual stays exact. On the normal award path, fold dust
+makes f099's receipt exceed the w0 amount added to `total_burn_minted`.
+A recipient that does not resolve to an ID address rejects the whole
+call: a backstop against typos and stranded funds, with the SRA
+validating recipients at registration.
 
 ##### 2.4.5 Claim
 
@@ -1091,9 +1114,18 @@ amount is banked as payable under the outgoing shares. On removal
 those balances move to a **tombstone** for the stream's id, so claims
 stay addressable after removal: `Claim` pays from the tombstone, rows
 delete as they are claimed, and a drained tombstone deletes entirely,
-so nothing about a removed stream is permanent. A removed stream's
-weight reverts to the burn residual until reallocated. Id non-reuse
-after the tombstone is gone is SWA discipline (f02 still rejects any
+so nothing about a removed stream is permanent. `RemoveStream` admission
+requires existing tombstone payable rows plus one
+`max(MAX_RECIPIENTS, |payable ∪ shares|)` reservation for each pending
+removal, including the candidate, to be at most `MAX_TOMBSTONE_ROWS`.
+For each removal, `|payable ∪ shares|` counts the distinct recipient IDs
+in that target stream's two tables; an ID present in both counts once. Any
+`SetShares` while a removal is pending recomputes every reservation from
+the post-fold `payable ∪ shares` and rejects the change if the aggregate
+exceeds the cap. Removal revalidates at application. Each successful
+`Claim` immediately frees capacity by deleting paid rows. A removed
+stream's weight reverts to the burn residual until reallocated. Id
+non-reuse after the tombstone is gone is SWA discipline (f02 still rejects any
 duplicate it can see); violating it risks event-history ambiguity
 only, a deleted tombstone having zero payable by definition.
 `SetDistribution` changes only the writer: the share map stands until
@@ -1114,8 +1146,9 @@ epoch plus `swa_timelock_epochs`, except for `RegisterStream`, whose
 caller-supplied `activation_epoch` is its effective epoch, rejected if
 below that same floor. The apply epoch is the first epoch at or after
 the effective epoch at which `AwardBlockReward` or any mutating method
-runs; due entries apply then, in effective-epoch order, ties broken by
-queue position, so no message executes against stale configuration.
+runs. Each reads the ordered queue head directly and applies due entries
+in effective-epoch order, ties broken by queue position, so no message
+executes against stale configuration.
 No entry's timing depends on any other entry. The objection window is
 `[queue epoch, effective epoch)`: `CancelPending` acts only inside it,
 and being itself a mutating method, a due entry applies before a
@@ -1210,8 +1243,13 @@ For either weight failure, `AwardBlockReward` caps the sum of evaluated
 `EXPLICIT` allocation, and burns the exact remainder. This defensive
 branch cannot over-issue or construct a negative burn.
 `total_minted_reward` and `total_burn_minted` increase by `BR` and the
-remainder; `total_explicit_minted` is unchanged. Undecodable state,
-malformed non-weight state, and inconsistent accounting remain illegal.
+remainder; `total_explicit_minted` is unchanged. Undecodable or malformed
+non-weight state remains illegal. Inconsistent accounting aborts `Claim`,
+`SetShares`, and governance mutations; `AwardBlockReward` instead uses
+the accounting-failure behavior in Section 2.4.3.
+
+These are fail-closed responses to inconsistent or corrupted state, not
+alternative allocation modes.
 
 ##### 2.4.9 Methods and bounds
 
@@ -1244,8 +1282,10 @@ nothing until its `activation_epoch`.
 
 Parameter and return values are tuples under Section 2.4.2. Registration
 accepts `DistributionInit`; f02 constructs empty accounting tables when
-the write applies. Share maps are validated wherever supplied. All
-write methods return nothing.
+the write applies. `SetShares` checks `MAX_RECIPIENTS` and authorizes its
+writer before resolving recipients; `Claim` checks `MAX_RECIPIENTS`
+before resolving wallets. Share maps are validated wherever supplied.
+All write methods return nothing.
 
 ```rust
 struct DistributionInit {
@@ -1296,26 +1336,34 @@ disambiguates cancellation and requeue of the same slot.
 
 Schedule-wide events omit `stream-id`. Applied events precede dropped
 events, both in queue order, followed by a newly queued or cancelled
-event; claim events follow request order. Reverted calls emit no event,
-and event construction or emission failure aborts the transaction.
+event; claim events follow request order. Reverted calls emit no event;
+event construction or emission failure aborts an explicit call.
 
-`write-applied` and `write-dropped` emitted during implicit
-`AwardBlockReward` calls are not chain-visible today, as with
-miner-actor events from implicit paths. Activating FIP-0107 would make
-their receipts and event roots chain-reachable; until then these
+`write-applied` and `write-dropped` construction and emission during
+implicit `AwardBlockReward` are best-effort: failure does not alter the
+state transition or award. These events are not chain-visible today, as
+with miner-actor events from implicit paths. Activating FIP-0107 would
+make their receipts and event roots chain-reachable; until then the
 outcomes require replay or state comparison.
 
 **`MAX_STREAMS = 8`, `MAX_RECIPIENTS = 64`,
+`MAX_TOMBSTONE_ROWS = 256`,
 `MAX_PENDING_WRITES = 3 * MAX_STREAMS + 2 = 26`.** `MAX_STREAMS`
-includes Consensus. `MAX_RECIPIENTS` bounds each share map. The queue
-bound is its exact slot space: three per-stream operations and two
-schedule-wide operations.
+includes Consensus. `MAX_RECIPIENTS` bounds each share map and
+`Claim.wallets`; `MAX_TOMBSTONE_ROWS` caps payable rows across all
+tombstones. The queue bound is its exact slot space: three per-stream
+operations and two schedule-wide operations.
 
-These bounds limit configured award and mutation work, not historical
-accounting rows. Payable rows and tombstones have no aggregate bound,
-but anyone can drain them through `Claim`. Raising a limit requires a
-future FIP and network upgrade that also reshapes the affected
-structures for the new scale.
+These bounds limit configured award and mutation work. Live-stream
+payable rows have no aggregate bound and drain through `Claim`. At the
+tombstone cap, operators remove until reserved capacity is full, drain
+rows through permissionless `Claim`, then continue. The shared cap also
+couples governance tiers: each pending removal reserves at least 64 rows,
+so at most four can be in flight, and the lower-tier SRA writer can reduce
+that concurrency by growing recipient unions; it cannot block removals,
+which serialize under the drainage cadence above. Raising a limit requires
+a future FIP and network upgrade that also reshapes the affected structures
+for the new scale.
 
 ##### 2.4.10 Migration
 
@@ -1338,6 +1386,8 @@ and the SRA as designated writer. The migration also renames position
 constants of Section 2.4.2 on every network), zeroes the new
 counters, and sets `swa_timelock_epochs`: the only place it is ever
 written.
+The migration resolves every bootstrap writer and recipient to an ID
+address before persistence.
 
 #### 2.5 Supply accounting
 
@@ -2128,14 +2178,14 @@ The implementation test suite MUST cover at least:
     gate pass and failure transitions, the sequential gate latch
     (quarter ordering, late cranks, and atomic revert on f02 rejection),
     exact-residual burn, atto-exact reward conservation, unchanged gas
-    and penalty treatment, bounded miner-only fallback for malformed
-    weight records or a schedule whose evaluated weights exceed `DENOM`,
-    and timelocked repair of both;
+    and penalty treatment, bounded `IMPLICIT` allocation with no explicit
+    accrual when a weight record is malformed or evaluated weights exceed
+    `DENOM`, and timelocked repair of both;
 
   - authorization, slot occupancy, projected-schedule validation, queue
     ordering, activation and exact-slot cancellation, dependent-write
-    dropping, refusal to cancel `StepWeightRecords`, and all five actor
-    event types;
+    dropping, refusal to cancel `StepWeightRecords`, and all five event
+    types, including explicit failure rollback and implicit best effort;
 
   - stream registration and distribution changes, share-map validation
     and immediate binding, period folds and dust, positional claims and
@@ -2144,8 +2194,10 @@ The implementation test suite MUST cover at least:
     consensus-stream removal, and stream-ID reuse only after its
     tombstone drains;
 
-  - monotone issuance counters, the exact derived explicit-stream reserve,
-    low-balance protection of accrued funds, and unchanged `FilMined`;
+  - monotone issuance counters, the derived explicit-stream reserve,
+    unchanged `FilMined`, and accounting-failure or reserve-shortfall
+    awards that return only `gas_reward` with the existing penalty and
+    change no state;
 
   - FPV calculation for admitted stablecoin and FIL settlements,
     pricing-print boundaries, reporting and correction windows,
@@ -2392,10 +2444,13 @@ Implementation is tracked in the
     [Solstice repository](https://github.com/filecoin-project/solstice)
     and its [open issues](https://github.com/filecoin-project/solstice/issues).
 
-  - **Built-in actors:** current work in progress on
-    [datacap and QAP changes](https://github.com/filecoin-project/builtin-actors/pull/1760),
-    the [legacy-sector upgrade](https://github.com/filecoin-project/builtin-actors/issues/1763)
-    and the [reward split](https://github.com/filecoin-project/builtin-actors/issues/1764).
+  - **Built-in actors:** miner-actor work in
+    [PR #1760](https://github.com/filecoin-project/builtin-actors/pull/1760)
+    (DataCap/verified-registry disconnect and 10× QAP) and
+    [PR #1775](https://github.com/filecoin-project/builtin-actors/pull/1775)
+    (`ExtendSectorExpiration3`, to be merged into #1760); reward-actor f02
+    changes in
+    [PR #1774](https://github.com/filecoin-project/builtin-actors/pull/1774).
 
   - **Node implementations and shared types:** planned updates to
     go-state-types, Lotus, Forest, Venus and SP tooling.
@@ -2406,7 +2461,7 @@ The following items must be resolved before this FIP can enter Last
 Call:
 
   - finalize the legacy-sector 10× upgrade pathway and reconcile
-    Sections 1.2 and 1.3 with builtin-actors issue #1763;
+    Sections 1.2 and 1.3 with builtin-actors PR #1775;
 
   - incorporate the implementation decisions in builtin-actors PR
     #1760 for in-flight allocations, the `FULL_QA_POWER` flag, and

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -1206,9 +1206,10 @@ each entry's admission and disposition observable (Section 2.4.9).
 
 Cancellability is a static per-operation rule: `CancelPending(id, op)`
 deletes any pending slot except a `StepWeightRecords` slot, the gate
-write (Section 3.1.1), so a compromised Safe cannot suppress a gate
-step; the id is null for schedule-wide operations, and a mismatched
-id/op pair is rejected.
+write (Section 3.1.1). `StepWeightRecords` is therefore uncancellable:
+this prevents a Safe from retracting a gate write the SWA has successfully
+queued; it does not require the SWA to make that write. The id is null for
+schedule-wide operations, and a mismatched id/op pair is rejected.
 Canceling an empty slot is a benign no-op, since both Safes may relay
 the same objection; it emits no event.
 Cancellation does not re-validate the remaining queue: a cancel can
@@ -1296,7 +1297,7 @@ contracts. Existing methods keep their numbers and signatures.
 | Method | Caller | Binding |
 |---|---|---|
 | `SetWeightRecords(records)` | SWA | queued |
-| `StepWeightRecords(records)` | SWA (gate path) | queued; not cancellable |
+| `StepWeightRecords(records)` | SWA (gate path) | queued; uncancellable |
 | `RegisterStream(id, weight_record, distribution, activation_epoch)` | SWA | queued |
 | `RemoveStream(id)` | SWA | queued |
 | `SetDistribution(id, writer)` | SWA | queued |
@@ -1307,16 +1308,17 @@ contracts. Existing methods keep their numbers and signatures.
 SWA caller checks compare the caller's f0 ID address exactly with
 `swa_actor`; Init assigns actor IDs per network, so no portable code
 constant exists and the deployed address is migration configuration.
-There is no setter: replacing the SWA still requires a FIP and network
-upgrade, the compromised-tier backstop in Section 4. The SRA needs no
+There is no setter: replacing the authorized SWA address still requires
+a FIP and network upgrade. Code at that identity may be upgraded under
+Section 4 without changing the address or f02 state; f02 assumes nothing
+about SWA code beyond the `swa_actor` identity. The SRA needs no
 equivalent root field because each stream names its designated writer.
 
 `SetWeightRecords` and `StepWeightRecords` are payload-identical; they are
-separate methods so that cancellability is a static per-operation
-rule. The SWA's gate path (`QuarterlyGateCheck`) calls
-`StepWeightRecords` and its discretionary path (`ProposeWrite`) calls the
-rest; which SWA path calls which is SWA code, not an assertion f02
-has to trust.
+separate methods so that cancellability is a static per-operation rule.
+The SWA's gate path (`QuarterlyGateCheck`) calls `StepWeightRecords` and
+its discretionary path (`ProposeWrite`) calls the rest; this division is
+contract behavior, not an assertion f02 has to trust.
 
 `RegisterStream` validates that the resulting stream count does not
 exceed `MAX_STREAMS`, the recipient count within `MAX_RECIPIENTS`,
@@ -1482,6 +1484,10 @@ award path, and Orchestrator funds accrue in f02 until withdrawn via
 the SWA only sets weight records and the SRA only computes shares, and
 both simply write them to f02.
 
+Sections 3 and 4 specify governed FEVM contract behavior, not consensus
+rules. Both contracts are upgradeable under Section 4 without a network
+upgrade; consensus enforcement remains in the miner actor and f02.
+
 #### 3.1 Stream Weights Actor (SWA): the split among streams
 
 The SWA is the actor that sets and updates the weight records. In
@@ -1530,8 +1536,8 @@ particular
         it has not yet run (Section 2.2). Runs the gate rule of
         Section 3.1.1 and, when the gate passes, writes the new w2
         Weight record to f02 via `StepWeightRecords`, the uncancellable
-        gate write (Section 2.4.7). It can submit only the value it
-        computes.
+        gate write (Section 2.4.7). The specified contract submits only
+        the value it computes.
 
       - **`ProposeWrite(write)`.** Requires the approval of both SWA
         Safes. Relays a discretionary write (`SetWeightRecords`,
@@ -1843,7 +1849,7 @@ Orchestrator registry and the split within the service stream. Registry
 changes alter who participates within fixed rules (analogous to a new
 miner joining the consensus stream), so they need no FIP. Contract code
 is the exception on both sides: upgrading either contract requires a
-FIP.
+published and accepted FIP, but no network upgrade.
 
 The system is secured because every deliberate change waits in a public
 queue before it takes effect and can be canceled during the wait. A
@@ -1862,11 +1868,16 @@ across surfaces. Two entities is the target state at activation: the
 approval rule lives in the contracts, so a later FIP and contract
 upgrade can extend the roster without a network upgrade. How each Safe
 is implemented internally (threshold, keys, custody, rotation) is that
-entity's affair. The same approval mechanism covers every discretionary
-action at both tiers: both Safes approve, the change is published and
-held before it binds, and either Safe alone can cancel it during the
-hold. A cancellation can only preserve the status quo, so it grants no
-new power.
+entity's affair.
+
+The two Safes for each contract hold its upgrade authority. The same
+approval process covers every discretionary action at both tiers: both
+Safes approve, the change is published on chain and held before it
+binds, and either Safe alone can cancel it during the hold. A code
+upgrade additionally requires a published and accepted FIP, but no
+network upgrade; the pending upgrade and its execution MUST be
+observable on chain. A cancellation can only preserve the status quo,
+so it grants no new power.
 
 **SWA Governance** discretionary powers, each requiring a published and
 accepted FIP:
@@ -1926,26 +1937,26 @@ Every discretionary change follows the same path: both Safes approve,
 the change is published and held, and either Safe can cancel during the
 hold. There is no exemption by category beyond one carve-out (below), so
 reducing a weight to zero is held exactly like removing a stream.
-Mechanism-executed updates cannot be canceled: the gate’s quarterly w2
+Mechanism-executed updates cannot be canceled: the gate's quarterly w2
 write queues in f02 under `SWA_TIMELOCK` for visibility, but it arrives
 through its own method, `StepWeightRecords`, the one operation
-`CancelPending` refuses (Section 2.4.7), while the SRA’s quarterly share
-map is never queued and binds
-directly via `SetShares` (Section 3.2). The carve-out is `CorrectVolume`
-(Section 3.2): the verification window itself is the hold, so a
-correction binds when the window closes and has no separate cancellation
-path; a contested correction is appealed through the dispute process,
-and the appeal outcome affects only later quarters.
+`CancelPending` refuses (Section 2.4.7), while the SRA's quarterly share
+map is never queued and binds directly via `SetShares` (Section 3.2).
+The carve-out is `CorrectVolume` (Section 3.2): the verification window
+itself is the hold, so a correction binds when the window closes and has
+no separate cancellation path; a contested correction is appealed
+through the dispute process, and the appeal outcome affects only later
+quarters.
 
 The 7-day delay on SWA writes (the objection window) is enforced at L1:
 f02 itself holds every SWA write for `SWA_TIMELOCK` (7 days, Section 2.4)
 before applying it, so even a compromised Safe or a maliciously upgraded
-SWA cannot make a change bind early. The backing FIP has already carried
-the substance of the change through the FIP process, including its Last
-Call; the hold reviews execution rather than substance. During the hold
-anyone can verify that the queued write matches the accepted FIP, and
-either Safe cancels on a mismatch, a missing FIP, or new information
-that surfaced after acceptance.
+SWA cannot make a change bind early. For a compliant discretionary write,
+the accepted FIP has already carried the substance through Last Call; the
+hold reviews execution rather than substance. During the hold anyone can
+verify that the queued write matches the accepted FIP, and either Safe
+cancels on a mismatch, a missing FIP, or new information that surfaced
+after acceptance.
 
 A governance tier that can no longer act is replaced from one level
 above, always under a published FIP: a deadlocked SRA Governance is
@@ -1975,9 +1986,9 @@ tiers and their powers; the two-Safe rule; the per-change FIP
 requirement on discretionary SWA writes; the mechanism/discretionary
 distinction; the (payer, operator) uniqueness invariant (Section 2.3);
 the L1 conditions enforced in f02 (Section 2.4); and the backstops for
-replacing a governance tier that can no longer act. An upgrade executes
-through the pre-upgrade code, so it cannot bypass its own lifecycle, and
-f02 enforces its conditions on every SWA write regardless of what the
+replacing a governance tier that can no longer act. The upgrade properties
+in Section 4.2 are fixed; the contract-level implementation mechanism is
+not. f02 enforces its conditions on every SWA write regardless of what the
 contracts become.
 
 Summary of change process requirements at each level:
@@ -1985,7 +1996,7 @@ Summary of change process requirements at each level:
 | **Change**                                                                      | **Process**                                          |
 | ------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | f02 code or its invariants; replacing the SWA address                           | FIP and network upgrade                              |
-| Streams, weights, distributions, gate parameters, SWA or SRA code               | FIP, both Safes, held                                |
+| Streams, weights, distributions, gate parameters, SWA or SRA code               | FIP, both Safes, on-chain hold; no network upgrade   |
 | Registry membership, bindings, volume corrections, cooperative Safe replacement | Both Safes, held, no FIP                             |
 | Gate step, quarterly shares, volume posting, pair registration                  | Mechanism-executed or permissionless, window-bounded |
 | Repository content (rosters, criteria, durations, playbooks, indexer, etc.)     | Pull request                                         |
@@ -2244,9 +2255,11 @@ The implementation test suite MUST cover at least:
     allocation ceiling and burn the remainder without accruing, an
     exhausted ceiling, and an aborting store fault;
 
-  - FPV calculation for admitted stablecoin and FIL settlements,
-    pricing-print boundaries, reporting and correction windows,
-    missing reports, frozen Orchestrators, and identical inputs to
+  - SWA and SRA upgrade authorization, hold, cancellation and on-chain
+    observability, plus f02's identity-only authorization across an SWA
+    upgrade; FPV calculation for admitted stablecoin and FIL settlements,
+    pricing-print boundaries, reporting and correction windows, missing
+    reports, frozen Orchestrators, and identical inputs to
     `QuarterlyGateCheck` and `SubmitShares`; and
 
   - cross-implementation vectors for the f02 state schema, exported
@@ -2271,25 +2284,28 @@ changes to leader election or finality.
 
   - **Governance over consensus.** SWA Governance can rewrite the
     consensus weight schedule, so the main risk is a captured tier. Its
-    power stops at parameters: the consensus protocol is changeable only
-    by FIP and network upgrade, and the path is keyless, nothing to
-    drain, no reward redirectable in flight. Mitigations layer: every
-    discretionary write needs a published, accepted FIP; both Safes must
-    approve and either alone can cancel during the hold; the 7-day hold
-    is enforced by f02 itself, binding even under a maliciously upgraded
-    SWA; a failed tier is replaced from above via network upgrade
-    (Section 4.3). Residual worst case: with both Safes captured, a
-    hostile write still sits visibly queued for the full timelock, and
-    the bound is that race, an emergency network upgrade within
-    `SWA_TIMELOCK`.
+    authority covers SWA contract code and parameters, but not consensus
+    validation: changing f02, the miner actor, or their invariants requires
+    a FIP and network upgrade. The SWA holds no balance. Every compliant
+    discretionary write and code upgrade needs a published, accepted FIP;
+    both Safes must approve, either alone can cancel during the hold, and
+    the upgrade is observable on chain. f02 enforces its own validation
+    and 7-day hold even under a maliciously upgraded SWA. A captured or
+    upgraded SWA can suppress a future gate step by omitting the call;
+    uncancellability only prevents a Safe from retracting a gate write
+    already queued. It still cannot make an invalid write pass f02 or
+    make a queued write bind early. With both Safes captured, a hostile
+    valid write remains visibly queued for the full timelock; the backstop
+    is an emergency network upgrade within `SWA_TIMELOCK` (Section 4.3).
 
   - **Governance over the registry (SRA capture).** A captured SRA
     Governance could admit a bogus Orchestrator, misattribute (payer,
-    operator) pairs, or freeze a competitor, but its blast radius is
-    limited: the SRA sets only shares (validated to sum to one, Section
-    2.4), custodies no balance, and at worst misallocates one period of
-    the service stream among Orchestrators, which is recomputable and
-    correctable from public events. Misattribution is further
+    operator) pairs, or freeze a competitor, but its blast radius at f02
+    is limited regardless of SRA code: as the designated writer it can
+    set only shares validated to sum to one (Section 2.4), custodies no
+    balance, and at worst misallocates one period of the service stream
+    among Orchestrators, which is recomputable and correctable from public
+    events. Misattribution is further
     constrained in-contract: (payer, operator) bindings are unique, so
     redirecting another Orchestrator’s volume requires an explicit
     registry change, which is public during the cancellation hold. One
@@ -2298,9 +2314,8 @@ changes to leader election or finality.
     report inflated volume to force a w2 step-up. That step is still
     bounded (one `W2_STEP` per quarter under the gate latch, with
     f02's queue-time validation keeping the weights within `Σ ≤ 1`,
-    Sections 2.4.8 and 3.1.1), held by
-    `SWA_TIMELOCK`, and visible during that hold, though not cancellable
-    since gate steps are mechanism-executed (Section 4.3) and the posted
+    Sections 2.4.8 and 3.1.1), held by `SWA_TIMELOCK`, visible during
+    that hold, and uncancellable (Section 4.3); the posted
     FPV is itself held by the verification window and correctable
     against recomputation (Section 2.2). Unlike the share misallocation,
     which is confined to one quarter, a wrongly executed step is

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -519,8 +519,11 @@ Once per quarter, off the per-epoch path:
         after the window closes and read only bound values, with
         `AggregatedFPV(Q)` the sum of bound values. There is no
         retroactive clawback: a misreport discovered after binding is
-        grounds for audit, freeze, or removal (Section 4), and its
-        damage is bounded to that quarter's service stream.
+        grounds for audit, freeze, or removal (Section 4). Its share-map
+        effect is bounded to that quarter. A gate it wrongly passes is a
+        standing w2 step, reversible only by a FIP-backed discretionary
+        write with the matching `steps` adjustment (Sections 3.1.1 and
+        4.2).
 
     5.  Determinism: `FPV_i(Q)` is fully determined by (i) settlement
         events from admitted Filecoin Pay contracts: stablecoin
@@ -579,7 +582,7 @@ Once per quarter, off the per-epoch path:
     does not enter `AggregatedFPV(Q)` (Section 3.2).
 
     Quarter 1 runs this full pipeline with one exception: no gate
-    check. Posting, verification, binding and `SubmitShares(1)` proceed
+    check. Posting, verification, binding and `SubmitShares()` proceed
     as in any other quarter, and the first quarter's report is
     required even though it gates nothing: the Orchestrator posts on
     chain and the bound values set the shares. Only `QuarterlyGateCheck`
@@ -796,8 +799,8 @@ a recipient's behalf.
         3.  **`claimed_period`**: per-wallet amounts already claimed
             against the current period's accrual.
 
-        A future stream paying one fixed wallet needs no separate
-        form: it is the one-entry `EXPLICIT` case.
+        A future stream paying any fixed set of wallets needs no
+        separate form: it is the plain `EXPLICIT` case.
 
 Weight and Distribution are orthogonal: a stream picks each
 independently, so registering a new stream means giving it a Weight
@@ -847,25 +850,24 @@ w0(e) = 1 - Σ_{i>=1} ComputeWeight(W_i, e)  // residual over all streams; never
     with floor. Slope quantization over the 9-quarter ramp is ~1e-10 of
     a percentage point at this scale, and the clamp endpoints are
     stored exact, so w1 comes to rest at exactly its 50% floor. Token
-    amounts are attoFIL big integers, serialized as f02's existing
-    fields are.
+    amounts are attoFIL big integers.
 
 ##### 2.4.2 State
 
-f02's state is an 11-field tuple rewritten every block. The rule for
-the changes: values that mutate per block stay inline in the root
-tuple (`TokenAmount` counters and an epoch, both small on the wire);
-everything else lives behind one CID, written only at governance,
-quarterly or claim cadence.
+The pre-upgrade f02 state is an 11-field tuple; this migration produces
+the 15-field tuple below. Per-block counters, accruals, and epochs remain
+inline. Stream configuration, recipient accounting, tombstones, and the
+queue live behind one CID, read every award for weights and liabilities
+but rewritten only by stream mutations or a due transition.
 
 | Field | Change |
 |---|---|
 | `total_minted_reward` (position 9) | Renamed from `total_storage_power_reward`, position kept. Accrues the full block reward, all streams (Section 2.5). |
 | `simple_total`, `baseline_total` (positions 10, 11) | Deleted: retired to the code constants below, as the existing state comment anticipates ("can be moved from state back into a code constant in a subsequent upgrade"). |
 | `total_burn_minted` | New counter: cumulative w0 residual, accrued at award. |
-| `total_service_minted` | New counter: cumulative accrual across all `EXPLICIT` streams. |
-| `service_accrued[id]` | New, one per `EXPLICIT` stream: the current period's gross accrual. |
-| `next_transition_epoch` | New: the earliest effective epoch over the pending writes; recomputed on queue, apply and cancel; -1 (`EPOCH_UNDEFINED`) when the queue is empty. The per-block path compares this one integer and touches `streams_root` only when a write is due. |
+| `total_explicit_minted` | New counter: cumulative accrual across all `EXPLICIT` streams. |
+| `accrued[id]` | New, one per `EXPLICIT` stream: the current period's gross accrual. |
+| `next_transition_epoch` | New: the earliest effective epoch over the pending writes; recomputed on queue, apply and cancel; -1 (`EPOCH_UNDEFINED`) when the queue is empty. It lets the per-block path skip queue projection, cloning, and a CID rewrite when no write is due. |
 | `swa_timelock_epochs` | New: the SWA timelock in epochs (`SWA_TIMELOCK`), set per network by the migration and never written afterwards. Mainnet: 7 days; test networks may set it shorter. |
 | `streams_root` | New CID: the stream list, the tombstones and the pending-write queue. |
 
@@ -887,21 +889,22 @@ reward actor state at any pre-upgrade epoch, and the Test Cases
 section requires the functional check that reward computation is
 unchanged by the substitution.
 
-Encoding rules are per Filecoin standard IPLD format:
-every structure is CBOR tuple-encoded, an array of its fields in the
-order written; maps are never used. `TokenAmount` and other big
-integers are byte strings: one sign byte (00 non-negative, 01
-negative) then the big-endian magnitude, empty for zero. `Address`
-is Filecoin address bytes, always ID form (protocol byte 00 then the
-LEB128 id), normalized at every write. `Option<T>` is CBOR null or `T`.
-Keyed arrays sort ascending by key with unique keys; `pending_writes`
-alone is ordered by effective epoch, equal epochs retaining queue
-position (the apply tiebreak). `Spacetime` is a big integer;
-`FilterEstimate`
-is a pair of big integers, unchanged.
+Encoding follows Filecoin's canonical IPLD conventions:
+
+  - each Rust struct below is a DAG-CBOR tuple, encoded as an array in
+    field order; logical maps use ordered entry arrays, not CBOR maps;
+  - `TokenAmount`, other big integers, `FilterEstimate`, and `Address`
+    use their standard chain encodings, with stored addresses normalized
+    to ID form;
+  - `Option<T>` is null or `T`, and `PendingWriteOp` is its displayed
+    unsigned integer discriminant; and
+  - `accrued`, `streams`, and `tombstones` have unique ascending stream
+    IDs; recipient tables have unique ascending recipient IDs; and
+    `pending_writes` is ordered by effective epoch, preserving admission
+    order at equal epochs.
 
 ```rust
-pub struct State {                          // positions 1-8 unchanged
+struct State {
     cumsum_baseline: Spacetime,             //  1
     cumsum_realized: Spacetime,             //  2
     effective_network_time: ChainEpoch,     //  3
@@ -910,58 +913,58 @@ pub struct State {                          // positions 1-8 unchanged
     this_epoch_reward_smoothed: FilterEstimate, // 6
     this_epoch_baseline_power: StoragePower, // 7
     epoch: ChainEpoch,                      //  8
-    total_minted_reward: TokenAmount,       //  9  renamed
-    total_burn_minted: TokenAmount,         // 10  new
-    total_service_minted: TokenAmount,      // 11  new
-    service_accrued: Vec<StreamAccrual>,    // 12  new; ascending id
-    next_transition_epoch: ChainEpoch,      // 13  new; -1 when queue empty
-    swa_timelock_epochs: ChainEpoch,        // 14  new; migration-set only
-    streams_root: Cid,                      // 15  new
+    total_minted_reward: TokenAmount,       //  9 renamed
+    total_burn_minted: TokenAmount,         // 10 new
+    total_explicit_minted: TokenAmount,     // 11 new
+    accrued: Vec<StreamAccrual>,            // 12 new
+    next_transition_epoch: ChainEpoch,      // 13 new; -1 when queue empty
+    swa_timelock_epochs: ChainEpoch,        // 14 new; migration-set only
+    streams_root: Cid,                      // 15 new
 }
 
-pub struct StreamAccrual { id: u64, amount: TokenAmount }
+struct StreamAccrual { id: u64, amount: TokenAmount }
 
 // The block streams_root links to:
-pub struct StreamsState {
-    streams: Vec<Stream>,                   // ascending id
-    tombstones: Vec<Tombstone>,             // ascending id
+struct StreamsState {
+    streams: Vec<Stream>,
+    tombstones: Vec<Tombstone>,
     pending_writes: Vec<PendingWrite>,      // effective epoch, then queue position
 }
 
-pub struct Stream {
+struct Stream {
     id: u64,
     weight: WeightRecord,
-    distribution: Option<ExplicitDistribution>, // None = IMPLICIT
+    distribution: Option<ExplicitDistribution>,
 }
 
-pub struct WeightRecord {
-    v_start: u64,                           // fixed point, DENOM = 10^18
-    slope: i64,                             // fixed point, per epoch
+struct WeightRecord {
+    v_start: u64,
+    slope: i64,
     t_start: ChainEpoch,
     floor: u64,
     cap: u64,
 }
 
-pub struct ExplicitDistribution {
+struct ExplicitDistribution {
     writer: Address,
-    shares: Vec<RecipientShare>,            // ascending recipient
-    payable: Vec<RecipientAmount>,          // ascending recipient
-    claimed_period: Vec<RecipientAmount>,   // ascending recipient
+    shares: Vec<RecipientShare>,
+    payable: Vec<RecipientAmount>,
+    claimed_period: Vec<RecipientAmount>,
 }
 
-pub struct RecipientShare  { recipient: Address, share: u64 }
-pub struct RecipientAmount { recipient: Address, amount: TokenAmount }
+struct RecipientShare  { recipient: Address, share: u64 }
+struct RecipientAmount { recipient: Address, amount: TokenAmount }
 
-pub struct Tombstone { id: u64, payable: Vec<RecipientAmount> }
+struct Tombstone { id: u64, payable: Vec<RecipientAmount> }
 
-pub struct PendingWrite {
+struct PendingWrite {
     id: Option<u64>,                        // None for schedule-wide ops
     op: PendingWriteOp,
     payload: RawBytes,                      // the op's payload tuple, below
     effective_epoch: ChainEpoch,
 }
 
-pub enum PendingWriteOp {                   // u8
+enum PendingWriteOp { // encoded as the displayed integer
     SetWeightRecords = 0,   // payload: [ [ [id, WeightRecord], .. ] ]
     StepWeightRecords = 1,  // payload as SetWeightRecords; uncancellable
     RegisterStream = 2,     // payload: [ WeightRecord, Option<DistributionInit> ]
@@ -983,27 +986,44 @@ callers do not.
 
 ```
 AwardBlockReward(miner, penalty, gas_reward, win_count):
-    if epoch >= next_transition_epoch: apply due queued writes (Section 2.4.7)
-    BR = this_epoch_reward * win_count / 5      // minted reward, as today
+    fold_dust = apply due queued writes if any (Section 2.4.7)
+    liability =
+        Σ live (accrued - Σ claimed_period + Σ payable)
+        + Σ tombstone payable
+    computed_BR = this_epoch_reward * win_count / 5
+    require balance >= gas_reward + liability + fold_dust
+    BR = min(computed_BR, balance - gas_reward - liability - fold_dust)
+    evaluated = ComputeWeight for every active stream
+    weights_valid = every record satisfies 0 <= floor <= v_start <= cap <= DENOM
+    miner_reward = 0
     paid = 0
-    for each active stream s:                   // in list order
-        portion = floor(ComputeWeight(s.weight_record, epoch) * BR)
-        if s.distribution is IMPLICIT:          // consensus stream
-            miner_reward = portion
-        else:                                   // EXPLICIT: accrue
-            service_accrued[s.id] += portion
-            total_service_minted += portion
-        paid += portion
-    burn = BR - paid                            // exact residual = w0 * BR
-    send(f099, burn); total_burn_minted += burn
+    if not weights_valid or Σ evaluated > DENOM:
+        // Defensive: queue and application validation enforce both conditions.
+        implicit_weight = min(Σ evaluated weights of IMPLICIT streams, DENOM)
+        miner_reward = floor(implicit_weight * BR / DENOM)
+        paid = miner_reward                       // Section 2.4.8
+    else:
+        for each active stream s:                 // in list order
+            portion = floor(evaluated[s] * BR / DENOM)
+            if s.distribution is IMPLICIT:
+                miner_reward += portion
+            else:
+                accrued[s.id] += portion
+                total_explicit_minted += portion
+            paid += portion
+    burn = BR - paid
+    send(f099, burn + fold_dust); total_burn_minted += burn
     total_minted_reward += BR
     pay miner_reward + gas_reward to the winning miner, penalties as today
 ```
 
-The burn as exact residual is the authoritative rounding rule: it
-makes conservation exact to the atto, where flooring each weight
-independently would not. Gas rewards remain wholly with the winning
-miner. Nothing on this path can fail: the only send is to f099.
+`liability` is computed after due writes apply. Rounding dust produced
+by those writes is no longer owed to recipients but has not yet been
+burned, so `fold_dust` is excluded from `BR` separately and sent to
+f099 with the residual burn.
+Burning the exact residual conserves `BR` atto-exactly despite
+per-stream floors. Gas rewards and existing miner-send failure handling
+are unchanged; the allocation path calls no FEVM contract or recipient.
 
 ##### 2.4.4 SetShares and the period fold
 
@@ -1024,22 +1044,22 @@ SetShares(id, new_map):     // designated writer only; never queued
     require caller == the stream's designated writer
     require Σ new_map shares == DENOM, every share positive
     resolve each recipient to an ID address, rejecting on failure
-    pool = service_accrued[id]
+    pool = accrued[id]
     for each (wallet, share) in the OLD map:
         earned = floor(share * pool)
         payable[wallet] += earned - claimed_period[wallet]
     residue = pool - Σ earned               // rounding dust only
     send(f099, residue)                     // burned; neither counter moves
-    service_accrued[id] = 0; clear claimed_period
+    accrued[id] = 0; clear claimed_period
     install new_map
 ```
 
 A wallet dropped from the new map keeps its payable balance until it
 claims. The residue is rounding dust only, because shares sum to
 exactly one, and it burns without touching either counter:
-`total_service_minted` already counted it at accrual, so the
-decomposition attributes dust to the service stream and the derived
-miner residual stays exact; f099's receipts exceed `total_burn_minted`
+`total_explicit_minted` already counted it at accrual, so the
+decomposition attributes dust to explicit-stream issuance and the
+derived miner residual stays exact; f099's receipts exceed `total_burn_minted`
 by cumulative dust. A recipient that does not resolve to an ID address
 rejects the whole call: a backstop against typos and stranded funds,
 with the SRA validating recipients at registration.
@@ -1048,11 +1068,12 @@ with the SRA validating recipients at registration.
 
 `Claim(id, wallets[]) -> amounts[]` is permissionless and batched. Each
 wallet's entitlement is its live portion of the current period,
-`floor(share * service_accrued[id])` minus what it has already claimed
+`floor(share * accrued[id])` minus what it has already claimed
 this period, plus its payable balance from closed periods; for a
 tombstoned id, the payable balance alone. f02 records the claim
 (bumping `claimed_period`, deleting the payable row), sends the wallet
-its entitlement, and emits an event. Zero-entitlement entries (unknown
+its entitlement, and emits `claim-payout` (Section 2.4.9).
+Zero-entitlement entries (unknown
 wallets, duplicates within a batch) transfer nothing and return 0 at
 their position, and an unknown id, including a tombstone that has
 drained and deleted, returns all zeros the same way; an all-zero
@@ -1107,10 +1128,8 @@ validated, applied, and canceled as a whole. Per-stream operations
 `StepWeightRecords`) key by op alone, the whole batch one entry.
 Queueing into an occupied slot is rejected, so revising a pending
 write is cancel plus requeue, restarting the timelock; no path changes
-a pending payload while keeping its effective epoch. Two events
-bracket an entry's life: queued fires at admission, carrying the op,
-payload and effective epoch, so a watcher can evaluate the objection
-from the event alone; applied fires at application.
+a pending payload while keeping its effective epoch. Actor events make
+each entry's admission and disposition observable (Section 2.4.9).
 
 Cancellability is a static per-operation rule: `CancelPending(id, op)`
 deletes any pending slot except a `StepWeightRecords` slot, the gate
@@ -1118,7 +1137,7 @@ write (Section 3.1.1), so a compromised Safe cannot suppress a gate
 step; the id is null for schedule-wide operations, and a mismatched
 id/op pair is rejected.
 Canceling an empty slot is a benign no-op, since both Safes may relay
-the same objection; the cancellation event fires only on removal.
+the same objection; it emits no event.
 Cancellation does not re-validate the remaining queue: a cancel can
 strand a pending write that depended on the canceled entry, which is
 handled at application (Section 2.4.8).
@@ -1176,6 +1195,24 @@ are public during the objection window so anyone can recompute the
 breakpoints, but f02's queue-time check is authoritative for
 admission.
 
+Otherwise structurally well-formed persisted state may contain invalid
+weight records or a schedule whose evaluated weights exceed `DENOM`
+only after a faulty migration, implementation defect, or state
+corruption. Neither case halts block production or settlement. Claims,
+cancellation, and `SetShares` remain available; due writes apply only
+when their result passes full validation. New writes are rejected except a
+timelocked `SetWeightRecords` batch whose projected application restores
+valid records and a valid future schedule without stranding an admitted
+write.
+
+For either weight failure, `AwardBlockReward` caps the sum of evaluated
+`IMPLICIT` weights at `DENOM`, pays that bounded allocation, accrues no
+`EXPLICIT` allocation, and burns the exact remainder. This defensive
+branch cannot over-issue or construct a negative burn.
+`total_minted_reward` and `total_burn_minted` increase by `BR` and the
+remainder; `total_explicit_minted` is unchanged. Undecodable state,
+malformed non-weight state, and inconsistent accounting remain illegal.
+
 ##### 2.4.9 Methods and bounds
 
 All new methods are FRC-0042 exported, since their callers are
@@ -1187,7 +1224,7 @@ contracts. Existing methods keep their numbers and signatures.
 | `StepWeightRecords(records)` | SWA (gate path) | queued; not cancellable |
 | `RegisterStream(id, weight_record, distribution, activation_epoch)` | SWA | queued |
 | `RemoveStream(id)` | SWA | queued |
-| `SetDistribution(id, distribution)` | SWA | queued |
+| `SetDistribution(id, writer)` | SWA | queued |
 | `CancelPending(id, op)` | SWA | immediate |
 | `SetShares(id, map)` | the stream's designated writer | immediate |
 | `Claim(id, wallets[])` | anyone | immediate |
@@ -1205,53 +1242,80 @@ exceed `MAX_STREAMS`, the recipient count within `MAX_RECIPIENTS`,
 distribution is one of the two supported forms; the stream pays
 nothing until its `activation_epoch`.
 
-Parameter and return tuples, under the encoding rules of Section 2.4.2
-and reusing its component types. Registration supplies only the
-caller-suppliable subset of a distribution, `DistributionInit`; f02
-constructs the full `ExplicitDistribution` with empty accounting
-tables at application, so an invalid registration state is
-unrepresentable. `CancelPending` names a slot exactly as the queue
-keys it: a mismatched id/op pair is rejected, not ignored. `Claim`
-resolves each supplied wallet to ID form before matching; an
-unresolvable wallet is a zero-entitlement entry. Share maps are
-validated as in `SetShares` wherever they appear. All write methods
-return nothing.
+Parameter and return values are tuples under Section 2.4.2. Registration
+accepts `DistributionInit`; f02 constructs empty accounting tables when
+the write applies. Share maps are validated wherever supplied. All
+write methods return nothing.
 
 ```rust
-pub struct DistributionInit {
+struct DistributionInit {
     writer: Address,
-    shares: Vec<RecipientShare>,     // ascending recipient, unique
+    shares: Vec<RecipientShare>,
 }
 
-SetWeightRecordsParams  { updates: Vec<WeightRecordUpdate> }
-                        // WeightRecordUpdate { id: u64, weight: WeightRecord }
-StepWeightRecordsParams // identical to SetWeightRecordsParams
-RegisterStreamParams    { id: u64, weight: WeightRecord,
-                          distribution: Option<DistributionInit>,  // None = IMPLICIT
-                          activation_epoch: ChainEpoch }
-RemoveStreamParams      { id: u64 }
-SetDistributionParams   { id: u64, writer: Address }
-SetSharesParams         { id: u64, shares: Vec<RecipientShare> }
-CancelPendingParams     { id: Option<u64>,                // None for schedule-wide ops
-                          op: PendingWriteOp }
-ClaimParams             { id: u64, wallets: Vec<Address> }
-ClaimReturn             { amounts: Vec<TokenAmount> }     // positional with wallets
+struct WeightRecordUpdate { id: u64, weight: WeightRecord }
+struct SetWeightRecordsParams { updates: Vec<WeightRecordUpdate> }
+type StepWeightRecordsParams = SetWeightRecordsParams;
+
+struct RegisterStreamParams {
+    id: u64,
+    weight: WeightRecord,
+    distribution: Option<DistributionInit>,
+    activation_epoch: ChainEpoch,
+}
+
+struct RemoveStreamParams { id: u64 }
+struct SetDistributionParams { id: u64, writer: Address }
+struct SetSharesParams { id: u64, shares: Vec<RecipientShare> }
+struct CancelPendingParams { id: Option<u64>, op: PendingWriteOp }
+struct ClaimParams { id: u64, wallets: Vec<Address> }
+struct ClaimReturn { amounts: Vec<TokenAmount> }
 ```
 
-**`MAX_STREAMS = 8`, `MAX_RECIPIENTS = 64`.** `MAX_STREAMS` counts every
-registered stream, the consensus stream included; recipients are
-where growth lands, so `MAX_RECIPIENTS` carries the headroom. The caps
-are deliberately small: every structure they bound lives in state the
-award path reads every block, so they are consensus-path work bounds,
-not product limits. `MAX_RECIPIENTS` caps the share map, not the
-history tables, which self-drain: payable fills at a fold and drains
-as recipients claim, `claimed_period` resets each period, so in normal
-operation the history sits near empty and exists for the edge cases
-(dropped wallets, an absent writer, removed streams). Raising either
-cap requires a future FIP and network upgrade that also reshapes the
-affected structures for the new scale. Tombstones need no cap: growth
-is gated on `RemoveStream`, a governance-cadence operation, and any
-payable row is flushable by anyone via the permissionless `Claim`.
+`CancelPending` must match the queue's `(id, op)` key; `Claim` resolves
+wallets to ID form and returns zero for an unresolvable wallet.
+
+**Actor events.** Values use DAG-CBOR codec `0x51`. `$type`, `op`,
+`stream-id`, and `recipient` are indexed by key and value; other fields
+are indexed by key only.
+
+| `$type` | Emission | Additional fields |
+|---|---|---|
+| `write-queued` | pending write admitted | `op`, `effective-epoch`, optional `stream-id`, captured `payload` bytes |
+| `write-applied` | due write committed | `op`, scheduled `effective-epoch`, optional `stream-id` |
+| `write-cancelled` | pending write removed | `op`, scheduled `effective-epoch`, optional `stream-id` |
+| `write-dropped` | cancellation-stranded write discarded | `op`, scheduled `effective-epoch`, optional `stream-id` |
+| `claim-payout` | non-zero claim transfer committed | `stream-id`, recipient Actor ID, chain-bigint `amount` |
+
+`write-queued` is the proposal publication record, so it carries the
+captured payload needed to evaluate the write during its objection
+window. The three terminal write events identify that immutable
+proposal by queue slot (`op`, optional `stream-id`) and scheduled
+`effective-epoch` without repeating its payload; chain order
+disambiguates cancellation and requeue of the same slot.
+
+Schedule-wide events omit `stream-id`. Applied events precede dropped
+events, both in queue order, followed by a newly queued or cancelled
+event; claim events follow request order. Reverted calls emit no event,
+and event construction or emission failure aborts the transaction.
+
+`write-applied` and `write-dropped` emitted during implicit
+`AwardBlockReward` calls are not chain-visible today, as with
+miner-actor events from implicit paths. Activating FIP-0107 would make
+their receipts and event roots chain-reachable; until then these
+outcomes require replay or state comparison.
+
+**`MAX_STREAMS = 8`, `MAX_RECIPIENTS = 64`,
+`MAX_PENDING_WRITES = 3 * MAX_STREAMS + 2 = 26`.** `MAX_STREAMS`
+includes Consensus. `MAX_RECIPIENTS` bounds each share map. The queue
+bound is its exact slot space: three per-stream operations and two
+schedule-wide operations.
+
+These bounds limit configured award and mutation work, not historical
+accounting rows. Payable rows and tombstones have no aggregate bound,
+but anyone can drain them through `Claim`. Raising a limit requires a
+future FIP and network upgrade that also reshapes the affected
+structures for the new scale.
 
 ##### 2.4.10 Migration
 
@@ -1290,20 +1354,20 @@ receives issuance, not how much, so the total keeps its slot:
     implementation changes its circulating-supply logic.
 
   - **`total_burn_minted`** (the w0 residual) and
-    **`total_service_minted`** (gross service accrual) are stored
+    **`total_explicit_minted`** (gross explicit-stream accrual) are stored
     counters, otherwise hard to recover independently: each needs the
-    full weight and reward history. Fold dust burns from the service
-    side and is attributed there (Section 2.4.4), keeping the residual
+    full weight and reward history. Fold dust is attributed to
+    explicit-stream issuance, not w0 (Section 2.4.4), keeping the residual
     exact.
 
   - What miners have received is the derived residual
-    `M = total_minted_reward − total_burn_minted − total_service_minted`;
+    `M = total_minted_reward − total_burn_minted − total_explicit_minted`;
     it is not stored. Tools that treated
     position 9 as miner income must move to this residual (see
     Backwards Compatibility).
 
   - Minting is counted at accrual: each award adds
-    `BR = miner + service + burn` exactly and bumps the three totals by
+    `BR = miner + explicit + burn` exactly and bumps the three totals by
     their parts, so the decomposition holds by construction. The burn
     is minted and sent to f099: counted in `FilMined`, captured by
     `FilBurnt`, net zero on circulating supply.
@@ -1311,7 +1375,7 @@ receives issuance, not how much, so the total keeps its slot:
 The claim state carries no supply duty: the counters account for FIL
 ever minted, while the claim state accounts only for the slice still
 inside f02. At every epoch f02's balance covers
-`Σ (service_accrued − Σ claimed_period + Σ payable)` over streams and
+`Σ (accrued − Σ claimed_period + Σ payable)` over streams and
 tombstones. Its terms are period-scoped but the invariant is not; the
 fold just moves value between terms.
 
@@ -1643,6 +1707,12 @@ divided among Orchestrators. In particular,
         frozen at the close of the posting period are excluded:
         omitted from the submitted map, with their FPV not entering
         `AggregatedFPV(Q)`.
+        If eligible FPV for that quarter sums to zero, `SubmitShares` is
+        a benign no-op: `SplitRule` is not evaluated and the existing
+        share map stands. With nobody contributing eligible volume,
+        changing the map is a governance act through freeze, removal,
+        re-pointing, or a weight change (Sections 3.1 and 4.2), never an
+        automatic one.
         Like the SWA’s crank, it can submit only the value it computes,
         and it is not held (Section 4.3).
 
@@ -2027,7 +2097,7 @@ state consistently and preserve circulating-supply accounting.
 Position 9 of the f02 state keeps the grand minted total under a new
 name, so `FilMined` readers are unchanged; anything that treated it as
 miner-only income must derive the miner total as the stored total
-minus the burn and service counters (Section 2.5).
+minus the burn and explicit-stream counters (Section 2.5).
 Explorers and profitability tools that currently treat the full block
 reward as miner income must apply the consensus weight w1 after
 activation. The SWA and SRA contracts must be deployed and their
@@ -2056,19 +2126,26 @@ The implementation test suite MUST cover at least:
 
   - `ComputeWeight` clamping and rounding, the Q1 w1/w2 bootstrap,
     gate pass and failure transitions, the sequential gate latch
-    (quarter ordering, late cranks, and the atomic revert on an f02
-    rejection, Section 3.1.1), the exact-residual burn, and
-    atto-exact conservation of the full block reward while gas rewards
-    and penalties retain their existing treatment;
+    (quarter ordering, late cranks, and atomic revert on f02 rejection),
+    exact-residual burn, atto-exact reward conservation, unchanged gas
+    and penalty treatment, bounded miner-only fallback for malformed
+    weight records or a schedule whose evaluated weights exceed `DENOM`,
+    and timelocked repair of both;
 
-  - authorization, queuing, slot occupancy, projected-schedule
-    validation, application ordering and cancellation of f02 writes,
-    including the refusal to cancel `StepWeightRecords`;
+  - authorization, slot occupancy, projected-schedule validation, queue
+    ordering, activation and exact-slot cancellation, dependent-write
+    dropping, refusal to cancel `StepWeightRecords`, and all five actor
+    event types;
 
-  - share-map validation, the period fold on `SetShares`, accrual and
-    `Claim` (mid-period, dropped-wallet, tombstone and zero-entitlement
-    cases), stream registration, distribution changes and stream
-    removal;
+  - stream registration and distribution changes, share-map validation
+    and immediate binding, period folds and dust, positional claims and
+    send rollback, full explicit-stream decommissioning, removal around
+    pending gate writes, repeated awards with no explicit stream,
+    consensus-stream removal, and stream-ID reuse only after its
+    tombstone drains;
+
+  - monotone issuance counters, the exact derived explicit-stream reserve,
+    low-balance protection of accrued funds, and unchanged `FilMined`;
 
   - FPV calculation for admitted stablecoin and FIL settlements,
     pricing-print boundaries, reporting and correction windows,
@@ -2216,21 +2293,19 @@ changes to leader election or finality.
     volume stays uncounted: the gate can only under-count, never
     over-count.
 
-  - **Consensus-path safety of the split.** The per-block split runs
-    in f02 from its own state with no external call, so a contract
-    that is down, buggy, or compromised cannot stall block-reward
-    distribution. Three L1 properties carry the safety and should be
-    stated as invariants: total payout can never exceed the block
-    reward, because every schedule write is validated at queue time
-    against the projected schedule and the burn is the exact residual
-    (Section 2.4.8), so the per-block `Σ ≤ 1` check is an assertion
-    rather than a recoverable failure; `MAX_STREAMS` and `MAX_RECIPIENTS`
-    must bound the per-block work so the split cannot become a
-    consensus-path denial-of-service; and the award path performs no
-    send that can fail, its only send being the burn to f099, with
-    recipients paid solely through the explicit `Claim` method, where a
-    failure reverts the claim and leaves the entitlement intact
-    (Section 2.4.5).
+  - **Consensus-path safety of the split.** The per-block split makes no
+    FEVM or recipient call. Queue admission rejects a projected epoch
+    with `Σ w_i > 1`, and cancellation-stranded writes drop before
+    allocation. An otherwise well-formed persisted violation pays only
+    the implicit allocation, burns the remainder, and permits a
+    validating timelocked repair. Otherwise each allocation is floored
+    and the exact residual burns, conserving `BR` atto-exactly.
+    `MAX_STREAMS` bounds allocation work and `MAX_RECIPIENTS` bounds each
+    share map. The low-balance cap derives outstanding liability from
+    the stream block already decoded for weights; historical payable and
+    tombstone rows have no aggregate protocol bound and are drained
+    through permissionless claims. Recipient sends occur only in
+    `Claim`, where failure reverts the call without stalling an award.
 
   - **Compromised Orchestrator wallet.** An Orchestrator address holds
     no authority over weights or other participants' shares;

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -89,7 +89,9 @@ to a service-oriented economy. Two main changes:
     issuance, the built-in L1 Reward Actor (f02) divides the full block
     reward BR by weight:
 
-      - `w2 * BR` to the *Service Orchestrator wallets* (service stream),
+      - `w2 * BR` to the *Service Orchestrator wallets* (service
+        stream), accrued in f02 and withdrawn via a permissionless
+        `Claim` (Section 2.4),
         
       - `w1 * BR` to the winning miner (consensus stream),
 
@@ -111,8 +113,9 @@ constraint that the sum of all non-burn weights is at most 1. At
 the time this FIP ships, the weight schedules for the existing
 streams are as follows. The weight w1 ramps down from 95% to 50% over
 roughly 9 quarters. During the first quarter (the bootstrap phase),
-`w2 = 1 − w1` so nothing is burned and w2 reaches 10% by the end of the
-quarter. From Q2 onward, w2 steps up by 5 percentage points per quarter,
+`w2 = 1 − w1` so no w0 share is scheduled and w2 reaches 10% by the
+end of the quarter. From Q2 onward, w2 steps up by 5 percentage
+points per quarter,
 capped at the ceiling `1 − w1`, and only when on-chain aggregated Filecoin
 Pay Volume (FPV) clears its target for the quarter. The SWA is governed
 by **SWA Governance** (see Section 4).
@@ -432,10 +435,11 @@ Orchestrators within the service stream** ("shares") (see Figure 1).
     a new stream needs no new code to be paid. Adding a future stream
     is an on-chain list write rather than a network upgrade. By
     governance convention it still requires an accepted FIP. We begin
-    with three streams: Consensus, Service and Burn. At each
+    with two stream records, Consensus and Service; Burn is the
+    residual, computed each block rather than stored. At each
     block-reward issuance, f02 reads its own state, pays the winning
-    miner and each Orchestrator wallet its portion, and burns the
-    remainder.
+    miner, accrues the service portion for its wallets to withdraw
+    via `Claim` (Section 2.4), and burns the remainder.
 
 2.  **Stream Weights Actor (SWA): the split AMONG streams.** It
     registers or removes streams and sets each stream's *Weight record*.
@@ -559,16 +563,19 @@ Once per quarter, off the per-epoch path:
     produce diverging numbers.
 
 4.  **Weights and shares updates.** `QuarterlyGateCheck` compares the
-    USD-denominated `AggregatedFPV(Q)` against `ComputeTarget(w2)`, the
-    fixed USD target (Section 3.1.1). If it passes, the SWA calls
-    `SetWeightRecords` to raise w2. `SplitRule` sets each Orchestrator's
+    USD-denominated `AggregatedFPV(Q)` against the quarter's fixed USD
+    target (Section 3.1.1). If it passes, the SWA raises w2 via
+    `StepWeightRecords` (Section 2.4.9), the uncancellable gate write.
+    `SplitRule` sets each Orchestrator's
     share in proportion to its USD-denominated `FPV_i(Q)`, using the
     same converted values as the gate (one set of prints serves both
     the gate comparison and the split), and the SRA writes the
-    wallet-to-share map into f02 via `SetShares`. Orchestrators frozen at
+    wallet-to-share map into f02 via `SetShares`, which binds
+    immediately (Section 2.4.4). Orchestrators frozen at
     the close of the posting period are excluded from both
-    computations: their share is zero and their FPV does not enter
-    `AggregatedFPV(Q)` (Section 3.2).
+    computations: they are omitted from the submitted share map
+    (shares in the map must be positive, Section 2.4.4) and their FPV
+    does not enter `AggregatedFPV(Q)` (Section 3.2).
 
 #### 2.3 FPV definitions
 
@@ -705,193 +712,619 @@ Once per quarter, off the per-epoch path:
 
 #### 2.4 L1 actor changes (f02)
 
-Add the following structures and methods:
+f02 becomes the stream engine. Every block it evaluates the weight
+records held in its own state, pays the winning miner the consensus
+portion, accrues the service stream's portion, and burns the exact
+residual; SWA writes queue inside f02 under a timelock and apply when
+due. Settlement of `EXPLICIT` streams is pull, not push: f02 accrues
+each stream's portion per block and recipients withdraw it with an
+explicit message, the permissionless `Claim` method. Value leaves f02 in
+exactly three ways: the consensus payment inside `AwardBlockReward`, the
+burn send to f099, and `Claim`.
+
+Pull settlement is chosen over per-epoch push for three reasons.
+Churn: f02's state is rewritten every block, and push puts per-recipient
+state writes on that path forever, where accrual is one integer
+increment in a block already being rewritten. Observability: per-stream
+accrual and per-wallet entitlements are a state read at any epoch, and
+every payout is an ordinary message with the transfer in its receipt,
+where push buries transfers in implicit executions that need a replay
+to see. Failure modes: the consensus path performs no send that can
+fail, and a failed `Claim` reverts and leaves the entitlement in place,
+so no failed-send rule is needed. The cost is that someone must send a
+message and pay gas to be paid; `Claim` is permissionless and funds can
+only go to the wallets the share map names, so a keeper can settle on
+a recipient's behalf.
+
+##### 2.4.1 Streams, weights and distributions
 
 1)  **Stream**: a named, weighted portion of the block reward:
     Stream = { id, `WeightRecord`, Distribution }.
 
-    1.  **Distribution**: the stream's recipients and how the stream
-        is split among them. There are two possible values: `IMPLICIT`
-        (nothing stored; f02 resolves the recipient from protocol
-        state). For example, the consensus stream is `IMPLICIT`, its
-        recipient being the block winner chosen by leader election
-        each epoch. Or `EXPLICIT` (a stored wallet-to-share map, updated
-        only by the stream's designated **writer** via `SetShares`; for
-        example, for the service stream, writer = SRA). A future stream
-        paying one fixed wallet needs no separate form: it is the
-        one-entry `EXPLICIT` case.
+    1.  **id**: assigned by the SWA at `RegisterStream` and opaque to
+        f02, which enforces uniqueness across the live streams, the
+        tombstones (Section 2.4.6) and any pending `RegisterStream`
+        write, checked at queue time. The SWA keeps the id-to-purpose
+        mapping. The migration pins consensus = 1 and service = 2,
+        matching the w1/w2 subscripts; 0 is reserved (could be used
+        to signify the burn stream).
+
+    2.  **Weight record**: the bundle of scheduler parameters for one
+        stream weight, { `v_start`, slope, `t_start`, floor, cap }.
+        Written only by the SWA (see the methods below).
+
+        1.  **`v_start`**: the weight at `t_start`, within the clamp
+            band. A ramp that begins moving later is expressed with a
+            future `t_start` (evaluation before `t_start` clamps at
+            the band edge), not with an out-of-band anchor.
+
+        2.  **slope**: the weight's change per epoch over this segment;
+            negative for a declining ramp (w1), positive for a rising
+            ramp (w2 during the Q1 bootstrap), and 0 for a weight held
+            flat over the segment (w2 from Q2 onward, between gate
+            steps)
+
+        3.  **`t_start`**: the epoch the segment starts from
+
+        4.  **floor / cap**: clamp bounds
+
+    3.  **Distribution**: the stream's recipients and how the stream
+        is split among them. There are two possible values. `IMPLICIT`:
+        nothing stored; f02 resolves the recipient from protocol
+        state. The consensus stream is `IMPLICIT`, its recipient being
+        the block winner chosen by leader election each epoch.
+        `EXPLICIT`: the stream's stored recipient state, updated only by
+        the stream's designated **writer** (the SRA for the service
+        stream; never a payee). An `EXPLICIT` distribution holds the
+        writer's address and three wallet-keyed tables:
+
+        1.  **shares**: the current wallet-to-share map, at most
+            `MAX_RECIPIENTS` entries, written via `SetShares`;
+
+        2.  **payable**: per-wallet amounts carried over from closed
+            periods, not yet claimed;
+
+        3.  **`claimed_period`**: per-wallet amounts already claimed
+            against the current period's accrual.
+
+        A future stream paying one fixed wallet needs no separate
+        form: it is the one-entry `EXPLICIT` case.
 
 Weight and Distribution are orthogonal: a stream picks each
-independently, so registering a new stream means giving it a Weight and
-a Distribution and, when `EXPLICIT`, naming its single writer. f02 is not
-involved in calculating the stream's share distribution. The writer
-contract computes the shares off the per-epoch path and pushes the map
-through `SetShares`; f02 applies that map when dividing the stream. f02
-stores only the writer's address and the current map, never the rules.
-For the service stream, `SplitRule` over FPV volumes lives inside the SRA
-contract and governance process, leaving f02 agnostic.
+independently, so registering a new stream means giving it a Weight
+and a Distribution and, when `EXPLICIT`, naming its single writer. f02
+is not involved in calculating the stream's share distribution. The
+writer contract computes the shares off the per-epoch path and pushes
+the map through `SetShares`; f02 applies that map when dividing the
+stream. f02 stores only the writer's address and the current map,
+never the rules. For the service stream, `SplitRule` over FPV volumes
+lives inside the SRA contract and governance process, leaving f02
+agnostic.
 
-2)  **Share**: one entry in an `EXPLICIT` stream's wallet-to-share map;
-    for the service stream, the SRA writes the Orchestrator share map.
+2)  **Stream list**: the ordered list of Stream records f02 holds in
+    state. Stream membership changes only through the SWA
+    (`RegisterStream` / `RemoveStream`); within a stream, the `EXPLICIT`
+    tables change through its designated writer (`SetShares`) and
+    through `Claim`.
 
-3)  **Stream list**: the ordered list of Stream records f02 holds in
-    state. Modified only by the SWA via `RegisterStream` / `RemoveStream`
-    (see later). *Implemented as* an external list
-    (`pub stream_registry: Cid` - since the f02 state churns and a
-    registry list will change infrequently, we store it externally to
-    save storage).
-
-4)  **Weight record**: the bundle of scheduler parameters for one
-    stream weight, { `v_start`, slope, `t_start`, floor, cap }. Written
-    only by the SWA via `SetWeightRecords` (see later).
-
-    1.  **`v_start`**: the weight's starting value
-
-    2.  **slope**: the weight's change per epoch over this segment;
-        negative for a declining ramp (w1), positive for a rising
-        ramp (w2 during the Q1 bootstrap), and 0 for a weight held
-        flat over the segment (w2 from Q2 onward, between gate
-        steps)
-
-    3.  **`t_start`**: the epoch the segment starts from
-
-    4.  **floor / cap**: clamp bounds
-
-Logic: the SWA adds/removes *streams* and writes *Weight Records*; f02
-evaluates them into *weights*; weight: the scalar in [0,1] a stream
-receives at epoch e. Evaluated each epoch by f02 via `ComputeWeight` (see
-later).
-
-5)  **`SWA_TIMELOCK`**; this is the L1 enforcement of the objection
-    window in Section 4, set equal to that window (7 days), and it
-    applies to every write the SWA makes to f02. That is, f02 queues
-    each SWA write (`SetWeightRecords`, `RegisterStream`, `RemoveStream`)
-    with an `effective_epoch` and applies it only after `SWA_TIMELOCK`
-    elapses, so the delay binds even if the SWA or the off-chain
-    objection process is bypassed.
-
-6)  **New method `SetWeightRecords`.** Callable only by the SWA. Sets the
-    Weight record (`v_start`, slope, `t_start`, floor, cap) for w1, w2, and
-    any future stream. Validates the minimal conditions before applying:
-    `Σ_{i>=1} w_i ≤ 1` (so the burn residual w0 is ≥ 0). f02 queues the
-    SWA message and holds it for `SWA_TIMELOCK` epochs.
-
-7)  A companion method **`SetShares(id, map)`** (callable only by stream
-    id’s designated writer, the SRA for the service stream) writes the
-    stream’s wallet-to-share map (its `EXPLICIT` distribution) that f02
-    uses to pay wallets directly; it is validated so the shares sum to
-    one.
-
-8)  **New method `GetState`.** Read-only. Returns the stream list (the
-    per-stream Weight records and their current evaluated weights).
-
-9)  **`RegisterStream`**(id, `weight_record`, distribution,
-    `activation_epoch`) adds a stream by writing its Stream record into
-    the list, validating that the stream count is below `MAX_STREAMS`,
-    the resulting recipient count stays within `MAX_RECIPIENTS`,
-    `activation_epoch` ≥ `current_epoch` + `SWA_TIMELOCK`, and the
-    distribution is one of the two supported forms (`IMPLICIT` or
-    `EXPLICIT`); the stream pays nothing until its `activation_epoch`.
-
-10) **`RemoveStream`**(id) removes a stream, whose weight then reverts
-    to the burn residual until reallocated. `SetShares` is generalized
-    to `SetShares(id, map)` and stays callable only by that stream’s
-    designated writer.
-
-11) **`SetDistribution`**(id, distribution) re-points a stream’s
-    Distribution, in particular the designated writer of an `EXPLICIT`
-    stream. Callable only by the SWA and queued under `SWA_TIMELOCK`
-    like every SWA write. The stream's current wallet-to-share map
-    remains in force until the new writer overwrites it via `SetShares`,
-    so payments continue across the transition. Converting a stream to
-    `IMPLICIT` is not permitted.
-
-12) **`CancelPending`**(id) discards a queued discretionary SWA write
-    during its `SWA_TIMELOCK`; the current state remains in force. Each
-    queued write carries an origin tag set at submission: writes
-    relayed by the SWA’s `ProposeWrite` (Section 3.1) are discretionary
-    and cancellable, while writes originated by `QuarterlyGateCheck` are
-    mechanism writes, which `CancelPending` rejects, so a compromised
-    Safe cannot suppress a gate step-up (Section 4.3). Callable only
-    by the SWA, which exposes the corresponding cancel entry point
-    callable by either SWA Safe alone (Section 4.3).
-
-13) **`ComputeWeight`.** The L1 actor f02 evaluates each weight every
-    epoch with one function, `ComputeWeight`, which implements a clamped
-    linear segment. Because each weight is a deterministic function of
-    the epoch, f02 keeps advancing even if the SWA is offline.
+3)  **`ComputeWeight`**: f02 evaluates each weight with one function
+    implementing a clamped linear segment. Because each weight is a
+    deterministic function of the epoch, f02 keeps advancing with no
+    SWA input: a deadlocked, compromised or abandoned SWA stalls
+    future schedule changes, never the split itself.
 
 ```
 WeightRecord = { v_start, slope, t_start, floor, cap }   // one record per stream
 
-func clamp(x, lo, hi) -> Rational:
+func clamp(x, lo, hi) -> Fraction:
     return max(lo, min(hi, x))
 
-func ComputeWeight(w WeightRecord, e Epoch) -> Rational:
+func ComputeWeight(w WeightRecord, e Epoch) -> Fraction:
     return clamp(w.v_start + w.slope * (e - w.t_start), w.floor, w.cap)
 
 // per-epoch weights, all evaluated by the same function:
-w1(e)  = ComputeWeight(W_consensus, e)  // linear: slope < 0, floor = W1_FLOOR, cap = W1_START
-w2(e)  = ComputeWeight(W_service, e)    // Q1: linear bootstrap record mirroring w1's ramp;
-                                        // Q2 onward: constant record stepped by the gate
+w1(e) = ComputeWeight(W_consensus, e)  // linear: slope < 0, floor = W1_FLOOR, cap = W1_START
+w2(e) = ComputeWeight(W_service, e)    // Q1: linear bootstrap record mirroring w1's ramp;
+                                       // Q2 onward: constant record stepped by the gate
 w0(e) = 1 - Σ_{i>=1} ComputeWeight(W_i, e)  // residual over all streams; never stored
 ```
 
-**About the invariant (`Σ w_i ≤ 1`).** f02 requires
-`Σ_{i>=1} ComputeWeight(W_i, e) ≤ 1` at every epoch, so the burn
-residual w0 stays ≥ 0. When two or more weights ramp at the same time
-their lines can sum above 1 mid-segment even when both endpoints are
-in range, so the heavy validation lives off the consensus path: the
-SWA checks the combined envelope over the whole segment before it
-submits (the sum of clamped lines is piecewise linear, so `Σ ≤ 1`
-need only hold at each `t_start`, each clamp crossing
-`e = t_start + (floor − v_start)/slope` and
-`e = t_start + (cap − v_start)/slope` for `slope ≠ 0`, and one point
-past the last of them), and the published FIP exposes the schedule to
-review during the objection window; anyone can recompute the breakpoints
-from the queued records. f02 itself stays minimal: at write time it
-validates only per-record sanity (`0 ≤ floor ≤ cap ≤ 1`) and `Σ ≤ 1` at
-the activation epoch, and each epoch it keeps the cheap check, storing
-the last weight vector that satisfied it. If the evaluated weights ever
-sum above 1, f02 pays that epoch from the stored vector instead: total
-payout never exceeds the block reward, nothing halts, and the weights
-hold at their last valid values until the SWA repairs the schedule
-through the normal timelocked write.
+4)  **Fixed point**: `v_start`, `floor`, `cap`, and shares are fractions,
+    stored as u64 fixed point with `DENOM = 10^18`; `slope` is signed
+    i64 fixed point so a weight can decline. At that scale the
+    percentages in this FIP are exact integers, and "shares sum to one"
+    is the exact integer check `Σ shares == DENOM`. The
+    weight-times-reward multiply promotes to a big integer and divides
+    with floor. Slope quantization over the 9-quarter ramp is ~1e-10 of
+    a percentage point at this scale, and the clamp endpoints are
+    stored exact, so w1 comes to rest at exactly its 50% floor. Token
+    amounts are attoFIL big integers, serialized as f02's existing
+    fields are.
+
+##### 2.4.2 State
+
+f02's state is an 11-field tuple rewritten every block. The rule for
+the changes: values that mutate per block stay inline in the root
+tuple (`TokenAmount` counters and an epoch, both small on the wire);
+everything else lives behind one CID, written only at governance,
+quarterly or claim cadence.
+
+| Field | Change |
+|---|---|
+| `total_minted_reward` (position 9) | Renamed from `total_storage_power_reward`, position kept. Accrues the full block reward, all streams (Section 2.5). |
+| `simple_total`, `baseline_total` (positions 10, 11) | Deleted: retired to the code constants below, as the existing state comment anticipates ("can be moved from state back into a code constant in a subsequent upgrade"). |
+| `total_burn_minted` | New counter: cumulative w0 residual, accrued at award. |
+| `total_service_minted` | New counter: cumulative accrual across all `EXPLICIT` streams. |
+| `service_accrued[id]` | New, one per `EXPLICIT` stream: the current period's gross accrual. |
+| `next_transition_epoch` | New: the earliest effective epoch over the pending writes; recomputed on queue, apply and cancel; -1 (`EPOCH_UNDEFINED`) when the queue is empty. The per-block path compares this one integer and touches `streams_root` only when a write is due. |
+| `swa_timelock_epochs` | New: the SWA timelock in epochs (`SWA_TIMELOCK`), set per network by the migration and never written afterwards. Mainnet: 7 days; test networks may set it shorter. |
+| `streams_root` | New CID: the stream list, the tombstones and the pending-write queue. |
+
+The retired fields become the code constants
+`SIMPLE_TOTAL` = 330,000,000 FIL and
+`BASELINE_TOTAL` = 768,335,872,210,768,889,362,796,814 attoFIL. The
+nominal allocations are 330M and 770M FIL, the simple and baseline
+shares of the storage-mining allocation, and the genesis constants
+in the reward actor still say so; the actors-v2 migration then wrote
+an adjusted `baseline_total` into state to keep minting continuous
+across its baseline-function fix, and it is that adjusted value, not
+the nominal 770M, that has governed mainnet minting since. This FIP
+canonicalizes mainnet's value across all networks rather than
+carrying either field forward, so a network whose stored value
+differs (calibnet) adopts the mainnet constant at the upgrade. Both
+constants are exactly what mainnet f02 state holds at positions 10
+and 11 today: anyone with a node can confirm them by reading the
+reward actor state at any pre-upgrade epoch, and the Test Cases
+section requires the functional check that reward computation is
+unchanged by the substitution.
+
+Encoding rules are per Filecoin standard IPLD format:
+every structure is CBOR tuple-encoded, an array of its fields in the
+order written; maps are never used. `TokenAmount` and other big
+integers are byte strings: one sign byte (00 non-negative, 01
+negative) then the big-endian magnitude, empty for zero. `Address`
+is Filecoin address bytes, always ID form (protocol byte 00 then the
+LEB128 id), normalized at every write. `Option<T>` is CBOR null or `T`.
+Keyed arrays sort ascending by key with unique keys; `pending_writes`
+alone is ordered by effective epoch, equal epochs retaining queue
+position (the apply tiebreak). `Spacetime` is a big integer;
+`FilterEstimate`
+is a pair of big integers, unchanged.
+
+```rust
+pub struct State {                          // positions 1-8 unchanged
+    cumsum_baseline: Spacetime,             //  1
+    cumsum_realized: Spacetime,             //  2
+    effective_network_time: ChainEpoch,     //  3
+    effective_baseline_power: StoragePower, //  4
+    this_epoch_reward: TokenAmount,         //  5
+    this_epoch_reward_smoothed: FilterEstimate, // 6
+    this_epoch_baseline_power: StoragePower, // 7
+    epoch: ChainEpoch,                      //  8
+    total_minted_reward: TokenAmount,       //  9  renamed
+    total_burn_minted: TokenAmount,         // 10  new
+    total_service_minted: TokenAmount,      // 11  new
+    service_accrued: Vec<StreamAccrual>,    // 12  new; ascending id
+    next_transition_epoch: ChainEpoch,      // 13  new; -1 when queue empty
+    swa_timelock_epochs: ChainEpoch,        // 14  new; migration-set only
+    streams_root: Cid,                      // 15  new
+}
+
+pub struct StreamAccrual { id: u64, amount: TokenAmount }
+
+// The block streams_root links to:
+pub struct StreamsState {
+    streams: Vec<Stream>,                   // ascending id
+    tombstones: Vec<Tombstone>,             // ascending id
+    pending_writes: Vec<PendingWrite>,      // effective epoch, then queue position
+}
+
+pub struct Stream {
+    id: u64,
+    weight: WeightRecord,
+    distribution: Option<ExplicitDistribution>, // None = IMPLICIT
+}
+
+pub struct WeightRecord {
+    v_start: u64,                           // fixed point, DENOM = 10^18
+    slope: i64,                             // fixed point, per epoch
+    t_start: ChainEpoch,
+    floor: u64,
+    cap: u64,
+}
+
+pub struct ExplicitDistribution {
+    writer: Address,
+    shares: Vec<RecipientShare>,            // ascending recipient
+    payable: Vec<RecipientAmount>,          // ascending recipient
+    claimed_period: Vec<RecipientAmount>,   // ascending recipient
+}
+
+pub struct RecipientShare  { recipient: Address, share: u64 }
+pub struct RecipientAmount { recipient: Address, amount: TokenAmount }
+
+pub struct Tombstone { id: u64, payable: Vec<RecipientAmount> }
+
+pub struct PendingWrite {
+    id: Option<u64>,                        // None for schedule-wide ops
+    op: PendingWriteOp,
+    payload: RawBytes,                      // the op's payload tuple, below
+    effective_epoch: ChainEpoch,
+}
+
+pub enum PendingWriteOp {                   // u8
+    SetWeightRecords = 0,   // payload: [ [ [id, WeightRecord], .. ] ]
+    StepWeightRecords = 1,  // payload as SetWeightRecords; uncancellable
+    RegisterStream = 2,     // payload: [ WeightRecord, Option<DistributionInit> ]
+    RemoveStream = 3,       // payload: [] (empty tuple)
+    SetDistribution = 4,    // payload: [ Address ]
+}
+```
+
+A pending write is a deferred method call, executed verbatim at
+`effective_epoch` (Section 2.4.7). Each `EXPLICIT` stream owns its own
+recipient tables, so the same wallet may appear in more than one
+stream without collision, and a `Claim` rewrites only its own stream's
+rows.
+
+##### 2.4.3 The award path
+
+Only `AwardBlockReward`'s internals change; its number, signature and
+callers do not.
+
+```
+AwardBlockReward(miner, penalty, gas_reward, win_count):
+    if epoch >= next_transition_epoch: apply due queued writes (Section 2.4.7)
+    BR = this_epoch_reward * win_count / 5      // minted reward, as today
+    paid = 0
+    for each active stream s:                   // in list order
+        portion = floor(ComputeWeight(s.weight_record, epoch) * BR)
+        if s.distribution is IMPLICIT:          // consensus stream
+            miner_reward = portion
+        else:                                   // EXPLICIT: accrue
+            service_accrued[s.id] += portion
+            total_service_minted += portion
+        paid += portion
+    burn = BR - paid                            // exact residual = w0 * BR
+    send(f099, burn); total_burn_minted += burn
+    total_minted_reward += BR
+    pay miner_reward + gas_reward to the winning miner, penalties as today
+```
+
+The burn as exact residual is the authoritative rounding rule: it
+makes conservation exact to the atto, where flooring each weight
+independently would not. Gas rewards remain wholly with the winning
+miner. Nothing on this path can fail: the only send is to f099.
+
+##### 2.4.4 SetShares and the period fold
+
+A **period** in f02 is the interval between two `SetShares` calls on a
+stream: f02 knows nothing of quarters and imposes no cadence, so the
+writer may call `SetShares` at any time. The quarterly rhythm is SRA
+discipline: under this FIP the SRA's only path to `SetShares` is
+`SubmitShares`, once per quarter after the verification window (Section
+3.2), and registry changes (admission, removal, freeze) take payment
+effect at the next such submission. Installing a new map first
+closes the current period under the old one, and that fold is what
+makes immediate binding safe: earnings materialize under the shares
+in force while they accrued, so a share change is strictly
+prospective.
+
+```
+SetShares(id, new_map):     // designated writer only; never queued
+    require caller == the stream's designated writer
+    require Σ new_map shares == DENOM, every share positive
+    resolve each recipient to an ID address, rejecting on failure
+    pool = service_accrued[id]
+    for each (wallet, share) in the OLD map:
+        earned = floor(share * pool)
+        payable[wallet] += earned - claimed_period[wallet]
+    residue = pool - Σ earned               // rounding dust only
+    send(f099, residue)                     // burned; neither counter moves
+    service_accrued[id] = 0; clear claimed_period
+    install new_map
+```
+
+A wallet dropped from the new map keeps its payable balance until it
+claims. The residue is rounding dust only, because shares sum to
+exactly one, and it burns without touching either counter:
+`total_service_minted` already counted it at accrual, so the
+decomposition attributes dust to the service stream and the derived
+miner residual stays exact; f099's receipts exceed `total_burn_minted`
+by cumulative dust. A recipient that does not resolve to an ID address
+rejects the whole call: a backstop against typos and stranded funds,
+with the SRA validating recipients at registration.
+
+##### 2.4.5 Claim
+
+`Claim(id, wallets[]) -> amounts[]` is permissionless and batched. Each
+wallet's entitlement is its live portion of the current period,
+`floor(share * service_accrued[id])` minus what it has already claimed
+this period, plus its payable balance from closed periods; for a
+tombstoned id, the payable balance alone. f02 records the claim
+(bumping `claimed_period`, deleting the payable row), sends the wallet
+its entitlement, and emits an event. Zero-entitlement entries (unknown
+wallets, duplicates within a batch) transfer nothing and return 0 at
+their position, and an unknown id, including a tombstone that has
+drained and deleted, returns all zeros the same way; an all-zero
+batch is a benign no-op, so keepers get idempotent re-runs for free.
+Claims work mid-period, and funds can only go to the wallets the
+share map (or tombstone) names, so a third party settling on a
+recipient's behalf changes who pays the gas, not where the money
+goes.
+
+##### 2.4.6 Stream lifecycle: removal, re-pointing, tombstones
+
+`RemoveStream` and `SetDistribution` first settle the current period
+exactly as `SetShares` does: each recipient's earned-but-unclaimed
+amount is banked as payable under the outgoing shares. On removal
+those balances move to a **tombstone** for the stream's id, so claims
+stay addressable after removal: `Claim` pays from the tombstone, rows
+delete as they are claimed, and a drained tombstone deletes entirely,
+so nothing about a removed stream is permanent. A removed stream's
+weight reverts to the burn residual until reallocated. Id non-reuse
+after the tombstone is gone is SWA discipline (f02 still rejects any
+duplicate it can see); violating it risks event-history ambiguity
+only, a deleted tombstone having zero payable by definition.
+`SetDistribution` changes only the writer: the share map stands until
+the new writer replaces it via `SetShares`, so payments continue across
+the transition, and converting a stream to `IMPLICIT` is not permitted.
+
+##### 2.4.7 The pending-write queue and the timelock
+
+Every SWA write queues in f02 and applies only after the timelock:
+`SWA_TIMELOCK`, stored per network as `swa_timelock_epochs` (7 days on
+mainnet). This is the L1 enforcement of the Section 4 objection window
+and binds even if the SWA itself is compromised or maliciously
+upgraded. `SetShares` and `Claim` never queue.
+
+Three epochs describe an entry. The queue epoch is the epoch of the
+SWA's call. The effective epoch is when the entry becomes due: queue
+epoch plus `swa_timelock_epochs`, except for `RegisterStream`, whose
+caller-supplied `activation_epoch` is its effective epoch, rejected if
+below that same floor. The apply epoch is the first epoch at or after
+the effective epoch at which `AwardBlockReward` or any mutating method
+runs; due entries apply then, in effective-epoch order, ties broken by
+queue position, so no message executes against stale configuration.
+No entry's timing depends on any other entry. The objection window is
+`[queue epoch, effective epoch)`: `CancelPending` acts only inside it,
+and being itself a mutating method, a due entry applies before a
+same-epoch cancel.
+
+The queue holds captured calls: each queued call is one entry,
+validated, applied, and canceled as a whole. Per-stream operations
+(`RegisterStream`, `RemoveStream`, `SetDistribution`) key their slot by
+(id, op); schedule-wide operations (`SetWeightRecords`,
+`StepWeightRecords`) key by op alone, the whole batch one entry.
+Queueing into an occupied slot is rejected, so revising a pending
+write is cancel plus requeue, restarting the timelock; no path changes
+a pending payload while keeping its effective epoch. Two events
+bracket an entry's life: queued fires at admission, carrying the op,
+payload and effective epoch, so a watcher can evaluate the objection
+from the event alone; applied fires at application.
+
+Cancellability is a static per-operation rule: `CancelPending(id, op)`
+deletes any pending slot except a `StepWeightRecords` slot, the gate
+write (Section 3.1.1), so a compromised Safe cannot suppress a gate
+step; the id is null for schedule-wide operations, and a mismatched
+id/op pair is rejected.
+Canceling an empty slot is a benign no-op, since both Safes may relay
+the same objection; the cancellation event fires only on removal.
+Cancellation does not re-validate the remaining queue: a cancel can
+strand a pending write that depended on the canceled entry, which is
+handled at application (Section 2.4.8).
+
+##### 2.4.8 Schedule validation
+
+A queued write is validated at queue time against the state as it
+will be when it applies, that is, with the already-queued writes
+executed: two writes each valid against today's records can sum past
+1 together, so the projected schedule is the only sound base. The
+projection applies earlier entries in order, dropping any invalidated
+by cancellation, and the new write must leave the schedule valid from
+its effective epoch onward without relying on any later-queued entry;
+an applied configuration therefore never depends on a pending one,
+and cancellation can only strand pending writes, never invalidate
+installed state. Admission also rejects a call that would strand a
+currently valid queued entry: pending writes are invalidated only by
+cancellation, never by a later admission. The
+checks: per record, `0 <= floor <= v_start <= cap <= 1`; and the
+projected weights
+must satisfy `Σ_{i>=1} w_i(e) <= 1` at every epoch, so the burn
+residual w0 stays non-negative. Each weight is a clamped linear
+function of the epoch (`ComputeWeight`), so the sum is piecewise
+linear: between breakpoints it is a straight line, and a line at or
+below 1 at both ends stays at or below 1 in between. `Σ <= 1`
+therefore need only hold at:
+
+  - each record's `t_start`, where its segment begins;
+
+  - each epoch where a ramping weight meets a clamp and goes flat:
+    `e = t_start + (floor − v_start)/slope` and
+    `e = t_start + (cap − v_start)/slope`, for `slope ≠ 0`;
+
+  - one point past the last of these, where every weight has gone
+    flat and the sum no longer changes.
+
+A write that fails any check is rejected at queue time.
+
+Queue-time validation guards admission; it cannot guard against
+cancellation. A cancel can invalidate an admitted write that depended
+on the canceled entry: a weight increase that needed a canceled
+decrease's headroom, or a write targeting a stream whose registration
+was canceled. A well-formed due write that fails validation at
+application is discarded, with an event, and processing continues;
+the award path never fails on a queued write, and there is no
+fallback weight vector. The SWA should still pre-validate before
+submitting, and the queued records are public during the objection
+window so anyone can recompute the breakpoints, but f02's queue-time
+check is authoritative for admission.
+
+##### 2.4.9 Methods and bounds
+
+All new methods are FRC-0042 exported, since their callers are
+contracts. Existing methods keep their numbers and signatures.
+
+| Method | Caller | Binding |
+|---|---|---|
+| `SetWeightRecords(records)` | SWA | queued |
+| `StepWeightRecords(records)` | SWA (gate path) | queued; not cancellable |
+| `RegisterStream(id, weight_record, distribution, activation_epoch)` | SWA | queued |
+| `RemoveStream(id)` | SWA | queued |
+| `SetDistribution(id, distribution)` | SWA | queued |
+| `CancelPending(id, op)` | SWA | immediate |
+| `SetShares(id, map)` | the stream's designated writer | immediate |
+| `Claim(id, wallets[])` | anyone | immediate |
+| `GetState()` | anyone | read-only |
+
+`SetWeightRecords` and `StepWeightRecords` are payload-identical; they are
+separate methods so that cancellability is a static per-operation
+rule. The SWA's gate path (`QuarterlyGateCheck`) calls
+`StepWeightRecords` and its discretionary path (`ProposeWrite`) calls the
+rest; which SWA path calls which is SWA code, not an assertion f02
+has to trust.
+
+`RegisterStream` validates that the resulting stream count does not
+exceed `MAX_STREAMS`, the recipient count within `MAX_RECIPIENTS`,
+`activation_epoch >= current_epoch + swa_timelock_epochs`, and the
+distribution is one of the two supported forms; the stream pays
+nothing until its `activation_epoch`.
+
+`GetState` returns the logical state as one tuple:
+
+```
+[ total_minted_reward, total_burn_minted, total_service_minted,
+  service_accrued[], next_transition_epoch, swa_timelock_epochs,
+  streams[], tombstones[], pending_writes[] ]
+```
+
+the state schema above with `streams_root` dereferenced and
+due-but-unapplied writes projected in memory, so reads stay
+read-only; the next mutating call or award performs the real
+application. Its callers are contracts, so the return
+shape stays small and fixed. Claimable amounts need no dedicated read
+method: `Claim` returns `amounts[]` and an all-zero batch writes
+nothing, so a read-only invocation of `Claim` is the query.
+
+Parameter and return tuples, under the encoding rules of Section 2.4.2
+and reusing its component types. Registration supplies only the
+caller-suppliable subset of a distribution, `DistributionInit`; f02
+constructs the full `ExplicitDistribution` with empty accounting
+tables at application, so an invalid registration state is
+unrepresentable. `CancelPending` names a slot exactly as the queue
+keys it: a mismatched id/op pair is rejected, not ignored. `Claim`
+resolves each supplied wallet to ID form before matching; an
+unresolvable wallet is a zero-entitlement entry. Share maps are
+validated as in `SetShares` wherever they appear. All write methods
+return nothing.
+
+```rust
+pub struct DistributionInit {
+    writer: Address,
+    shares: Vec<RecipientShare>,     // ascending recipient, unique
+}
+
+SetWeightRecordsParams  { updates: Vec<WeightRecordUpdate> }
+                        // WeightRecordUpdate { id: u64, weight: WeightRecord }
+StepWeightRecordsParams // identical to SetWeightRecordsParams
+RegisterStreamParams    { id: u64, weight: WeightRecord,
+                          distribution: Option<DistributionInit>,  // None = IMPLICIT
+                          activation_epoch: ChainEpoch }
+RemoveStreamParams      { id: u64 }
+SetDistributionParams   { id: u64, writer: Address }
+SetSharesParams         { id: u64, shares: Vec<RecipientShare> }
+CancelPendingParams     { id: Option<u64>,                // None for schedule-wide ops
+                          op: PendingWriteOp }
+ClaimParams             { id: u64, wallets: Vec<Address> }
+ClaimReturn             { amounts: Vec<TokenAmount> }     // positional with wallets
+```
+
+**`MAX_STREAMS = 8`, `MAX_RECIPIENTS = 64`.** `MAX_STREAMS` counts every
+registered stream, the consensus stream included; recipients are
+where growth lands, so `MAX_RECIPIENTS` carries the headroom. The caps
+are deliberately small: every structure they bound lives in state the
+award path reads every block, so they are consensus-path work bounds,
+not product limits. `MAX_RECIPIENTS` caps the share map, not the
+history tables, which self-drain: payable fills at a fold and drains
+as recipients claim, `claimed_period` resets each period, so in normal
+operation the history sits near empty and exists for the edge cases
+(dropped wallets, an absent writer, removed streams). Raising either
+cap requires a future FIP and network upgrade that also reshapes the
+affected structures for the new scale. Tombstones need no cap: growth
+is gated on `RemoveStream`, a governance-cadence operation, and any
+payable row is flushable by anyone via the permissionless `Claim`.
+
+##### 2.4.10 Migration
+
+The state migration bootstraps the two initial streams as
+clamped-linear records with `t_start` = `activation_epoch`:
+
+```
+w1 (consensus, id 1, IMPLICIT):  { v_start: 0.95, slope: -0.45/(9 * EPOCHS_PER_QUARTER), floor: 0.50, cap: 0.95 }
+w2 (service,   id 2, EXPLICIT):  { v_start: 0.05, slope: +0.45/(9 * EPOCHS_PER_QUARTER), floor: 0.05, cap: W2_BASE }
+```
+
+The slopes cancel over Q1 so the weights schedule no w0 share during
+bootstrap; the independent per-stream flooring can still leave an atto
+of rounding residual per block, burned under the exact-residual rule.
+w2 hits its cap exactly at the Q1 boundary, exiting the bootstrap ramp
+with no scheduled write needed (Section 3.1.1). The service stream
+starts with the single-Orchestrator share map (one wallet, `share = 1`)
+and the SRA as designated writer. The migration also renames position
+9, drops positions 10 and 11 (their values continue as the code
+constants of Section 2.4.2 on every network), zeroes the new
+counters, and sets `swa_timelock_epochs`: the only place it is ever
+written.
 
 #### 2.5 Supply accounting
 
-(TO BE REVIEWED) f02 state holds `total_storage_power_reward`, the
-cumulative minted FIL awarded to block miners; clients read it to
-compute `FilMined`, an input to circulating supply. The split does not
-change how much is minted, only who receives it, so
-`total_storage_power_reward` alone no longer measures total minting; the
-following changes fix the accounting:
+Circulating supply is consensus-relevant (`FilMined` feeds the initial
+pledge input) and Lotus, Forest and Venus each compute it
+independently, so its inputs should not change. The split changes who
+receives issuance, not how much, so the total keeps its slot:
 
-  - **`total_storage_power_reward` keeps its current meaning**: from
-    activation onward it accumulates only the consensus stream.
+  - **`total_minted_reward`** (position 9, renamed from
+    `total_storage_power_reward`) accrues the full block reward, all
+    streams. The rename is source-level only: tuple serialization is
+    positional, so nothing changes on the wire for state readers.
+    **`FilMined` keeps reading position 9 unchanged**: no
+    implementation changes its circulating-supply logic.
 
-  - f02 adds **one cumulative counter per non-consensus stream**,
-    `total_stream_reward[id]`, incremented at accrual in `AwardBlockReward`.
+  - **`total_burn_minted`** (the w0 residual) and
+    **`total_service_minted`** (gross service accrual) are stored
+    counters, otherwise hard to recover independently: each needs the
+    full weight and reward history. Fold dust burns from the service
+    side and is attributed there (Section 2.4.4), keeping the residual
+    exact.
 
-  - **`FilMined` MUST equal
-    `total_storage_power_reward + Σ_id total_stream_reward[id]`**,
-    exposed via `GetState` [TODO: or a
-    dedicated read method, so Lotus, Forest, Venus, and downstream
-    consumers migrate uniformly].
+  - What miners have received is the derived residual
+    `M = total_minted_reward − total_burn_minted − total_service_minted`;
+    it is not stored. Tools that treated
+    position 9 as miner income must move to this residual (see
+    Backwards Compatibility).
 
-  - The burn stream is minted and transferred to f099: counted in
-    `FilMined`, captured by `FilBurnt`, net zero on circulating supply.
+  - Minting is counted at accrual: each award adds
+    `BR = miner + service + burn` exactly and bumps the three totals by
+    their parts, so the decomposition holds by construction. The burn
+    is minted and sent to f099: counted in `FilMined`, captured by
+    `FilBurnt`, net zero on circulating supply.
 
+The claim state carries no supply duty: the counters account for FIL
+ever minted, while the claim state accounts only for the slice still
+inside f02. At every epoch f02's balance covers
+`Σ (service_accrued − Σ claimed_period + Σ payable)` over streams and
+tombstones. Its terms are period-scoped but the invariant is not; the
+fold just moves value between terms.
 
 
 ### 3. Two new contracts
 
 Two FEVM contracts, the SWA and the SRA, parameterize f02. Neither is on
-the value path: the consensus miner and the Orchestrator payouts both
-run entirely in f02, and a failed send burns that share rather than
-reverting the epoch's distribution. Neither contract ever receives or
-holds value; the SWA only sets weight records and the SRA only computes
-shares, and both simply write them to f02.
+the value path: the consensus payment and the burn run inside f02's
+award path, and Orchestrator funds accrue in f02 until withdrawn via
+`Claim` (Section 2.4.5). Neither contract ever receives or holds value;
+the SWA only sets weight records and the SRA only computes shares, and
+both simply write them to f02.
 
 #### 3.1 Stream Weights Actor (SWA): the split among streams
 
@@ -907,15 +1340,20 @@ particular
     section 3.1.1) for the weight w2;
 
   - It is the only contract allowed to call f02’s methods
-    `RegisterStream`, `RemoveStream`, `SetWeightRecords`, `SetDistribution`,
-    and `CancelPending`;
+    `RegisterStream`, `RemoveStream`, `SetWeightRecords`,
+    `StepWeightRecords`, `SetDistribution`, and `CancelPending`;
 
   - The SWA holds the gate parameters (Section 3.1.1),
     governance-settable via `SetGateParams`, which govern how the next
     service weight record is computed once per quarter; the Weight records
     themselves live in f02 (Section 2.4); the SWA only writes them. It
-    also holds the last executed quarter (enforcing at most one gate
-    step per quarter), the two SWA Safe addresses (Section 4.2), and
+    also holds its gate progress: the count of executed gate steps,
+    the last w2 level it wrote, and the last executed quarter
+    (enforcing at most one gate step per quarter). The step counter
+    is authoritative for gate position: it indexes the target
+    schedule directly, unaffected by a write still queued in f02 or
+    by the `1 − w1` ceiling clamping w2 off the 5pp grid.
+    It also holds the two SWA Safe addresses (Section 4.2) and
     the addresses it is wired to: f02 and the SRA (read for
     `AggregatedFPV`). Pending f02 writes are queued and held in f02
     (`SWA_TIMELOCK`, Section 2.4); changes to the SWA’s own state and
@@ -930,8 +1368,9 @@ particular
         `AggregatedFPV(Q)` triggers the SRA’s `FinalizeConversion(Q)` if
         it has not yet run (Section 2.2). Runs the gate rule of
         Section 3.1.1 and, when the gate passes, writes the new w2
-        Weight record to f02 via `SetWeightRecords`. It can submit only
-        the value it computes.
+        Weight record to f02 via `StepWeightRecords`, the uncancellable
+        gate write (Section 2.4.7). It can submit only the value it
+        computes.
 
       - **`ProposeWrite(write)`.** Requires the approval of both SWA
         Safes. Relays a discretionary write (`SetWeightRecords`,
@@ -939,8 +1378,8 @@ particular
         it queues for `SWA_TIMELOCK`; per Section 4.4 the submission
         must be backed by a published and accepted FIP.
 
-      - **`Cancel(id)`.** Callable by either SWA Safe alone. Relays
-        f02.`CancelPending(id)`, discarding a queued discretionary write
+      - **`Cancel(id, op)`.** Callable by either SWA Safe alone. Relays
+        f02.`CancelPending(id, op)`, discarding a queued discretionary write
         during its timelock; a cancellation can only preserve the
         status quo and grants no new power, since either Safe could
         have withheld approval.
@@ -959,8 +1398,8 @@ quarter boundaries, and only if on-chain Filecoin Pay Volume clears a
 target. The weight w2 evolves differently in Q1 (bootstrap) vs.
 Q2 onward:
 
-**Bootstrap record (Q1).** At activation the SWA writes the service
-stream’s initial record:
+**Bootstrap record (Q1).** The state migration installs the service
+stream’s initial record (Section 2.4.10):
 
 ```
 W_service = { v_start: 0.05, slope: -slope_w1, t_start: activation_epoch, floor: 0.05, cap: W2_BASE }
@@ -968,7 +1407,8 @@ W_service = { v_start: 0.05, slope: -slope_w1, t_start: activation_epoch, floor:
 
 Because the slope is defined as the exact negative of w1’s,
 `w2(e) = 1 − w1(e)` at every epoch of Q1: the service stream absorbs
-the full ceiling and nothing is burned during the bootstrap quarter.
+the full ceiling; no w0 share is scheduled during the bootstrap
+quarter.
 
 **Steady state (Q2 onward).** The ramp rate is 5pp per quarter, so w2
 reaches `W2_BASE` (10%) exactly at the Q1 boundary, where the
@@ -977,7 +1417,7 @@ bootstrap: the clamp does it. From then on, w2 is a step function: when a
 gate passes, `QuarterlyGateCheck` replaces the record with a constant
 one at the new level,
 `{ v_start: new_w2, slope: 0, floor = cap = new_w2 }`, via
-`SetWeightRecords` under `SWA_TIMELOCK`; when a gate fails, the
+`StepWeightRecords` under `SWA_TIMELOCK`; when a gate fails, the
 record is untouched and w2 holds. Burn resumes automatically from the Q1
 boundary: w1 keeps ramping down while w2 holds at its gate-set level,
 and the residual is burned.
@@ -985,29 +1425,31 @@ and the residual is burned.
 **`QuarterlyGateCheck`**, run once per quarter from Q2 onward:
 
 ```
+// SWA state: steps = gate steps executed so far; w2_level = the level
+// the last gate write set (W2_BASE before any step). Tracking both
+// locally keeps the gate self-contained: steps indexes the target
+// schedule directly, unaffected by a write still queued in f02 or by
+// the 1 - w1 ceiling clamping w2 off the 5pp grid.
 func QuarterlyGateCheck(Q uint64):
     // 1. Read aggregated volume for the quarter just ended, posted to the SRA
     //    (see FPV definitions in Section 2)
     measured = AggregatedFPV(Q)
 
-    // 2. Read current w2
-    state = f02.GetState()
-    w2 = state.w2
+    // 2. Compute the volume target from the step counter
+    target = ComputeTarget(steps)  // fixed USD schedule, see below
 
-    // 3. Compute the volume target
-    target = ComputeTarget(w2)  // fixed USD schedule, see below
-
-    // 4. Gate decision
+    // 3. Gate decision
     if measured >= target:
-        new_ws = min(w2 + W2_STEP, 1 - state.w1)  // w1 read from f02.GetState(), not recomputed
-        f02.SetWeightRecords({ w2: new_ws })      // SWA-only; f02 re-derives w0
+        new_w2 = min(w2_level + W2_STEP, 1 - w1)      // w1 evaluated from f02 state
+        f02.StepWeightRecords({ w2: constant record at new_w2 })  // uncancellable; f02 re-derives w0
+        steps += 1; w2_level = new_w2
     // else: gate fails, w2 unchanged
 ```
 
 **`ComputeTarget` (volume target).** The gate compares USD-denominated
 volume directly against a fixed schedule:
-**`AggregatedFPV(Q) ≥ ComputeTarget(w2)`**, where w2 is the service
-weight before the step-up.
+**`AggregatedFPV(Q) ≥ ComputeTarget(steps)`**, where `steps` counts
+the gate step-ups already executed.
 It sets how much on-chain volume the service economy must generate to
 unlock the next w2 step-up.
 
@@ -1025,8 +1467,7 @@ VOL_TARGET_RATIO = 2.7    // per-step escalation; back-loads the volume requirem
 // Frozen schedule (USD): 3.5K, 9.4K, 25.5K, 68.9K, 186K, 502K, 1.36M, 3.66M
 // for gates 10->15 through 45->50. Fixed at FIP time.
 
-func ComputeTarget(w2) -> USD:
-    steps = (w2 - W2_BASE) / W2_STEP  // count of 5pp increments above start
+func ComputeTarget(steps) -> USD:
     steps = clamp(steps, 0, (W2_CAP - W2_BASE) / W2_STEP - 1)  // bound within [0, 7]: 8 gates, indices 0-7
     return VOL_TARGET_ENTRY * VOL_TARGET_RATIO ^ steps
 ```
@@ -1060,7 +1501,8 @@ divided among Orchestrators. In particular,
 
   - **Frozen status.** Frozen means admitted but suspended, and it is
     reversible. While frozen, an Orchestrator cannot call `RegisterPairs`
-    or `PostVolume`; it is excluded from `SplitRule` (`share = 0`) and its
+    or `PostVolume`; it is excluded from `SplitRule` (omitted from the
+    submitted share map) and its
     FPV from `AggregatedFPV(Q)`, for any quarter whose posting period
     closes while it is frozen; and its (payer, operator) bindings stay
     bound (no poaching during a dispute): a pair moves only via
@@ -1119,8 +1561,9 @@ divided among Orchestrators. In particular,
         not yet run, then computes each Orchestrator’s share via
         `SplitRule` over the stored USD values (Section 2.2) and writes
         the wallet-to-share map into f02 via `SetShares`. Orchestrators
-        frozen at the close of the posting period are excluded: their
-        share is zero and their FPV does not enter `AggregatedFPV(Q)`.
+        frozen at the close of the posting period are excluded:
+        omitted from the submitted map, with their FPV not entering
+        `AggregatedFPV(Q)`.
         Like the SWA’s crank, it can submit only the value it computes,
         and it is not held (Section 4.3).
 
@@ -1242,9 +1685,10 @@ the change is published and held, and either Safe can cancel during the
 hold. There is no exemption by category beyond one carve-out (below), so
 reducing a weight to zero is held exactly like removing a stream.
 Mechanism-executed updates cannot be canceled: the gate’s quarterly w2
-write queues in f02 under `SWA_TIMELOCK` for visibility, but it is tagged
-as a mechanism write at queue time and `CancelPending` rejects it (Section
-2.4), while the SRA’s quarterly share map is never queued and binds
+write queues in f02 under `SWA_TIMELOCK` for visibility, but it arrives
+through its own method, `StepWeightRecords`, the one operation
+`CancelPending` refuses (Section 2.4.7), while the SRA’s quarterly share
+map is never queued and binds
 directly via `SetShares` (Section 3.2). The carve-out is `CorrectVolume`
 (Section 3.2): the verification window itself is the hold, so a
 correction binds when the window closes and has no separate cancellation
@@ -1370,7 +1814,7 @@ pipeline), reintroducing complexity. Once the pipeline is
 self-sustaining, moving toward commission/rebate mechanisms is the
 intended direction (see Phase 2 of the SRA registry, Section 3.2).
 
-#### Question 5: Parameterising f02 from two off-path contracts
+#### Question 5: Parameterizing f02 from two off-path contracts
 
 The split is executed entirely by the f02 built-in actor, which stores
 the stream weights and the Orchestrator wallet-to-share map in its own
@@ -1390,7 +1834,7 @@ the contracts at runtime, for two reasons.
   - Second, *liveness independence*: f02 depends only on its own
     cached state, so a contract that is down, buggy, or compromised
     cannot stall block-reward distribution. Instead, f02 simply
-    continues to split on the last validated values.
+    continues to split on the records it holds.
 
 ### Parameter Choices and Calibration
 
@@ -1501,6 +1945,10 @@ additional miner funds.
 The f02 state schema, method surface and payout accounting change.
 Lotus, Forest, Venus and downstream state decoders must decode the new
 state consistently and preserve circulating-supply accounting.
+Position 9 of the f02 state keeps the grand minted total under a new
+name, so `FilMined` readers are unchanged; anything that treated it as
+miner-only income must derive the miner total as the stored total
+minus the burn and service counters (Section 2.5).
 Explorers and profitability tools that currently treat the full block
 reward as miner income must apply the consensus weight w1 after
 activation. The SWA and SRA contracts must be deployed and their
@@ -1514,6 +1962,11 @@ The implementation test suite MUST cover at least:
     market and reward-actor state, including empty and populated
     structures;
 
+  - exact reproduction of `this_epoch_reward` across consecutive
+    epochs with the canonical `SIMPLE_TOTAL` and `BASELINE_TOTAL` code
+    constants in place of the retired state fields, validated against
+    pre-upgrade mainnet state;
+
   - unchanged QAP for existing sectors at migration, 10× QAP and
     corresponding pledge for newly onboarded sectors, and each
     explicit legacy-sector upgrade path;
@@ -1523,16 +1976,18 @@ The implementation test suite MUST cover at least:
     existing claims and in-flight activation messages;
 
   - `ComputeWeight` clamping and rounding, the Q1 w1/w2 bootstrap,
-    gate pass and failure transitions, the non-negative burn residual,
-    and conservation of the full block reward while gas rewards and
-    penalties retain their existing treatment;
+    gate pass and failure transitions, the exact-residual burn, and
+    atto-exact conservation of the full block reward while gas rewards
+    and penalties retain their existing treatment;
 
-  - authorization, queuing, activation and cancellation of
-    discretionary f02 writes, including rejection of cancellation for
-    mechanism writes;
+  - authorization, queuing, slot occupancy, projected-schedule
+    validation, application ordering and cancellation of f02 writes,
+    including the refusal to cancel `StepWeightRecords`;
 
-  - share-map validation and update, failed-recipient handling,
-    stream registration, distribution changes and stream removal;
+  - share-map validation, the period fold on `SetShares`, accrual and
+    `Claim` (mid-period, dropped-wallet, tombstone and zero-entitlement
+    cases), stream registration, distribution changes and stream
+    removal;
 
   - FPV calculation for admitted stablecoin and FIL settlements,
     pricing-print boundaries, reporting and correction windows,
@@ -1675,22 +2130,21 @@ changes to leader election or finality.
     volume stays uncounted: the gate can only under-count, never
     over-count.
 
-  - **Consensus-path safety of the split.** The per-epoch split runs
-    in f02 from cached state with no external call, so a contract that
-    is down, buggy, or compromised cannot stall block-reward
-    distribution; f02 continues on the last validated values. Three L1
-    properties carry the safety and should be stated as invariants:
-    total payout must never exceed the block reward: the SWA validates
-    the schedule envelope before submitting, and f02 checks `Σ ≤ 1` at
-    write activation and again at every epoch, paying from the last
-    valid weight vector whenever the check fails, so payouts can never
-    exceed the block reward and a bad schedule degrades to frozen
-    weights rather than inflated issuance (Section 2.4); `MAX_STREAMS`
-    and `MAX_RECIPIENTS` must bound the per-epoch work so the split
-    cannot become a consensus-path denial-of-service; and a failed
-    send to any recipient must burn that share rather than revert the
-    epoch, with the send path failure-isolated and gas-bounded because
-    recipients can be contracts.
+  - **Consensus-path safety of the split.** The per-block split runs
+    in f02 from its own state with no external call, so a contract
+    that is down, buggy, or compromised cannot stall block-reward
+    distribution. Three L1 properties carry the safety and should be
+    stated as invariants: total payout can never exceed the block
+    reward, because every schedule write is validated at queue time
+    against the projected schedule and the burn is the exact residual
+    (Section 2.4.8), so the per-block `Σ ≤ 1` check is an assertion
+    rather than a recoverable failure; `MAX_STREAMS` and `MAX_RECIPIENTS`
+    must bound the per-block work so the split cannot become a
+    consensus-path denial-of-service; and the award path performs no
+    send that can fail, its only send being the burn to f099, with
+    recipients paid solely through the explicit `Claim` method, where a
+    failure reverts the claim and leaves the entitlement intact
+    (Section 2.4.5).
 
   - **Compromised Orchestrator wallet.** An Orchestrator address holds
     no authority over weights or other participants' shares;
@@ -1796,10 +2250,6 @@ Call:
   - incorporate the implementation decisions in builtin-actors PR
     #1760 for in-flight allocations, the `FULL_QA_POWER` flag, and
     post-upgrade deal-weight accounting;
-
-  - finalize f02 settlement, rounding, supply accounting, method
-    numbers and state layout under builtin-actors issue #1764, then
-    remove the provisional marker and inline TODO from Section 2.5;
 
   - specify deterministic `MAX_PRICE_PERIODS` merging and choose the
     initial `MIN_LOT` and `PRICE_BAND` values for FIL conversion;


### PR DESCRIPTION
FIP-0118 update: the f02 (reward actor) mechanics are now fully specified (Section 2.4/2.5 rewrite). This comes out of work done in https://github.com/filecoin-project/solstice/pull/13.

- Payouts are now claim-based. f02 holds each orchestrator's earnings and anyone can trigger the withdrawal to the named wallet(s). Nothing new is pushed out per epoch, and the old "failed payment burns your share" rule is gone.
- Share updates take effect immediately when the SRA submits them; the quarterly rhythm comes from the SRA process, not the reward actor. Earnings are always settled under the shares in force while they were earned.
- The gate's step-up (via QuarterlyGateCheck) is now its own uncancellable operation (separate to the discretionary ProposeWrite). Every other governance write still queues under the 7-day hold and either Safe can cancel it.
- Bad weight schedules are rejected up front, when queued, instead of being worked around at runtime. The split can never pay out more than the block reward.
- Nothing strands: a removed stream's unpaid balances stay claimable until drained.
- Hard caps: 8 streams, 64 recipients per stream. Raising either takes a new FIP and network upgrade.
- Total issuance and circulating-supply reporting are untouched; only who receives issuance changes.

Update 1:

- Codifies consts `SIMPLE_TOTAL` = 330,000,000 FIL and `BASELINE_TOTAL` = 768,335,872,210,768,889,362,796,814 attoFIL as per live mainnet measurements.