### PR TITLE
FIP-0118: align miner and market sections with the implementation

### DIFF
--- a/FIPS/fip-0118.md
+++ b/FIPS/fip-0118.md
@@ -301,6 +301,14 @@ pathways at once is preferred over a wind-down because new sectors and
 SnapDeals receive 10× QAP by default, so legacy datacap pathways add
 complexity without utility.
 
+This FIP supersedes the parts of [FIP-0045](./fip-0045.md) that make
+quality-adjusted power depend on verified allocations and claims, and
+the parts of [FIP-0084](./fip-0084.md) that give
+`verified_allocation_key` on a piece manifest any effect. The field
+remains on the wire and is accepted, but is ignored: quality-adjusted
+power derives from sector state, not from allocations. Claim terms no
+longer constrain sector expiration.
+
 **1.1 Transition rules (at the upgrade epoch).**
 
   - No new datacap is minted; all minting and allocation methods are
@@ -321,6 +329,11 @@ complexity without utility.
   - All new sectors get 10× QAP by default; onboarding does not
     consult the verified registry.
 
+  - `FULL_QA_POWER` on `SectorOnChainInfo` affects only QAP. When set,
+    it grants `qa_power_max` regardless of content. Every onboarding
+    path, SnapDeals, and `UpgradeSectorQuality` set it. Unflagged
+    sectors retain legacy weight-derived QAP.
+
   - SnapDeals (`ProveReplicaUpdate3`) remain available: snapping data
     into CC sectors will grant 10× QAP automatically without Datacap.
     No datacap is minted, allocated, or consumed on this path. The
@@ -328,7 +341,13 @@ complexity without utility.
     exceeds the sector's recorded pledge, the positive difference must
     be locked before the update succeeds.
 
-  - Introduce `ExtendSectorExpiration3`: a batch method that upgrades
+  - A committed-capacity sector predating this FIP sits at 1×, carrying
+    no `FULL_QA_POWER` and no recorded weight regardless of when it was
+    sealed. SnapDeals raises it to 10× once the update proof verifies,
+    under the pledge rule above and independently of
+    `UpgradeSectorQuality`.
+
+  - Introduce `UpgradeSectorQuality`: a batch method that upgrades
     existing sectors to 10× QAP under the same pledge rule. Any sector
     below 10× is eligible, including partially verified sectors; the
     upgrade tops the sector up to 10× QAP and its pledge up to the
@@ -342,17 +361,22 @@ complexity without utility.
     requirement has risen since. A 10× sector that only needs an
     extension uses `ExtendSectorExpiration2`.
 
-  - The daily fee (FIP-0100) follows the rule SnapDeals and extensions
-    already share: the sector's recorded fee is scaled in proportion
-    to the power change, and sectors from before FIP-0100 with no
-    recorded fee are assigned a fresh fee at upgrade. For those legacy
-    sectors the daily fee starts at the full 10× level from the
-    upgrade onward, so an upgraded sector is treated exactly like a
-    post-FIP-0100 sector of the same power.
+  - Fee debt must clear from unlocked balance in the same message before
+    a miner is eligible to use this method. Otherwise the whole call
+    aborts.
 
-  - `ExtendSectorExpiration3` emits one FIP-0083 `sector-updated`
-    event per successfully upgraded sector. Extensions emit no event,
-    matching `ExtendSectorExpiration2`.
+  - The batch is atomic: an invalid declaration aborts the whole call
+    and no declaration takes effect.
+
+  - The daily fee follows the rule SnapDeals and extensions already
+    share: the recorded fee scales in proportion to the power change,
+    and upgrading a pre-FIP-0100 sector with no recorded fee turns zero
+    into a fresh fee at the full 10× level.
+
+  - Transitional: no post-upgrade path creates a sector below 10×, so
+    once the legacy cohort expires the method can be retired. That cohort
+    is bounded by the five-year seal-proof lifetime and the 1,278-day
+    extension cap.
 
   - Expected behavior: most empty legacy CC sectors will be upgraded
     to 10×. CC sectors currently hold ~208 PiB of raw power (data as
@@ -367,38 +391,42 @@ complexity without utility.
 
 **1.3 Extensions: carry forward the recorded ratio**
 
-  - `ExtendSectorExpiration` / `ExtendSectorExpiration2` no longer touch
-    the verified registry: no `claim_space_by_sector` lookups, no
-    claim-term updates. Whether the SP holds datacap is irrelevant, so
-    extension keeps working for every sector after the cut-off and no
-    forced retire-or-reseal decision point is created for legacy SPs.
+  - `ExtendSectorExpiration2` no longer consults the verified registry:
+    no `claim_space_by_sector` lookups, claim-term updates, or
+    `term_max` checks. Datacap holdings are irrelevant, so extensions
+    remain available to every sector after the cut-off without a forced
+    retire-or-reseal decision.
 
-  - `ExtendSectorExpiration` and `ExtendSectorExpiration2` currently
-    extend sectors without recalculating initial pledge. Callers can
-    submit or batch them without accounting for a pledge delta.
-    Changing these methods to grant 10× would preserve wire
-    compatibility but break that behavioral contract. Leaving pledge
-    unchanged would fail to enforce the new collateral requirement;
-    recalculating it could lock funds or reject calls that previously
-    succeeded. This FIP therefore preserves both methods: they carry
-    the existing multiplier and pledge forward. `ExtendSectorExpiration3`
-    is the explicit opt-in to 10× and pledge recalculation.
+  - `ExtendSectorExpiration2` currently extends sectors without
+    recalculating initial pledge. Callers can submit or batch it without
+    accounting for a pledge delta. Changing it to grant 10× would
+    preserve wire compatibility but break that behavioral contract.
+    Leaving pledge unchanged would fail to enforce the new collateral
+    requirement; recalculating it could lock funds or reject calls that
+    previously succeeded. This FIP therefore preserves it: extension
+    carries the existing multiplier and pledge forward.
+    `UpgradeSectorQuality` is the explicit opt-in to 10× and pledge
+    recalculation.
 
   - Rule: carry forward the verified ratio already recorded on the
     sector. Compute
     `verified_space = verified_deal_weight / current_duration`, then
     set new `verified_deal_weight = verified_space × new_duration`.
 
-  - Effect: a sector keeps its multiplier when extended. Legacy CC
-    extends at 1×, a fully verified legacy sector at 10×, a partially
-    verified one at its recorded fraction, and all post-upgrade
-    sectors (fully verified by default) at 10×. One algorithm covers
-    legacy and new sectors, with no special cases.
+  - Effect: extension does not change QAP for any sector, of any vintage.
+    Before FIP-0045, verified weight could decay when deal terms ended;
+    content no longer determines power, so that decay is removed. An
+    unflagged legacy sector keeps its recorded multiplier, while a sector
+    carrying `FULL_QA_POWER` remains at 10× independently of its weights.
+
+  - `SIMPLE_QA_POWER` is no longer branched on. It remains set on new
+    sectors and persisted on existing ones, but no code path reads it.
 
 **1.4 Weight accounting cleanup.**
 
-  - `deal_weight` is set to zero() going forward; only
-    `verified_deal_weight` contributes to QAP.
+  - `deal_weight` is set to zero() going forward. For sectors without
+    `FULL_QA_POWER`, only `verified_deal_weight` contributes to QAP;
+    flagged sectors receive 10× QAP independently of both weights.
 
   - Refactor `DataActivationOutput` and `ReplicaUpdateActivatedData`
     around a single space notion (`verified_space` and
@@ -410,28 +438,50 @@ complexity without utility.
 
 **1.5 Actor changes and state migration.**
 
-  - Verified registry: revert `add_verifier`, `remove_verifier`,
-    `add_verified_client`, `extend_claim_terms`, and the claim entry
-    points used by the miner actor. Test-only Allocation creation is
-    dropped: with claims disabled there is nothing left to exercise.
+  - Every state-mutating method on the DataCap and Verified Registry
+    actors rejects with `USR_FORBIDDEN`. Read methods continue to serve
+    the frozen state.
+
+  - DataCap: `Mint`, `Destroy`, `Transfer`, `TransferFrom`, `Burn`,
+    `BurnFrom`, `IncreaseAllowance`, `DecreaseAllowance`, and
+    `RevokeAllowance` reject. `Name`, `Symbol`, `Granularity`,
+    `TotalSupply`, `Balance`, and `Allowance` continue to serve.
+
+  - Verified Registry: `AddVerifier`, `RemoveVerifier`,
+    `AddVerifiedClient`, `RemoveVerifiedClientDataCap`,
+    `RemoveExpiredAllocations`, `ClaimAllocations`, `ExtendClaimTerms`,
+    `RemoveExpiredClaims`, and the universal receiver hook reject.
+    `GetClaims` continues to serve. Test-only Allocation creation is
+    removed.
+
+  - No Verified Registry actor event is emitted after the upgrade,
+    because every path that emitted one now rejects.
 
   - Migration (verified registry): set `state.root_key = f099`, clear
     state.verifiers = {} including the verifiers HAMT, and clear
     pending allocations.
 
-  - DataCap actor: revert mint; balances are frozen.
+  - Migration (market): remove `pending_deal_allocation_ids` from actor
+    state. The map is empty at upgrade, so this removes the last
+    market-side allocation bookkeeping without changing semantics.
+
+  - Storage market `BatchActivateDeals` remains for the
+    published-to-active deal transition. The `compute_cid` parameter,
+    returned per-sector unsealed CID, and
+    `ActivatedDeal` and `SectorDealActivation` return types are removed.
+    Each sector group is now a `Vec<PieceInfo>`, and the result returns
+    `Vec<Vec<PieceInfo>>` directly. `ActivatedDeal` encodes as
+    `[cid, size]`, while `PieceInfo` encodes as `[size, cid]`, so the
+    returned bytes change. This method is only
+    callable by the miner actor so has no external use.
 
   - RKH: remove the signers of the f080 multisig in migration.
 
-  - The miner actor treats non-zero deal weight as "sector has
-    data" in two places. At termination the check degenerates to
-    always-true post-upgrade, which is harmless: a redundant market
-    call for dataless sectors, legacy deal slashing unaffected. In
-    SnapDeals (`validate_replica_updates`) it breaks: every
-    post-upgrade sector has non-zero verified weight, so all updates
-    would be rejected, contradicting Section 1.2. Replace the SnapDeals
-    check with an explicit data-presence signal; exact mechanism TBD
-    during implementation.
+  - The miner actor treats a sector as containing data when either
+    `deal_weight` or `verified_deal_weight` is non-zero. These fields
+    continue to record actual piece data, not the 10× QAP entitlement,
+    so the same test remains valid for termination and SnapDeals and no
+    new data-presence signal is required.
 
 **1.6 Others.**
 
@@ -2484,11 +2534,11 @@ New sectors receive 10× QAP regardless of content, changing the QAP and
 pledge inputs expected by sealing pipelines, pledge estimators and SP
 operations software. These consumers must select pre- or post-upgrade
 behavior according to the network version. Existing
-`ExtendSectorExpiration` and `ExtendSectorExpiration2` callers retain
+`ExtendSectorExpiration2` callers retain
 their collateral contract: ordinary extension does not recompute or lock
 additional initial pledge. Existing sectors receive 10× only through the
 explicit upgrade paths in Section 1.2; tooling must deliberately select
-and support `ExtendSectorExpiration3` before extension can implicate
+and support `UpgradeSectorQuality` before extension can implicate
 additional miner funds.
 
 The f02 state schema, method surface and payout accounting change.
@@ -2807,7 +2857,7 @@ whenever the service economy underperforms.
 only its input changes. New sectors onboard at 10× QAP, so pledge per
 raw byte scales up accordingly, as does expected reward: return on
 pledge is roughly preserved, and lifting a legacy sector (snap or
-`ExtendSectorExpiration3`) simply requires the matching top-up. Each
+`UpgradeSectorQuality`) simply requires the matching top-up. Each
 lift locks additional FIL, so aggregate locked supply rises with the QAP
 bump, and per-sector economics converge to today's verified-sector
 levels, already the norm for ~83% of the network.
@@ -2849,7 +2899,7 @@ Implementation is tracked in the
     [PR #1760](https://github.com/filecoin-project/builtin-actors/pull/1760)
     (DataCap/verified-registry disconnect and 10× QAP) and
     [PR #1775](https://github.com/filecoin-project/builtin-actors/pull/1775)
-    (`ExtendSectorExpiration3`, to be merged into #1760); reward-actor f02
+    (`UpgradeSectorQuality`, to be merged into #1760); reward-actor f02
     changes in
     [PR #1774](https://github.com/filecoin-project/builtin-actors/pull/1774).
 


### PR DESCRIPTION
This is on @irenegia's branch and for her to review, sorry FIP-editors for the spam, read if you want but it'll likely go into #1277.

* Rename `ExtendSectorExpiration3` to `UpgradeSectorQuality`
* `BatchActivateDeals` changes in the market actor
* Removal of `pending_deal_allocation_ids` from market state
* `FULL_QA_POWER` as the primary state mechanism; affects QAP only, not data presence
* Freeze of datacap and verifreg divided between "mutate" vs "read" methods (listed)
* SnapDeals named as a second legacy 10x path
* `SIMPLE_QA_POWER` extraneous now; extension power-neutral for every variant
* Claim `term_max` no longer bounds extension
* Supersedes FIP-0045 and FIP-0084; `verified_allocation_key` accepted and ignored
* Fee debt blocks the upgrade
* Upgrade batches are atomic
* Daily fee scales with the power change; pre-FIP-0100 sectors get a fresh one
* `UpgradeSectorQuality` is transitional and can be retired with the legacy cohort
* Drop references to the deprecated `ExtendSectorExpiration`
* Drop the upgrade-path `sector-updated` event (TBD whether we add something back)