### PR TITLE
FIP-0118: specify w2 gate mechanics; SWA tracks position as state

### DIFF
--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -115,10 +115,10 @@ streams are as follows. The weight w1 ramps down from 95% to 50% over
 roughly 9 quarters. During the first quarter (the bootstrap phase),
 `w2 = 1 − w1` so no w0 share is scheduled and w2 reaches 10% by the
 end of the quarter. From Q2 onward, w2 steps up by 5 percentage
-points per quarter,
-capped at the ceiling `1 − w1`, and only when on-chain aggregated Filecoin
-Pay Volume (FPV) clears its target for the quarter. The SWA is governed
-by **SWA Governance** (see Section 4).
+points per quarter, never exceeding the ceiling `1 − w1`, and only
+when on-chain aggregated Filecoin Pay Volume (FPV) clears the current
+gate's target. The SWA is governed by **SWA Governance** (see Section
+4).
 
 The **Service Rewards Actor (SRA)** is the new governed contract
 that computes how the service stream is divided among Service
@@ -515,7 +515,7 @@ Once per quarter, off the per-epoch path:
         publicly recomputable value before the window closes; if it
         does not, the zero value safely depresses the gate.
 
-    4.  `SubmitShares(Q)` and `QuarterlyGateCheck(Q)` become callable only
+    4.  `SubmitShares` and `QuarterlyGateCheck` become callable only
         after the window closes and read only bound values, with
         `AggregatedFPV(Q)` the sum of bound values. There is no
         retroactive clawback: a misreport discovered after binding is
@@ -563,8 +563,9 @@ Once per quarter, off the per-epoch path:
     produce diverging numbers.
 
 4.  **Weights and shares updates.** `QuarterlyGateCheck` compares the
-    USD-denominated `AggregatedFPV(Q)` against the quarter's fixed USD
-    target (Section 3.1.1). If it passes, the SWA raises w2 via
+    USD-denominated `AggregatedFPV(Q)` against the current gate's fixed
+    USD target, indexed by gates passed rather than by the quarter
+    number (Section 3.1.1). If it passes, the SWA raises w2 via
     `StepWeightRecords` (Section 2.4.9), the uncancellable gate write.
     `SplitRule` sets each Orchestrator's
     share in proportion to its USD-denominated `FPV_i(Q)`, using the
@@ -576,6 +577,14 @@ Once per quarter, off the per-epoch path:
     computations: they are omitted from the submitted share map
     (shares in the map must be positive, Section 2.4.4) and their FPV
     does not enter `AggregatedFPV(Q)` (Section 3.2).
+
+    Quarter 1 runs this full pipeline with one exception: no gate
+    check. Posting, verification, binding and `SubmitShares(1)` proceed
+    as in any other quarter, and the first quarter's report is
+    required even though it gates nothing: the Orchestrator posts on
+    chain and the bound values set the shares. Only `QuarterlyGateCheck`
+    is skipped, because the bootstrap ramp performs the 5% to 10% move
+    ungated (Section 3.1.1).
 
 #### 2.3 FPV definitions
 
@@ -1107,7 +1116,6 @@ contracts. Existing methods keep their numbers and signatures.
 | `CancelPending(id, op)` | SWA | immediate |
 | `SetShares(id, map)` | the stream's designated writer | immediate |
 | `Claim(id, wallets[])` | anyone | immediate |
-| `GetState()` | anyone | read-only |
 
 `SetWeightRecords` and `StepWeightRecords` are payload-identical; they are
 separate methods so that cancellability is a static per-operation
@@ -1121,22 +1129,6 @@ exceed `MAX_STREAMS`, the recipient count within `MAX_RECIPIENTS`,
 `activation_epoch >= current_epoch + swa_timelock_epochs`, and the
 distribution is one of the two supported forms; the stream pays
 nothing until its `activation_epoch`.
-
-`GetState` returns the logical state as one tuple:
-
-```
-[ total_minted_reward, total_burn_minted, total_service_minted,
-  service_accrued[], next_transition_epoch, swa_timelock_epochs,
-  streams[], tombstones[], pending_writes[] ]
-```
-
-the state schema above with `streams_root` dereferenced and
-due-but-unapplied writes projected in memory, so reads stay
-read-only; the next mutating call or award performs the real
-application. Its callers are contracts, so the return
-shape stays small and fixed. Claimable amounts need no dedicated read
-method: `Claim` returns `amounts[]` and an all-zero batch writes
-nothing, so a read-only invocation of `Claim` is the query.
 
 **`MAX_STREAMS = 8`, `MAX_RECIPIENTS = 64`.** `MAX_STREAMS` counts every
 registered stream, the consensus stream included; recipients are
@@ -1246,12 +1238,15 @@ particular
     governance-settable via `SetGateParams`, which govern how the next
     service weight record is computed once per quarter; the Weight records
     themselves live in f02 (Section 2.4); the SWA only writes them. It
-    also holds its gate progress: the count of executed gate steps,
-    the last w2 level it wrote, and the last executed quarter
-    (enforcing at most one gate step per quarter). The step counter
-    is authoritative for gate position: it indexes the target
-    schedule directly, unaffected by a write still queued in f02 or
-    by the `1 − w1` ceiling clamping w2 off the 5pp grid.
+    also holds its gate progress as explicit state: `steps`, the count
+    of gate steps executed, and `last_checked_quarter`, the last
+    quarter consumed by a check (the sequential once-per-quarter
+    latch, Section 3.1.1). Quarter numbering and window state are the
+    SRA's (Section 3.1.1); the SWA keeps no copy of the quarter
+    boundaries and asks the SRA whether a quarter's volumes are
+    bound. The step counter is authoritative for gate
+    position: it indexes the target schedule directly and determines
+    the next w2 level.
     It also holds the two SWA Safe addresses (Section 4.2) and
     the addresses it is wired to: f02 and the SRA (read for
     `AggregatedFPV`). Pending f02 writes are queued and held in f02
@@ -1260,10 +1255,12 @@ particular
     a SWA-internal timelock of the same duration, cancellable by
     either Safe. Its methods:
 
-      - **`QuarterlyGateCheck(Q)`.** The mechanism entry point;
-        permissionless. Requires that quarter Q has ended, that
-        `AggregatedFPV(Q)` is bound (its verification window has
-        closed), and that no step has yet executed for Q. Its read of
+      - **`QuarterlyGateCheck()`.** The mechanism entry point;
+        permissionless. Operates on the next unchecked quarter,
+        `Q = last_checked_quarter + 1` (the sequential latch, Section
+        3.1.1), and is callable only once quarter Q's verification
+        window has closed, so `AggregatedFPV(Q)` is bound (the posting
+        period always closes first, Section 2.2). Its read of
         `AggregatedFPV(Q)` triggers the SRA’s `FinalizeConversion(Q)` if
         it has not yet run (Section 2.2). Runs the gate rule of
         Section 3.1.1 and, when the gate passes, writes the new w2
@@ -1285,9 +1282,10 @@ particular
 
       - **`SetGateParams(params)`.** Discretionary; requires the
         approval of both SWA Safes and a published FIP. Updates the
-        gate parameters; held in the SWA-internal timelock and
-        cancellable by either Safe. The gate rule itself is code and
-        cannot be changed by a parameter write.
+        gate parameters, the step counter `steps` included; held in
+        the SWA-internal timelock and cancellable by either Safe. The
+        gate rule itself is code and cannot be changed by a parameter
+        write.
 
 ##### 3.1.1 The volume gate mechanism
 
@@ -1312,7 +1310,11 @@ quarter.
 **Steady state (Q2 onward).** The ramp rate is 5pp per quarter, so w2
 reaches `W2_BASE` (10%) exactly at the Q1 boundary, where the
 record clamps at its cap. No end-of-quarter write is needed to exit the
-bootstrap: the clamp does it. From then on, w2 is a step function: when a
+bootstrap: the clamp does it. The move from 5% to `W2_BASE` is therefore
+ungated: no gate check runs for Q1 (`last_checked_quarter` initializes
+to 1), and the first `QuarterlyGateCheck` evaluates quarter 2's bound
+volume, after Q2's verification window has closed.
+From then on, w2 is a step function: when a
 gate passes, `QuarterlyGateCheck` replaces the record with a constant
 one at the new level,
 `{ v_start: new_w2, slope: 0, floor = cap = new_w2 }`, via
@@ -1321,15 +1323,20 @@ record is untouched and w2 holds. Burn resumes automatically from the Q1
 boundary: w1 keeps ramping down while w2 holds at its gate-set level,
 and the residual is burned.
 
-**`QuarterlyGateCheck`**, run once per quarter from Q2 onward:
+**`QuarterlyGateCheck`**, callable once per quarter, in quarter order,
+the first check evaluating quarter 2:
 
 ```
-// SWA state: steps = gate steps executed so far; w2_level = the level
-// the last gate write set (W2_BASE before any step). Tracking both
-// locally keeps the gate self-contained: steps indexes the target
-// schedule directly, unaffected by a write still queued in f02 or by
-// the 1 - w1 ceiling clamping w2 off the 5pp grid.
-func QuarterlyGateCheck(Q uint64):
+// SWA state: steps = gate steps executed so far, indexing the target
+// schedule directly; last_checked_quarter = the last quarter consumed
+// by a check, initialized to 1 (the ungated bootstrap quarter).
+func QuarterlyGateCheck():
+    // Sequential once-per-quarter latch: quarters are checked in
+    // order and each quarter's bound volume is evaluated exactly once
+    Q = last_checked_quarter + 1
+    require verification window for Q has closed  // AggregatedFPV(Q) is bound
+    require steps < (W2_CAP - W2_BASE) / W2_STEP  // 8 gates; done once w2 rests at W2_CAP
+
     // 1. Read aggregated volume for the quarter just ended, posted to the SRA
     //    (see FPV definitions in Section 2)
     measured = AggregatedFPV(Q)
@@ -1339,18 +1346,73 @@ func QuarterlyGateCheck(Q uint64):
 
     // 3. Gate decision
     if measured >= target:
-        new_w2 = min(w2_level + W2_STEP, 1 - w1)      // w1 evaluated from f02 state
-        f02.StepWeightRecords({ w2: constant record at new_w2 })  // uncancellable; f02 re-derives w0
-        steps += 1; w2_level = new_w2
-    // else: gate fails, w2 unchanged
+        steps += 1
+        new_w2 = W2_BASE + steps * W2_STEP  // always on the 5pp grid
+        f02.StepWeightRecords({ w2: { v_start: new_w2, slope: 0, floor: new_w2, cap: new_w2 } })
+        // uncancellable (Section 2.4.7); f02 re-derives w0
+    // else: gate fails; steps, and so the target, are unchanged
+    last_checked_quarter = Q  // pass or fail, quarter Q is consumed
 ```
+
+**One gate at a time.** A quarter's bound volume clears at most one
+gate. When a gate fails, `steps` holds, so w2 and the target both hold;
+the ceiling `1 − w1` keeps ramping away and the widening residual is
+burned. There is no catch-up: no later quarter can clear more than its
+own single gate, and the only way forward is passing the
+still-standing gate with a later quarter's volume, one step per
+quarter. The latch makes replay-based catch-up impossible: a passed
+quarter cannot be re-checked, so its volume can never be run against
+the next target for a second step.
+
+**Late cranks self-heal.** Nothing requires the check for quarter Q to
+run during quarter Q+1. If nobody invokes it until later, it still
+evaluates quarter Q's bound volume, and the check for quarter Q+1
+becomes callable immediately after. Two steps landing in quick
+succession this way is each gate being cleared by its own quarter's
+volume, not catch-up: the latch counts quarters checked, not calendar
+time.
+
+**Gate write rejection.** If f02's queue-time schedule validation
+(Section 2.4.8) rejects the gate write, the whole `QuarterlyGateCheck`
+call reverts, `steps` and `last_checked_quarter` do not advance, and
+the gate is re-attemptable in a later quarter (on this FIP's schedule
+the rejection can occur only after a discretionary change to w1's
+schedule). w2 takes values only on the 5pp grid
+`W2_BASE + steps * W2_STEP`; partial steps do not exist.
+
+**The counter is the authority.** Gate position lives in `steps`; the
+w2 record is derived from it as `W2_BASE + steps * W2_STEP`. Any
+discretionary write that changes the w2 record MUST be accompanied,
+in the same governance action, by the matching `steps` adjustment via
+`SetGateParams`, and the two changes MUST take effect at the same
+epoch (the SWA schedules the `SetGateParams` application to the f02
+write's effective epoch). Record and counter otherwise diverge: a
+lowered record with a stale counter makes the next passing gate skip
+levels, and a gate check firing between two unaligned effective
+epochs acts on a mismatched pair. The terminal check reads the
+counter, so it is not permanent: lowering `steps` through
+`SetGateParams` reopens the gate.
+
+**Quarter boundaries.** The SRA is the sole authority on quarter
+numbering and window state; the SWA holds no boundary state and does
+no window arithmetic. `QuarterlyGateCheck` operates on
+`Q = last_checked_quarter + 1` and is callable once the SRA reports
+quarter Q's volumes bound (verification window closed, values final);
+the check then reads `AggregatedFPV(Q)` from the same contract, so the
+volume and its finality come from one place. The boundaries themselves are as defined
+in Section 2.2: consecutive `EPOCHS_PER_QUARTER`-epoch windows counted
+from the activation epoch, maintained in the SRA.
 
 **`ComputeTarget` (volume target).** The gate compares USD-denominated
 volume directly against a fixed schedule:
 **`AggregatedFPV(Q) ≥ ComputeTarget(steps)`**, where `steps` counts
 the gate step-ups already executed.
 It sets how much on-chain volume the service economy must generate to
-unlock the next w2 step-up.
+unlock the next w2 step-up. The ladder is step-indexed, not
+time-indexed: the target depends only on how many gates have passed,
+never on which quarter it is, so a missed gate leaves the next
+quarter's target exactly where it was, and the target escalates by
+`VOL_TARGET_RATIO` only when a gate passes.
 
 ```
 W2_STEP    = 0.05  // quarterly increment (5pp) when volume targets are cleared
@@ -1367,7 +1429,8 @@ VOL_TARGET_RATIO = 2.7    // per-step escalation; back-loads the volume requirem
 // for gates 10->15 through 45->50. Fixed at FIP time.
 
 func ComputeTarget(steps) -> USD:
-    steps = clamp(steps, 0, (W2_CAP - W2_BASE) / W2_STEP - 1)  // bound within [0, 7]: 8 gates, indices 0-7
+    // steps is within [0, 7] here: 8 gates, guarded by the terminal
+    // check in QuarterlyGateCheck
     return VOL_TARGET_ENTRY * VOL_TARGET_RATIO ^ steps
 ```
 
@@ -1383,7 +1446,10 @@ divided among Orchestrators. In particular,
 
   - The SRA holds the registry (the (payer, operator) to Orchestrator
     bindings and each Orchestrator’s status, active or frozen), the
-    posted volumes `FPV_i(Q)` with their verification-window state, the
+    posted volumes `FPV_i(Q)` with their verification-window state
+    (also served to the SWA, which reads quarter and window state
+    from the SRA alongside `AggregatedFPV`, Section 3.1.1), the
+    last quarter whose share map was submitted, the
     two Registry Safe addresses (Section 4.2), and the queue of
     pending governance changes under `SRA_CANCEL_HOLD`; the hold and
     verification-window durations are parameters set in the
@@ -1455,11 +1521,16 @@ divided among Orchestrators. In particular,
         `QuarterlyGateCheck`’s read and by `SubmitShares` when not
         already run.
 
-      - **`SubmitShares(Q)`.** Permissionless once every `FPV_i(Q)` for
-        the quarter is bound. Triggers `FinalizeConversion(Q)` if it has
-        not yet run, then computes each Orchestrator’s share via
-        `SplitRule` over the stored USD values (Section 2.2) and writes
-        the wallet-to-share map into f02 via `SetShares`. Orchestrators
+      - **`SubmitShares()`.** Permissionless. Operates on the latest
+        quarter whose volumes are bound, so an older quarter's
+        shares can never overwrite a newer quarter's; if submissions
+        lag by more than a quarter, the skipped quarters' maps are
+        superseded and are never submitted late. Reverts when that
+        quarter's map has already been submitted. Triggers
+        `FinalizeConversion(Q)` for that quarter if it has not yet run,
+        then computes each Orchestrator’s share via `SplitRule` over
+        the stored USD values (Section 2.2) and writes the
+        wallet-to-share map into f02 via `SetShares`. Orchestrators
         frozen at the close of the posting period are excluded:
         omitted from the submitted map, with their FPV not entering
         `AggregatedFPV(Q)`.
@@ -1875,7 +1946,9 @@ The implementation test suite MUST cover at least:
     existing claims and in-flight activation messages;
 
   - `ComputeWeight` clamping and rounding, the Q1 w1/w2 bootstrap,
-    gate pass and failure transitions, the exact-residual burn, and
+    gate pass and failure transitions, the sequential gate latch
+    (quarter ordering, late cranks, and the atomic revert on an f02
+    rejection, Section 3.1.1), the exact-residual burn, and
     atto-exact conservation of the full block reward while gas rewards
     and penalties retain their existing treatment;
 
@@ -1940,15 +2013,20 @@ changes to leader election or finality.
     indirect path is not bounded by share validation alone: the gate
     reads `AggregatedFPV` from SRA state, so a compromised SRA could
     report inflated volume to force a w2 step-up. That step is still
-    bounded (≤ `W2_STEP` per quarter, capped at `1 − w1`), held by
+    bounded (one `W2_STEP` per quarter under the gate latch, with
+    f02's queue-time validation keeping the weights within `Σ ≤ 1`,
+    Sections 2.4.8 and 3.1.1), held by
     `SWA_TIMELOCK`, and visible during that hold, though not cancellable
     since gate steps are mechanism-executed (Section 4.3) and the posted
     FPV is itself held by the verification window and correctable
     against recomputation (Section 2.2). Unlike the share misallocation,
     which is confined to one quarter, a wrongly executed step is
     standing: the gate only moves w2 up, so reversing it takes a
-    discretionary, FIP-backed SWA write lowering the w2 record (Section
-    4.2).
+    discretionary, FIP-backed SWA write lowering the w2 record,
+    paired in the same governance action with the matching `steps`
+    adjustment via `SetGateParams`, taking effect at the same epoch
+    (Section 3.1.1), so the counter keeps its authority over gate
+    position (Section 4.2).
 
   - **Sustainability of consensus mining.** The initial ceiling (1 −
     w1 = 5%) is not expected to materially threaten L1-PoRep SP

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -1096,10 +1096,17 @@ decrease's headroom, or a write targeting a stream whose registration
 was canceled. A well-formed due write that fails validation at
 application is discarded, with an event, and processing continues;
 the award path never fails on a queued write, and there is no
-fallback weight vector. The SWA should still pre-validate before
-submitting, and the queued records are public during the objection
-window so anyone can recompute the breakpoints, but f02's queue-time
-check is authoritative for admission.
+fallback weight vector. A discarded `StepWeightRecords` self-heals:
+gate writes are absolute levels derived from the SWA's step counter
+(Section 3.1.1), so the next passing gate restores the full correct
+level, w2 sitting one level low until then. The final step is the
+exception: `steps` is terminal, no later gate exists, and repair is
+a discretionary write (the counter already correct, no `steps`
+adjustment needed). The SWA
+should still pre-validate before submitting, and the queued records
+are public during the objection window so anyone can recompute the
+breakpoints, but f02's queue-time check is authoritative for
+admission.
 
 ##### 2.4.9 Methods and bounds
 
@@ -1319,9 +1326,9 @@ gate passes, `QuarterlyGateCheck` replaces the record with a constant
 one at the new level,
 `{ v_start: new_w2, slope: 0, floor = cap = new_w2 }`, via
 `StepWeightRecords` under `SWA_TIMELOCK`; when a gate fails, the
-record is untouched and w2 holds. Burn resumes automatically from the Q1
-boundary: w1 keeps ramping down while w2 holds at its gate-set level,
-and the residual is burned.
+record is untouched and w2 holds. Scheduled burn resumes
+automatically from the Q1 boundary: w1 keeps ramping down while w2
+holds at its gate-set level, and the residual is burned.
 
 **`QuarterlyGateCheck`**, callable once per quarter, in quarter order,
 the first check evaluating quarter 2:
@@ -1377,7 +1384,7 @@ time.
 call reverts, `steps` and `last_checked_quarter` do not advance, and
 the gate is re-attemptable in a later quarter (on this FIP's schedule
 the rejection can occur only after a discretionary change to w1's
-schedule). w2 takes values only on the 5pp grid
+schedule, applied or pending). w2 takes values only on the 5pp grid
 `W2_BASE + steps * W2_STEP`; partial steps do not exist.
 
 **The counter is the authority.** Gate position lives in `steps`; the
@@ -1399,9 +1406,10 @@ no window arithmetic. `QuarterlyGateCheck` operates on
 `Q = last_checked_quarter + 1` and is callable once the SRA reports
 quarter Q's volumes bound (verification window closed, values final);
 the check then reads `AggregatedFPV(Q)` from the same contract, so the
-volume and its finality come from one place. The boundaries themselves are as defined
-in Section 2.2: consecutive `EPOCHS_PER_QUARTER`-epoch windows counted
-from the activation epoch, maintained in the SRA.
+volume and its finality come from one place. The boundaries
+themselves are as defined in Section 2.2: consecutive
+`EPOCHS_PER_QUARTER`-epoch windows counted from the activation epoch,
+maintained in the SRA.
 
 **`ComputeTarget` (volume target).** The gate compares USD-denominated
 volume directly against a fixed schedule:


### PR DESCRIPTION
_(Stacked PR for now, Draft to get feedback)_

- SWA gate position is explicit state: steps counter + sequential once-per-quarter latch; the min(w2 + W2_STEP, 1 - w1) clamp and w2_level are removed
- Targets are step-indexed: a missed gate leaves the target unchanged; no catch-up; w2 moves only on the 5pp grid
- The counter is authoritative: discretionary w2 writes must carry a matching steps adjustment, taking effect at the same epoch
- Quarter numbering and window state belong to the SRA; the SWA does no window arithmetic
- `QuarterlyGateCheck()` and `SubmitShares()` take no quarter argument; shares can never regress to an older quarter
- Q1 runs the full reporting pipeline; only the gate check is skipped
- `GetState` removed; f02 exposes no read methods