### PR TITLE
FIP-0118: add Orchestrator transparency rules

### DIFF
--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -1934,12 +1934,11 @@ The template, required disclosures, and filing cadence are defined in the
 Failure to file is a removal trigger and forfeits re-admission for the
 following quarter. 
 
-**Genesis Orchestrator disclosure.** The Orchestrator seated at
-activation is fixed by the activation migration (Section 2.4.10), not
-by `Admit`. To carry the same public scrutiny an `Admit` call would,
-the Registry Safes SHALL share, by activation, who operates that
-wallet, why it was selected, and what is expected of it — distinct
-from and in addition to that Orchestrator's own report above.
+**Initial Disclosure of Orchestrator Seated at Activation.** The Orchestrator
+seated at activation is fixed by the activation migration (Section 2.4.10), not
+by `Admit`. To carry the same public scrutiny an `Admit` call would, the
+Orchestrator shall publish a disclosure on activation, following the
+requirements in the governance repository set for any other Orchestrator.
 
 **Service Orchestrators** are not considered a governance tier. An
 Orchestrator's only protocol interaction is receiving rewards and

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -1927,6 +1927,28 @@ Admission criteria, the freeze criteria and evidence standard, the
 escalation-to-Remove policy, the dispute procedure, the audit playbook,
 and the quarterly verification duty live in the governance repository.
 
+**Orchestrator Community Report.** Each Service Orchestrator SHALL
+share a quarterly Community Report with the community, using the
+Orchestrator Community Report Template; the goal is transparency. The
+template and its filing cadence are defined and iterate in the
+[governance repository](https://github.com/FilecoinFoundationWeb/Solstice-Governance/tree/main),
+maintained by [Filecoin Foundation's governance team](https://fil.org/governance).
+Every change to the report lands as a public pull request, on the
+public record. This applies to every Orchestrator, including the one
+seated at activation: there is no genesis exemption. Filing is
+binary; failure to file is a freeze trigger and forfeits
+re-admission for the following quarter. Report quality is surfaced
+through public scrutiny; enforcement runs through the Registry
+Safes' and Orchestrators' operating guidelines in the governance
+repository, at Filecoin Foundation's governance discretion.
+
+**Genesis Orchestrator disclosure.** The Orchestrator seated at
+activation is fixed by the activation migration (Section 2.4.10), not
+by `Admit`. To carry the same public scrutiny an `Admit` call would,
+the Registry Safes SHALL share, by activation, who operates that
+wallet, why it was selected, and what is expected of it — distinct
+from and in addition to that Orchestrator's own report above.
+
 **Service Orchestrators** are not considered a governance tier. An
 Orchestrator's only protocol interaction is receiving rewards and
 conducting measurement: it registers its (payer, operator) pairs

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -1936,7 +1936,7 @@ following quarter.
 
 **Initial Disclosure of Orchestrator Seated at Activation.** The Orchestrator
 seated at activation is fixed by the activation migration (Section 2.4.10), not
-by `Admit`. To carry the same public scrutiny an `Admit` call would, the
+by `AddOrchestrator(orch, wallet)`. To carry the same public scrutiny an `AddOrchestrator(orch, wallet)` call would, the
 Orchestrator shall publish a disclosure on activation, following the
 requirements in the governance repository set for any other Orchestrator.
 

--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -1927,20 +1927,12 @@ Admission criteria, the freeze criteria and evidence standard, the
 escalation-to-Remove policy, the dispute procedure, the audit playbook,
 and the quarterly verification duty live in the governance repository.
 
-**Orchestrator Community Report.** Each Service Orchestrator SHALL
-share a quarterly Community Report with the community, using the
-Orchestrator Community Report Template; the goal is transparency. The
-template and its filing cadence are defined and iterate in the
-[governance repository](https://github.com/FilecoinFoundationWeb/Solstice-Governance/tree/main),
-maintained by [Filecoin Foundation's governance team](https://fil.org/governance).
-Every change to the report lands as a public pull request, on the
-public record. This applies to every Orchestrator, including the one
-seated at activation: there is no genesis exemption. Filing is
-binary; failure to file is a freeze trigger and forfeits
-re-admission for the following quarter. Report quality is surfaced
-through public scrutiny; enforcement runs through the Registry
-Safes' and Orchestrators' operating guidelines in the governance
-repository, at Filecoin Foundation's governance discretion.
+**Orchestrator Community Report.** Each Service Orchestrator shall share a
+quarterly Community Report using the Orchestrator Community Report Template.
+The template, required disclosures, and filing cadence are defined in the
+[governance repository](https://github.com/filecoin-project/solstice-governance/).
+Failure to file is a removal trigger and forfeits re-admission for the
+following quarter. 
 
 **Genesis Orchestrator disclosure.** The Orchestrator seated at
 activation is fixed by the activation migration (Section 2.4.10), not


### PR DESCRIPTION
## Summary

Adds a reporting requirement to §4.2 that's currently missing: each Service Orchestrator SHALL share a quarterly Community Report with the community, and — since the first Orchestrator's wallet is fixed by the activation migration and never goes through `Admit` — the Registry Safes SHALL disclose who operates it, why, and what's expected of it, by activation. 

## What this adds

- **Orchestrator Community Report** — quarterly, public, binary filing (filed or not; failure is a freeze trigger). The template and its cadence live in and iterate through the [governance repository](https://github.com/FilecoinFoundationWeb/Solstice-Governance/tree/main), not in this FIP — so it can change by PR without a FIP amendment. No genesis exemption: applies to the Orchestrator seated at activation too.
- **Genesis Orchestrator disclosure** — the first Orchestrator is seated by the migration, not `Admit`, so it never gets the onchain scrutiny every later admission does. This closes that gap.
- Given the group's strong preference to keep the reporting and Orchestrator-governance process out of the FIP for quick iteration, that responsibility implicitly shifts to be heavier on [Filecoin Foundation's governance team](https://fil.org/governance), who maintain the governance repo, hold the power to set the runbook, expectations, and report template, and share in admit/freeze decisions as one of the SRA's Registry Safes — accountable to the community for keeping the process credible and neutral.

## Why

The goal is transparency. According to the overall governance goal, "our goal is to facilitate a decentralized, innovative, and transparent system to support community decision-making and collective ownership of Filecoin" (fips.filecoin.io). As raised in the FIP discussion, this subnet is GTM/PMF-focused which needs strong strategy and robust execution — companies raising capital don't get funded on revenue data alone, they also share their plans and high level operations. Paying Service Orchestrators out of the block reward with no requirement that they report to the community beyond onchain ARR, and no requirement that anyone even knows who's behind the first one, doesn't meet that bar IMO.

## Disclosure   

I'm not affiliated with Filecoin Foundation.